### PR TITLE
Add Batchwriter.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+harbourbridge
+vendor/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-harbourbridge
-vendor/
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Community Guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# Under construction
+# HarbourBridge: Turnkey Postgres-to-Spanner Evaluation
+
+HarbourBridge is a stand-alone tool for Cloud Spanner evaluation, using data
+from an existing PostgreSQL database. The tool ingests pg_dump output,
+automatically builds a Spanner schema, and creates a new Spanner database
+populated with data from pg_dump.
+
+This tool is currently under development.

--- a/spanner/batchwriter.go
+++ b/spanner/batchwriter.go
@@ -1,0 +1,320 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package spanner provides high-level abstractions for working with
+// Cloud Spanner that are not available from the core Cloud Spanner
+// libraries.
+package spanner
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	sp "cloud.google.com/go/spanner"
+)
+
+// Parameters used to control building batches to write to Spanner.
+// Batches are built by adding rows until we hit one of the thresholds.
+// Bigger batches are usually more efficient, but we need to be careful
+// not to exceed Spanner's limits. Also, sending huge RPCs is potentially
+// unreliable.
+const (
+	kb             = 1 << 10
+	mb             = 1 << 20
+	countThreshold = 10 * kb // Spanner per-operation limit is 20K.
+	byteThreshold  = 20 * mb // Spanner per-operation limit is 100MB.
+)
+
+// BatchWriter accumulates Spanner mutations (via AddRow) and assembles
+// them into batches that it asynchronously writes to Spanner. If Spanner
+// returns an error for a batch, BatchWriter splits the batch into
+// smaller chunks to retry, as it attempts to isolate which row(s) in a
+// batch is bad. BatchWriter respects Spanner's limits on byte size and
+// mutation count and has configurable limits on the number of
+// in-progress writes, amount of data buffered and retry behavior.
+// BatchWriter is not threadsafe: only one call to AddRow or Flush should
+// be active at any time.  See ExampleBatchWriter (batchwriter_test.go)
+// for sample usage code.
+type BatchWriter struct {
+	rows       []*row                     // Buffered rows.
+	rBytes     int64                      // Estimate of bytes for buffered rows.
+	rCount     int64                      // Mutation count for buffered rows.
+	write      func([]*sp.Mutation) error // Typically a closure that calls client.Apply, but structured this way for testing.
+	wg         sync.WaitGroup             // Tracks in-progress writes.
+	writeLimit int64                      // Limit on number of in-progress writes.
+	bytesLimit int64                      // Limit on bytes buffered. AddRow blocks if rBytes exceeded this value.
+	retryLimit int64                      // Limit on retries.
+	verbose    bool                       // If true, print out messages about each write batch.
+	a          asyncState
+}
+
+type row struct {
+	table string
+	cols  []string
+	vals  []interface{}
+}
+
+// Fields in this struct are modified asynchronously e.g. by go routines writing
+// data to Spanner. Either hold a lock or use atomics, as detailed below.
+type asyncState struct {
+	writes       int64            // Number of in-progress writes; access using atomic.
+	retries      int64            // Number of retries; access using atomic.
+	lock         sync.Mutex       // Protects errors and badRows
+	errors       map[string]int64 // Errors encountered; protected by lock.
+	badRows      []*row           // Rows that generated errors; protected by lock.
+	badRowsBytes int64            // Estimate of bytes for badRows; protected by lock.
+	droppedRows  map[string]int64 // Count of dropped rows, broken down by table.
+}
+
+// BatchWriterConfig specifies parameters for configuring BatchWriter.
+type BatchWriterConfig struct {
+	WriteLimit int64                      // Limit on number of in-progress writes.
+	BytesLimit int64                      // Limit on bytes buffered.
+	RetryLimit int64                      // Limit on retries.
+	Write      func([]*sp.Mutation) error // Function to call to write to Spanner (typically a closure that calls client.Apply).
+	Verbose    bool                       // If true, print out messages about each write batch.
+}
+
+// NewBatchWriter returns a new BatchWriter with parameters defined by config.
+func NewBatchWriter(config BatchWriterConfig) *BatchWriter {
+	return &BatchWriter{
+		write:      config.Write,
+		writeLimit: config.WriteLimit,
+		bytesLimit: config.BytesLimit,
+		retryLimit: config.RetryLimit,
+		verbose:    config.Verbose,
+		a: asyncState{
+			errors:      make(map[string]int64),
+			droppedRows: make(map[string]int64),
+		},
+	}
+}
+
+// AddRow appends a new row of data to bw's buffer of rows. Depending on the
+// state of BatchWriter, AddRow may immediately return, or it may initiate writes,
+// or it may block (waiting for some of the writes already in progress to
+// complete) and then initiate writes.
+func (bw *BatchWriter) AddRow(table string, cols []string, vals []interface{}) {
+	r := &row{table, cols, vals}
+	bw.rows = append(bw.rows, r)
+	bw.rBytes += byteSize(r)
+	bw.rCount += int64(len(r.cols))
+	bw.writeData()
+}
+
+// Flush initiates writes to Spanner of all buffered rows of data, and waits
+// for them to complete.
+func (bw *BatchWriter) Flush() {
+	for len(bw.rows) > 0 {
+		if atomic.LoadInt64(&bw.a.writes) < bw.writeLimit {
+			m, count, bytes := bw.getBatch()
+			if bw.verbose {
+				fmt.Printf("Starting write of %d rows to Spanner (%d bytes, %d mutations) [%d in progress]\n",
+					len(m), bytes, count, atomic.LoadInt64(&bw.a.writes))
+			}
+			bw.startWrite(m)
+		} else {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	bw.wg.Wait()
+}
+
+// DroppedRows returns a map of tables to counts of dropped rows.
+func (bw *BatchWriter) DroppedRows() map[string]int64 {
+	m := make(map[string]int64)
+	bw.a.lock.Lock()
+	defer bw.a.lock.Unlock()
+
+	for t, n := range bw.a.droppedRows {
+		m[t] = n
+	}
+	return m
+}
+
+// BadRows returns a string-formatted list of rows that generated errors.
+// Returns at most n rows.
+func (bw *BatchWriter) BadRows(n int) []string {
+	var l []string
+	bw.a.lock.Lock()
+	defer bw.a.lock.Unlock()
+	for _, x := range bw.a.badRows {
+		l = append(l, fmt.Sprintf("table=%s cols=%v data=%v", x.table, x.cols, x.vals))
+		if len(l) > n {
+			break
+		}
+	}
+	return l
+}
+
+// GetErrors returns a map summarizing errors encountered. Keys are error
+// strings, and values are the count of that error.
+func (bw *BatchWriter) GetErrors() map[string]int64 {
+	m := make(map[string]int64)
+	bw.a.lock.Lock()
+	defer bw.a.lock.Unlock()
+	for k, v := range bw.a.errors {
+		m[k] = v
+	}
+	return m
+}
+
+func (bw *BatchWriter) getBadRowsForTest() []*row {
+	return bw.a.badRows
+}
+
+// getBatch returns a slice of data from the front of bw.rows.  The slice
+// returned is the largest one not exceeding countThreshold and byteThreshold.
+func (bw *BatchWriter) getBatch() (rows []*row, count int64, bytes int64) {
+	for i, _ := range bw.rows {
+		c := count + int64(len(bw.rows[i].cols))
+		b := bytes + byteSize(bw.rows[i])
+		// If next row puts us over the thresholds, then stop. But make sure
+		// we have at least one row. If a single row puts us over the
+		// thresholds, there's not much we can do: we just try sending it to Spanner
+		// (it might succeed, since our thresholds are conservative).
+		if (c >= countThreshold || b >= byteThreshold) && len(rows) >= 1 {
+			bw.rCount -= count
+			bw.rBytes -= bytes
+			bw.rows = bw.rows[i:]
+			return rows, count, bytes
+		}
+		count = c
+		bytes = b
+		rows = append(rows, bw.rows[i])
+	}
+	bw.rCount = 0
+	bw.rBytes = 0
+	bw.rows = nil
+	return rows, count, bytes
+}
+
+func (bw *BatchWriter) errorStats(rows []*row, err error, retry bool) {
+	if bw.verbose {
+		fmt.Printf("Error while writing %d rows to Spanner: %v\n", len(rows), err)
+	}
+
+	bw.a.lock.Lock()
+	defer bw.a.lock.Unlock()
+
+	bw.a.errors[err.Error()]++
+	if retry {
+		return
+	}
+	// All rows in r will be dropped.
+	if len(rows) == 1 {
+		// This is a confirmed bad row: add it to the badRows list.
+		r := rows[0]
+		n := byteSize(r)
+		// Use bw.bytesLimit to cap storage used by badRows. Keep at least one bad row.
+		if bw.a.badRowsBytes+n < bw.bytesLimit || len(bw.a.badRows) == 0 {
+			bw.a.badRows = append(bw.a.badRows, r)
+			bw.a.badRowsBytes += n
+		}
+	}
+	for _, x := range rows {
+		bw.a.droppedRows[x.table]++
+	}
+	return
+}
+
+// Note: doWriteAndHandleErrors must be thread-safe.
+func (bw *BatchWriter) doWriteAndHandleErrors(rows []*row) {
+	var m []*sp.Mutation
+	for _, x := range rows {
+		m = append(m, sp.InsertOrUpdate(x.table, x.cols, x.vals))
+	}
+	if err := bw.write(m); err != nil {
+		hitRetryLimit := atomic.LoadInt64(&bw.a.retries) >= bw.retryLimit
+		retry := len(rows) > 1 && !hitRetryLimit
+		bw.errorStats(rows, err, retry)
+		if !retry {
+			if hitRetryLimit && bw.verbose {
+				fmt.Printf("Have hit %d retries: will no do any more\n", atomic.LoadInt64(&bw.a.retries))
+			}
+			return
+		}
+		// Split into 10 pieces and retry. This is useful
+		// if a batch contains a bad data row (Spanner
+		// will fail the entire batch). In effect we attempt
+		// to narrow down which row (or rows) are bad, and
+		// write the 'good' rows to Spanner.
+		k := 1 + len(rows)/10
+		min := func(i, j int) int {
+			if i <= j {
+				return i
+			}
+			return j
+		}
+		for i := 0; i < len(rows); i += k {
+			atomic.AddInt64(&bw.a.retries, 1)
+			bw.doWriteAndHandleErrors(rows[i:min(i+k, len(rows))])
+		}
+	}
+}
+
+// Note: backgroundWrite must be thread-safe.
+func (bw *BatchWriter) backgroundWrite(rows []*row) {
+	defer bw.wg.Done()
+	defer atomic.AddInt64(&bw.a.writes, -1)
+	bw.doWriteAndHandleErrors(rows)
+}
+
+// startWrite initiates an asynchronous write of m to Spanner.
+func (bw *BatchWriter) startWrite(rows []*row) {
+	bw.wg.Add(1)
+	atomic.AddInt64(&bw.a.writes, 1)
+	go bw.backgroundWrite(rows)
+}
+
+// writeData initiates writes to Spanner until either:
+// a) we have less than a 'batch' to write, or
+// b) we've hit writeLimit and we're under bytesLimit.
+// It will block and re-try till either (a) or (b) holds.
+func (bw *BatchWriter) writeData() {
+	for bw.rCount > countThreshold || bw.rBytes > byteThreshold {
+		if atomic.LoadInt64(&bw.a.writes) < bw.writeLimit {
+			m, count, bytes := bw.getBatch()
+			if bw.verbose {
+				fmt.Printf("Starting write of %d rows to Spanner (%d bytes, %d mutations) [%d in progress]\n",
+					len(m), bytes, count, atomic.LoadInt64(&bw.a.writes))
+			}
+			bw.startWrite(m)
+		} else {
+			if bw.rBytes < bw.bytesLimit {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func byteSize(r *row) int64 {
+	n := int64(len(r.table))
+	for _, c := range r.cols {
+		n += int64(len(c))
+	}
+	for _, v := range r.vals {
+		switch x := v.(type) {
+		case string:
+			n += int64(len(x))
+		default:
+			n += int64(unsafe.Sizeof(v))
+		}
+	}
+	return n
+}

--- a/spanner/batchwriter.go
+++ b/spanner/batchwriter.go
@@ -33,10 +33,8 @@ import (
 // not to exceed Spanner's limits. Also, sending huge RPCs is potentially
 // unreliable.
 const (
-	kb             = 1 << 10
-	mb             = 1 << 20
-	countThreshold = 10 * kb // Spanner per-operation limit is 20K.
-	byteThreshold  = 20 * mb // Spanner per-operation limit is 100MB.
+	countThreshold = 10 * 1000    // Spanner per-operation limit is 20,000.
+	byteThreshold  = 20 * 1 << 20 // Spanner per-operation limit is 100MB.
 )
 
 // BatchWriter accumulates Spanner mutations (via AddRow) and assembles

--- a/spanner/batchwriter.go
+++ b/spanner/batchwriter.go
@@ -138,6 +138,7 @@ func (bw *BatchWriter) Flush() {
 }
 
 // DroppedRowsByTable returns a map of tables to counts of dropped rows.
+// Dropped rows are rows that were not written to Spanner.
 func (bw *BatchWriter) DroppedRowsByTable() map[string]int64 {
 	// Make a copy of bw.a.droppedRows since it is not thread-safe.
 	m := make(map[string]int64)
@@ -150,8 +151,11 @@ func (bw *BatchWriter) DroppedRowsByTable() map[string]int64 {
 	return m
 }
 
-// SampleBadRows returns a string-formatted list of rows that generated errors.
-// Returns at most n rows.
+// SampleBadRows returns a string-formatted list of sample rows that
+// generated errors. Returns at most n rows.
+// Note that we split up batches to isolate errors. Each row returned
+// by SampleBadRows generated an error when sent to Spanner as a
+// single-row batch.
 func (bw *BatchWriter) SampleBadRows(n int) []string {
 	var l []string
 	bw.a.lock.Lock()

--- a/spanner/batchwriter.go
+++ b/spanner/batchwriter.go
@@ -243,7 +243,8 @@ func (bw *BatchWriter) errorStats(rows []*row, err error, retry bool) {
 	return
 }
 
-// Note: doWriteAndHandleErrors must be thread-safe.
+// Note: doWriteAndHandleErrors must be thread-safe because it is run
+// inside a go routine.
 func (bw *BatchWriter) doWriteAndHandleErrors(rows []*row) {
 	var m []*sp.Mutation
 	for _, x := range rows {
@@ -278,7 +279,8 @@ func (bw *BatchWriter) doWriteAndHandleErrors(rows []*row) {
 	}
 }
 
-// Note: backgroundWrite must be thread-safe.
+// Note: backgroundWrite must be thread-safe because it is run as
+// a go routine.
 func (bw *BatchWriter) backgroundWrite(rows []*row) {
 	defer bw.wg.Done()
 	defer atomic.AddInt64(&bw.async.writes, -1)

--- a/spanner/batchwriter.go
+++ b/spanner/batchwriter.go
@@ -253,7 +253,7 @@ func (bw *BatchWriter) doWriteAndHandleErrors(rows []*row) {
 		bw.errorStats(rows, err, retry)
 		if !retry {
 			if hitRetryLimit && bw.verbose {
-				fmt.Printf("Have hit %d retries: will no do any more\n", atomic.LoadInt64(&bw.a.retries))
+				fmt.Printf("Have hit %d retries: will not do any more\n", atomic.LoadInt64(&bw.a.retries))
 			}
 			return
 		}
@@ -283,7 +283,7 @@ func (bw *BatchWriter) backgroundWrite(rows []*row) {
 	bw.doWriteAndHandleErrors(rows)
 }
 
-// startWrite initiates an asynchronous write of m to Spanner.
+// startWrite initiates an asynchronous write of rows to Spanner.
 func (bw *BatchWriter) startWrite(rows []*row) {
 	bw.wg.Add(1)
 	atomic.AddInt64(&bw.a.writes, 1)

--- a/spanner/batchwriter_test.go
+++ b/spanner/batchwriter_test.go
@@ -215,7 +215,7 @@ func intersect(m1 []*sp.Mutation, m2 []*sp.Mutation) bool {
 func toMutations(r []*row) []*sp.Mutation {
 	var m []*sp.Mutation
 	for _, x := range r {
-		m = append(m, sp.InsertOrUpdate(x.table, x.cols, x.vals))
+		m = append(m, sp.Insert(x.table, x.cols, x.vals))
 	}
 	return m
 }

--- a/spanner/batchwriter_test.go
+++ b/spanner/batchwriter_test.go
@@ -31,17 +31,17 @@ import (
 // TestFlush tests NewBatchWriter, AddRow and Flush.
 func TestFlush(t *testing.T) {
 	tests := []struct {
+		name        string
 		count       int
 		rowSize     int
 		writeLimit  int64
-		name        string
 		badRowIndex map[int]bool // Identifies which rows are bad (by index).
 	}{
-		{count: 1, rowSize: 5, writeLimit: 40, name: "One write"},
-		{count: 50000, rowSize: 5, writeLimit: 40, name: "Many writes"},      // Forces split based on mutation count.
-		{count: 100, rowSize: 1 << 20, writeLimit: 40, name: "Large writes"}, // Forces split based on byte size.
-		{count: 50000, rowSize: 5, writeLimit: 5, name: "Write limit"},       // Forces write-limiting.
-		{count: 50, rowSize: 5, writeLimit: 40, name: "Bad rows", badRowIndex: map[int]bool{6: true, 17: true}},
+		{name: "One write", count: 1, rowSize: 5, writeLimit: 40},
+		{name: "Many writes", count: 50000, rowSize: 5, writeLimit: 40},      // Forces split based on mutation count.
+		{name: "Large writes", count: 100, rowSize: 1 << 20, writeLimit: 40}, // Forces split based on byte size.
+		{name: "Write limit", count: 50000, rowSize: 5, writeLimit: 5},       // Forces write-limiting.
+		{name: "Bad rows", count: 50, rowSize: 5, writeLimit: 40, badRowIndex: map[int]bool{6: true, 17: true}},
 	}
 	config := BatchWriterConfig{
 		BytesLimit: 100 << 20,

--- a/spanner/batchwriter_test.go
+++ b/spanner/batchwriter_test.go
@@ -52,7 +52,7 @@ func TestFlush(t *testing.T) {
 		data, limit := generateRows(tc.count, tc.rowSize)
 		goodRows, badRows := partitionRows(tc.badRowIndex, data)
 		badMutations := toMutations(badRows)
-		var mutex = &sync.Mutex{}
+		mutex := &sync.Mutex{}
 		var writeCount int64
 		var rowsWritten []*sp.Mutation
 		config.WriteLimit = tc.writeLimit

--- a/spanner/batchwriter_test.go
+++ b/spanner/batchwriter_test.go
@@ -95,10 +95,10 @@ func TestFlush(t *testing.T) {
 
 func TestDroppedRowsByTable(t *testing.T) {
 	bw := NewBatchWriter(BatchWriterConfig{})
-	bw.a.lock.Lock()
-	bw.a.droppedRows["test1"] = 22
-	bw.a.droppedRows["test2"] = 42
-	bw.a.lock.Unlock()
+	bw.async.lock.Lock()
+	bw.async.droppedRows["test1"] = 22
+	bw.async.droppedRows["test2"] = 42
+	bw.async.lock.Unlock()
 	m := bw.DroppedRowsByTable()
 	assert.Equal(t, 2, len(m))
 	assert.Equal(t, int64(22), m["test1"])
@@ -107,22 +107,22 @@ func TestDroppedRowsByTable(t *testing.T) {
 
 func TestSampleBadRows(t *testing.T) {
 	bw := NewBatchWriter(BatchWriterConfig{})
-	bw.a.lock.Lock()
-	bw.a.sampleBadRows = []*row{
+	bw.async.lock.Lock()
+	bw.async.sampleBadRows = []*row{
 		&row{"test", []string{"col1", "col2"}, []interface{}{"a", int64(42)}},
 		&row{"test", []string{"col1", "col2"}, []interface{}{"b", int64(6)}},
 	}
-	bw.a.lock.Unlock()
+	bw.async.lock.Unlock()
 	l := bw.SampleBadRows(1)
 	assert.Equal(t, l, []string{"table=test cols=[col1 col2] data=[a 42]"})
 }
 
 func TestErrors(t *testing.T) {
 	bw := NewBatchWriter(BatchWriterConfig{})
-	bw.a.lock.Lock()
-	bw.a.errors["error string 1"] = 22
-	bw.a.errors["error string 2"] = 42
-	bw.a.lock.Unlock()
+	bw.async.lock.Lock()
+	bw.async.errors["error string 1"] = 22
+	bw.async.errors["error string 2"] = 42
+	bw.async.lock.Unlock()
 	m := bw.Errors()
 	assert.Equal(t, 2, len(m))
 	assert.Equal(t, int64(22), m["error string 1"])

--- a/spanner/batchwriter_test.go
+++ b/spanner/batchwriter_test.go
@@ -1,0 +1,197 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	sp "cloud.google.com/go/spanner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchWriter(t *testing.T) {
+	tests := []struct {
+		count       int
+		rowSize     int
+		writeLimit  int64
+		name        string
+		badRowIndex map[int]bool // Identifies which rows are bad (by index).
+	}{
+		{count: 1, rowSize: 5, writeLimit: 40, name: "One write"},
+		{count: 50000, rowSize: 5, writeLimit: 40, name: "Many writes"},     // Forces split based on mutation count.
+		{count: 100, rowSize: 1 * mb, writeLimit: 40, name: "Large writes"}, // Forces split based on byte size.
+		{count: 50000, rowSize: 5, writeLimit: 5, name: "Write limit"},      // Forces write-limiting.
+		{count: 50, rowSize: 5, writeLimit: 40, name: "Bad rows", badRowIndex: map[int]bool{6: true, 17: true}},
+	}
+	config := BatchWriterConfig{
+		BytesLimit: 100 * mb,
+		Verbose:    false,
+		RetryLimit: 1000,
+	}
+	for _, tc := range tests {
+		data, limit := generateRows(tc.count, tc.rowSize)
+		goodRows, badRows := partitionRows(tc.badRowIndex, data)
+		badMutations := toMutations(badRows)
+		var mutex = &sync.Mutex{}
+		var writeCount int64
+		var rowsWritten []*sp.Mutation
+		config.WriteLimit = tc.writeLimit
+		config.Write = func(m []*sp.Mutation) error {
+			var err error
+			assert.LessOrEqual(t, len(m), limit, fmt.Sprintf("%s: Too many rows in write", tc.name))
+			mutex.Lock()
+			writeCount++
+			// intersect could be slow if badMutations is more than a few rows.
+			if intersect(m, badMutations) {
+				err = errors.New("bad data")
+			} else {
+				rowsWritten = append(rowsWritten, m...)
+			}
+			mutex.Unlock()
+			time.Sleep(20 * time.Millisecond) // Mimic a Spanner write.
+			mutex.Lock()
+			assert.LessOrEqual(t, writeCount, tc.writeLimit, fmt.Sprintf("%s: Too many pending writes", tc.name))
+			writeCount--
+			mutex.Unlock()
+			return err
+		}
+		bw := NewBatchWriter(config)
+		for _, x := range data {
+			bw.AddRow(x.table, x.cols, x.vals)
+		}
+		bw.Flush()
+
+		// Check data written.
+		expected := toMutations(goodRows)
+		actual := rowsWritten
+		equalMutations(t, expected, actual, tc.name+" (good data)")
+
+		// Check data rejected.
+		expected = toMutations(badRows)
+		actual = toMutations(bw.getBadRowsForTest()) // All go routines are done, so we can access bw internals.
+		equalMutations(t, expected, actual, tc.name+" (bad data)")
+	}
+}
+
+func ExampleBatchWriter() {
+	write := func(m []*sp.Mutation) error {
+		var err error
+		// Code to write to Spanner e.g.
+		// client := sp.NewClient(...)
+		// _, err = client.Apply(context.Background(), m)
+		return err
+	}
+	config := BatchWriterConfig{
+		WriteLimit: 40,            // Limit on number of in-progress writes; 40 is a good default.
+		BytesLimit: 100 * 1 << 20, // Limit on bytes buffered; 100MB is a good default.
+		RetryLimit: 1000,          // Limit on retries (if a large set of mutations fails, we split it into smaller pieces and re-try).
+		Write:      write,
+		Verbose:    false, // Whether to print messages about each write.
+	}
+	writer := NewBatchWriter(config)
+
+	// Code to generate rows of data to write to Spanner.
+	cols := []string{"id", "quote"}
+	vals := []interface{}{42, "The answer to life the universe and everything."}
+	writer.AddRow("mytable", cols, vals)
+	vals = []interface{}{6, "I am not a number."}
+	writer.AddRow("mytable", cols, vals)
+	// End of code to generate rows.
+
+	writer.Flush() // Flush out remaining writes and wait for them to complete.
+}
+
+func generateRows(count int, size int) ([]*row, int) {
+	var r []*row
+	cols := []string{"a", "b"}
+	val := strings.Repeat("x", size)
+	for i := 0; i < count; i++ {
+		// vals[0] serves as a unique id for each row.
+		vals := []interface{}{i, val}
+		r = append(r, &row{"table", cols, vals})
+	}
+	// Find the max number of rows in a write for the (fixed sized)
+	// rows generated in this test data.
+	limitCount := countThreshold / len(cols) // Compute limit based on mutation count.
+	limitBytes := byteThreshold / (8 + size) // Compute limit based on mutation bytes.
+	if limitCount <= limitBytes {
+		return r, limitCount
+	}
+	return r, limitBytes
+}
+
+// equalMutations is a fast way to check that two slices of mutations are
+// the same (reflect.deepEquals) except for re-ordering.
+// Note that we should use assert.ElementsMatch, but it is very, very slow
+// for the sizes of slices we use here (up to 50K). We convert the mutations
+// to strings and sort them, and then use assert.Equal (ElementsMatch
+// probably can't do this).
+func equalMutations(t *testing.T, expected []*sp.Mutation, actual []*sp.Mutation, name string) {
+	toStrings := func(m []*sp.Mutation) []string {
+		var s []string
+		for _, x := range m {
+			s = append(s, fmt.Sprintf("%+v", x))
+		}
+		return s
+	}
+	e := toStrings(expected)
+	a := toStrings(actual)
+	sort.Slice(e, func(i, j int) bool { return e[i] < e[j] })
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	assert.Equal(t, a, e, name)
+}
+
+// intersect returns true if m1 and m2 have a common element.
+func intersect(m1 []*sp.Mutation, m2 []*sp.Mutation) bool {
+	if m1 == nil || m2 == nil {
+		return false
+	}
+	for _, x := range m1 {
+		for _, y := range m2 {
+			if reflect.DeepEqual(x, y) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func toMutations(r []*row) []*sp.Mutation {
+	var m []*sp.Mutation
+	for _, x := range r {
+		m = append(m, sp.InsertOrUpdate(x.table, x.cols, x.vals))
+	}
+	return m
+}
+
+// partitionRows splits data into goodRows and badRows based on badRowIndex,
+// which specifies the indices of bad rows.
+func partitionRows(badRowIndex map[int]bool, data []*row) (goodRows []*row, badRows []*row) {
+	for i, _ := range data {
+		if badRowIndex[i] {
+			badRows = append(badRows, data[i])
+		} else {
+			goodRows = append(goodRows, data[i])
+		}
+	}
+	return goodRows, badRows
+}

--- a/spanner/batchwriter_test.go
+++ b/spanner/batchwriter_test.go
@@ -28,7 +28,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBatchWriter(t *testing.T) {
+// TestFlush tests NewBatchWriter, AddRow and Flush.
+func TestFlush(t *testing.T) {
 	tests := []struct {
 		count       int
 		rowSize     int
@@ -37,13 +38,13 @@ func TestBatchWriter(t *testing.T) {
 		badRowIndex map[int]bool // Identifies which rows are bad (by index).
 	}{
 		{count: 1, rowSize: 5, writeLimit: 40, name: "One write"},
-		{count: 50000, rowSize: 5, writeLimit: 40, name: "Many writes"},     // Forces split based on mutation count.
-		{count: 100, rowSize: 1 * mb, writeLimit: 40, name: "Large writes"}, // Forces split based on byte size.
-		{count: 50000, rowSize: 5, writeLimit: 5, name: "Write limit"},      // Forces write-limiting.
+		{count: 50000, rowSize: 5, writeLimit: 40, name: "Many writes"},      // Forces split based on mutation count.
+		{count: 100, rowSize: 1 << 20, writeLimit: 40, name: "Large writes"}, // Forces split based on byte size.
+		{count: 50000, rowSize: 5, writeLimit: 5, name: "Write limit"},       // Forces write-limiting.
 		{count: 50, rowSize: 5, writeLimit: 40, name: "Bad rows", badRowIndex: map[int]bool{6: true, 17: true}},
 	}
 	config := BatchWriterConfig{
-		BytesLimit: 100 * mb,
+		BytesLimit: 100 << 20,
 		Verbose:    false,
 		RetryLimit: 1000,
 	}


### PR DESCRIPTION
Initial commit to harbourbridge repository with license/contrib files
an initial README (mostly empty), and the first chunk of code: batchwriter.

Batchwriter is an abstraction on top of the standard Spanner Client
library that batches mutations together and manages the writing of
those mutations to Spanner. Harbourbridge uses this to effeciently
write data to Spanner.