### PR TITLE
Initial commit of ddl.

### DIFF
--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -1,0 +1,252 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ddl provides a go representation of Spanner DDL
+// as well as helpers for building and manipulating Spanner DDL.
+// We only implement enough DDL types to meet the needs of HarbourBridge.
+//
+// Definitions are from
+// https://cloud.google.com/spanner/docs/data-definition-language.
+// Before defining each type, we give the snippet from this definition.
+//
+// We use go interface types to preserve the structural constraints of
+// Spanner DDL. For example, suppose ScalarType could be either
+// an INT or a STRING with a length specifier:
+//    ScalarType := INT | STRING( length )
+// then we use a go interface type to encode ScalarType:
+//    type ScalarType interface {
+//        PrScalarType() string  // To print ScalarTypes types.
+//    }
+// and struct types for each case:
+//    type Int struct { }
+//    type String struct { length int64 }
+// and finally, we define functions:
+//    func (i Int) PrScalarType() { ... }
+//    func (s String) PrScalarType() { .. }
+//
+// The net result is that the only way to build a ScalarType
+// is using Int or String.
+package ddl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Length encodes the following Spanner DDL definition:
+//     length:
+//        { int64_value | MAX }
+type Length interface {
+	PrLength() string
+}
+
+// Int64Length wraps an integer length specifier.
+type Int64Length struct{ Value int64 }
+
+// MaxLength represents "MAX".
+type MaxLength struct{}
+
+// PrLength unparses Int64Length.
+func (i Int64Length) PrLength() string { return fmt.Sprintf("%d", i.Value) }
+
+// PrLength unparses MaxLength.
+func (m MaxLength) PrLength() string { return fmt.Sprintf("MAX") }
+
+// ScalarType encodes the following DDL definition:
+//     scalar_type:
+//        { BOOL | INT64 | FLOAT64 | STRING( length ) | BYTES( length ) | DATE | TIMESTAMP }
+type ScalarType interface {
+	PrScalarType() string
+}
+
+// Bool encodes DDL BOOL.
+type Bool struct{}
+
+// Bytes encodes DDL BYTES( length ).
+type Bytes struct{ Len Length }
+
+// Date encodes DDL DATE.
+type Date struct{}
+
+// Float64 encodes DDL FLOAT64.
+type Float64 struct{}
+
+// Int64 encodes DDL INT64.
+type Int64 struct{}
+
+// String encodes DDL STRING.
+type String struct{ Len Length }
+
+// Timestamp encodes DDL TIMESTAMP.
+type Timestamp struct{}
+
+// PrScalarType unparses Bool.
+func (b Bool) PrScalarType() string { return "BOOL" }
+
+// PrScalarType unparses Bytes.
+func (b Bytes) PrScalarType() string { return fmt.Sprintf("BYTES(%s)", b.Len.PrLength()) }
+
+// PrScalarType unparses Date.
+func (d Date) PrScalarType() string { return "DATE" }
+
+// PrScalarType unparses Float64
+func (g Float64) PrScalarType() string { return "FLOAT64" }
+
+// PrScalarType unparses Int64
+func (i Int64) PrScalarType() string { return "INT64" }
+
+// PrScalarType unparses String
+func (s String) PrScalarType() string { return fmt.Sprintf("STRING(%s)", s.Len.PrLength()) }
+
+// PrScalarType unparses Timestamp
+func (t Timestamp) PrScalarType() string { return "TIMESTAMP" }
+
+// ColumnDef encodes the following DDL definition:
+//     column_def:
+//       column_name {scalar_type | array_type} [NOT NULL] [options_def]
+type ColumnDef struct {
+	Name    string
+	T       ScalarType
+	IsArray bool // When false, this column has type T; when true, it is an array of type T.
+	NotNull bool
+	Comment string
+}
+
+// PrColumnDef unparses ColumnDef and returns it as well as any ColumnDef
+// comment. These are returned as separate strings to support formatting
+// needs of PrCreateTable.
+func (cd ColumnDef) PrColumnDef(c Config) (string, string) {
+	s := fmt.Sprintf("%s %s", backtick(c)(cd.Name), cd.PrColumnDefType())
+	if cd.NotNull {
+		s += " NOT NULL"
+	}
+	return s, cd.Comment
+}
+
+// PrColumnDefType unparses the type encoded in a ColumnDef.
+func (cd ColumnDef) PrColumnDefType() string {
+	t := cd.T.PrScalarType()
+	if cd.IsArray {
+		return fmt.Sprintf("ARRAY<%s>", t)
+	}
+	return t
+}
+
+// IndexKey encodes the following DDL definition:
+//     primary_key:
+//       PRIMARY KEY ( [key_part, ...] )
+//     key_part:
+//        column_name [{ ASC | DESC }]
+type IndexKey struct {
+	Col  string
+	Desc bool // Default order is ascending i.e. Desc = false.
+}
+
+// PrIndexKey unparses the index keys.
+func (pk IndexKey) PrIndexKey(c Config) string {
+	col := backtick(c)(pk.Col)
+	if pk.Desc {
+		return fmt.Sprintf("%s DESC", col)
+	}
+	// Don't print out ASC -- that's the default.
+	return col
+}
+
+// CreateTable encodes the following DDL definition:
+//     create_table: CREATE TABLE table_name ([column_def, ...] ) primary_key [, cluster]
+type CreateTable struct {
+	Name    string
+	Cols    []string             // Provides names and order of columns
+	Cds     map[string]ColumnDef // Provides definition of columns (a map for simpler/faster lookup during type processing)
+	Pks     []IndexKey
+	Comment string
+}
+
+// Config controls unparsing.
+type Config struct {
+	Comments   bool // If true, print comments.
+	ProtectIds bool // If true, table and col names are enclosed with backticks (avoids reserved-word issue).
+}
+
+// PrCreateTable unparses a CREATE TABLE statement.
+func (ct CreateTable) PrCreateTable(config Config) string {
+	bt := backtick(config)
+	var col []string
+	var colComment []string
+	var keys []string
+	for i, cn := range ct.Cols {
+		s, c := ct.Cds[cn].PrColumnDef(config)
+		s = "\n    " + s
+		if i < len(ct.Cols)-1 {
+			s += ","
+		} else {
+			s += " "
+		}
+		col = append(col, s)
+		colComment = append(colComment, c)
+	}
+	n := maxStringLength(col)
+	var cols string
+	for i, c := range col {
+		cols += c
+		if config.Comments && len(colComment[i]) > 0 {
+			cols += strings.Repeat(" ", n-len(c)) + " -- " + colComment[i]
+		}
+	}
+	for _, p := range ct.Pks {
+		keys = append(keys, p.PrIndexKey(config))
+	}
+	var tableComment string
+	if config.Comments && len(ct.Comment) > 0 {
+		tableComment = "--\n-- " + ct.Comment + "\n--\n"
+	}
+	return fmt.Sprintf("%sCREATE TABLE %s (%s\n) PRIMARY KEY (%s)", tableComment, bt(ct.Name), cols, strings.Join(keys, ", "))
+}
+
+// CreateIndex encodes the following DDL definition:
+//     create index: CREATE [UNIQUE] [NULL_FILTERED] INDEX index_name ON table_name ( key_part [, ...] ) [ storing_clause ] [ , interleave_clause ]
+type CreateIndex struct {
+	Name  string
+	Table string
+	Keys  []IndexKey
+	// We have no requirements for unique and null-filtered options and
+	// storing/interleaving clauses yet, so we omit them for now.
+}
+
+// PrCreateIndex unparses a CREATE INDEX statement.
+func (ci CreateIndex) PrCreateIndex(c Config) string {
+	bt := backtick(c)
+	var keys []string
+	for _, p := range ci.Keys {
+		keys = append(keys, p.PrIndexKey(c))
+	}
+	return fmt.Sprintf("CREATE INDEX %s ON %s (%s)", bt(ci.Name), bt(ci.Table), strings.Join(keys, ", "))
+}
+
+func maxStringLength(s []string) int {
+	n := 0
+	for _, x := range s {
+		if len(x) > n {
+			n = len(x)
+		}
+	}
+	return n
+}
+
+func backtick(config Config) func(s string) string {
+	if config.ProtectIds {
+		return func(s string) string { return "`" + s + "`" }
+	}
+	return func(s string) string { return s }
+}

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -57,6 +57,9 @@ type Int64Length struct{ Value int64 }
 // MaxLength represents "MAX".
 type MaxLength struct{}
 
+// Interface validation for Length.
+var _ = []Length{Int64Length{}, MaxLength{}}
+
 // PrintLength unparses Int64Length.
 func (i Int64Length) PrintLength() string { return fmt.Sprintf("%d", i.Value) }
 
@@ -90,6 +93,9 @@ type String struct{ Len Length }
 
 // Timestamp encodes DDL TIMESTAMP.
 type Timestamp struct{}
+
+// Interface validation for ScalarTypes
+var _ = []ScalarType{Bool{}, Bytes{}, Date{}, Float64{}, Int64{}, String{}}
 
 // PrintScalarType unparses Bool.
 func (b Bool) PrintScalarType() string { return "BOOL" }

--- a/spanner/ddl/ast_test.go
+++ b/spanner/ddl/ast_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypes(t *testing.T) {
+	check(t, "BOOL", Bool{}.PrScalarType())
+	check(t, "INT64", Int64{}.PrScalarType())
+	check(t, "FLOAT64", Float64{}.PrScalarType())
+	check(t, "STRING(MAX)", String{MaxLength{}}.PrScalarType())
+	check(t, "STRING(42)", String{Int64Length{42}}.PrScalarType())
+	check(t, "BYTES(MAX)", Bytes{MaxLength{}}.PrScalarType())
+	check(t, "BYTES(42)", Bytes{Int64Length{42}}.PrScalarType())
+	check(t, "DATE", Date{}.PrScalarType())
+	check(t, "TIMESTAMP", Timestamp{}.PrScalarType())
+}
+
+func TestColumnDef(t *testing.T) {
+	c := Config{ProtectIds: false}
+	check(t, "col1 INT64", pr(c, ColumnDef{Name: "col1", T: Int64{}}))
+	check(t, "col1 ARRAY<INT64>", pr(c, ColumnDef{Name: "col1", T: Int64{}, IsArray: true}))
+	check(t, "col1 INT64 NOT NULL", pr(c, ColumnDef{Name: "col1", T: Int64{}, NotNull: true}))
+	check(t, "col1 ARRAY<INT64> NOT NULL", pr(c, ColumnDef{Name: "col1", T: Int64{}, IsArray: true, NotNull: true}))
+	c = Config{ProtectIds: true}
+	check(t, "`col1` INT64", pr(c, ColumnDef{Name: "col1", T: Int64{}}))
+}
+
+func TestIndexKey(t *testing.T) {
+	c := Config{ProtectIds: false}
+	check(t, "col1", IndexKey{Col: "col1"}.PrIndexKey(c))
+	check(t, "col1 DESC", IndexKey{Col: "col1", Desc: true}.PrIndexKey(c))
+	c = Config{ProtectIds: true}
+	check(t, "`col1`", IndexKey{Col: "col1"}.PrIndexKey(c))
+}
+
+func TestCreateTable(t *testing.T) {
+	cds := make(map[string]ColumnDef)
+	cds["col1"] = ColumnDef{Name: "col1", T: Int64{}, NotNull: true}
+	cds["col2"] = ColumnDef{Name: "col2", T: String{MaxLength{}}, NotNull: false}
+	cds["col3"] = ColumnDef{Name: "col3", T: Bytes{Int64Length{42}}, NotNull: false}
+	ct := CreateTable{
+		"mytable",
+		[]string{"col1", "col2", "col3"},
+		cds,
+		[]IndexKey{IndexKey{Col: "col1", Desc: true}},
+		"",
+	}
+	c := Config{ProtectIds: false}
+	check(t, "CREATE TABLE mytable (col1 INT64 NOT NULL, col2 STRING(MAX), col3 BYTES(42)) PRIMARY KEY (col1 DESC)", ct.PrCreateTable(c))
+	c = Config{ProtectIds: true}
+	check(t, "CREATE TABLE `mytable` (`col1` INT64 NOT NULL, `col2` STRING(MAX), `col3` BYTES(42)) PRIMARY KEY (`col1` DESC)", ct.PrCreateTable(c))
+}
+
+func TestCreateIndex(t *testing.T) {
+	ci := CreateIndex{
+		"myindex",
+		"mytable",
+		[]IndexKey{IndexKey{Col: "col1", Desc: true}, IndexKey{Col: "col2"}},
+	}
+	c := Config{ProtectIds: false}
+	check(t, "CREATE INDEX myindex ON mytable (col1 DESC, col2)", ci.PrCreateIndex(c))
+	c = Config{ProtectIds: true}
+	check(t, "CREATE INDEX `myindex` ON `mytable` (`col1` DESC, `col2`)", ci.PrCreateIndex(c))
+}
+
+func normalizeSpace(s string) string {
+	// Insert whitespace around parenthesis and commas.
+	s = strings.ReplaceAll(s, ")", " ) ")
+	s = strings.ReplaceAll(s, "(", " ( ")
+	s = strings.ReplaceAll(s, ",", " , ")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// check verifies that actual and expected are the same, ignoring
+// variations in whitespace.
+func check(t *testing.T, expected, actual string) {
+	assert.Equal(t, normalizeSpace(expected), normalizeSpace(actual))
+}
+
+func pr(c Config, cd ColumnDef) string {
+	s, _ := cd.PrColumnDef(c)
+	return s
+}

--- a/spanner/ddl/ast_test.go
+++ b/spanner/ddl/ast_test.go
@@ -22,15 +22,15 @@ import (
 )
 
 func TestTypes(t *testing.T) {
-	check(t, "BOOL", Bool{}.PrScalarType())
-	check(t, "INT64", Int64{}.PrScalarType())
-	check(t, "FLOAT64", Float64{}.PrScalarType())
-	check(t, "STRING(MAX)", String{MaxLength{}}.PrScalarType())
-	check(t, "STRING(42)", String{Int64Length{42}}.PrScalarType())
-	check(t, "BYTES(MAX)", Bytes{MaxLength{}}.PrScalarType())
-	check(t, "BYTES(42)", Bytes{Int64Length{42}}.PrScalarType())
-	check(t, "DATE", Date{}.PrScalarType())
-	check(t, "TIMESTAMP", Timestamp{}.PrScalarType())
+	check(t, "BOOL", Bool{}.PrintScalarType())
+	check(t, "INT64", Int64{}.PrintScalarType())
+	check(t, "FLOAT64", Float64{}.PrintScalarType())
+	check(t, "STRING(MAX)", String{MaxLength{}}.PrintScalarType())
+	check(t, "STRING(42)", String{Int64Length{42}}.PrintScalarType())
+	check(t, "BYTES(MAX)", Bytes{MaxLength{}}.PrintScalarType())
+	check(t, "BYTES(42)", Bytes{Int64Length{42}}.PrintScalarType())
+	check(t, "DATE", Date{}.PrintScalarType())
+	check(t, "TIMESTAMP", Timestamp{}.PrintScalarType())
 }
 
 func TestColumnDef(t *testing.T) {
@@ -45,10 +45,10 @@ func TestColumnDef(t *testing.T) {
 
 func TestIndexKey(t *testing.T) {
 	c := Config{ProtectIds: false}
-	check(t, "col1", IndexKey{Col: "col1"}.PrIndexKey(c))
-	check(t, "col1 DESC", IndexKey{Col: "col1", Desc: true}.PrIndexKey(c))
+	check(t, "col1", IndexKey{Col: "col1"}.PrintIndexKey(c))
+	check(t, "col1 DESC", IndexKey{Col: "col1", Desc: true}.PrintIndexKey(c))
 	c = Config{ProtectIds: true}
-	check(t, "`col1`", IndexKey{Col: "col1"}.PrIndexKey(c))
+	check(t, "`col1`", IndexKey{Col: "col1"}.PrintIndexKey(c))
 }
 
 func TestCreateTable(t *testing.T) {
@@ -64,9 +64,9 @@ func TestCreateTable(t *testing.T) {
 		"",
 	}
 	c := Config{ProtectIds: false}
-	check(t, "CREATE TABLE mytable (col1 INT64 NOT NULL, col2 STRING(MAX), col3 BYTES(42)) PRIMARY KEY (col1 DESC)", ct.PrCreateTable(c))
+	check(t, "CREATE TABLE mytable (col1 INT64 NOT NULL, col2 STRING(MAX), col3 BYTES(42)) PRIMARY KEY (col1 DESC)", ct.PrintCreateTable(c))
 	c = Config{ProtectIds: true}
-	check(t, "CREATE TABLE `mytable` (`col1` INT64 NOT NULL, `col2` STRING(MAX), `col3` BYTES(42)) PRIMARY KEY (`col1` DESC)", ct.PrCreateTable(c))
+	check(t, "CREATE TABLE `mytable` (`col1` INT64 NOT NULL, `col2` STRING(MAX), `col3` BYTES(42)) PRIMARY KEY (`col1` DESC)", ct.PrintCreateTable(c))
 }
 
 func TestCreateIndex(t *testing.T) {
@@ -76,9 +76,9 @@ func TestCreateIndex(t *testing.T) {
 		[]IndexKey{IndexKey{Col: "col1", Desc: true}, IndexKey{Col: "col2"}},
 	}
 	c := Config{ProtectIds: false}
-	check(t, "CREATE INDEX myindex ON mytable (col1 DESC, col2)", ci.PrCreateIndex(c))
+	check(t, "CREATE INDEX myindex ON mytable (col1 DESC, col2)", ci.PrintCreateIndex(c))
 	c = Config{ProtectIds: true}
-	check(t, "CREATE INDEX `myindex` ON `mytable` (`col1` DESC, `col2`)", ci.PrCreateIndex(c))
+	check(t, "CREATE INDEX `myindex` ON `mytable` (`col1` DESC, `col2`)", ci.PrintCreateIndex(c))
 }
 
 func normalizeSpace(s string) string {
@@ -96,6 +96,6 @@ func check(t *testing.T, expected, actual string) {
 }
 
 func pr(c Config, cd ColumnDef) string {
-	s, _ := cd.PrColumnDef(c)
+	s, _ := cd.PrintColumnDef(c)
 	return s
 }


### PR DESCRIPTION
Package ddl provides a go representation of Spanner DDL
(https://cloud.google.com/spanner/docs/data-definition-language).  In
particular, it provides structs to build up Spanner DDL objects, and a
way to print out those objects.

Note that, for the moment, we only implement enough DDL types to meet
the needs of HarbourBridge.