### PR TITLE
Fix build breakage: switch to go 1.13 docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,12 @@ version: 2
 jobs:
   build_and_test:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.13
 
     working_directory: /go/src/github.com/cloudspannerecosystem/harbourbridge
 
     steps:
       - checkout
-      - run: go get -v -t -d ./...
       - run: go test -v ./...
 
 workflows:


### PR DESCRIPTION
HarbourBridge is based on go 1.13, so need to use the 1.13 docker
image. Also cleanup unnecessary go get call in config.