### PR TITLE
Update copyright and fix imports.

### DIFF
--- a/internal/fixname.go
+++ b/internal/fixname.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/fixname_test.go
+++ b/internal/fixname_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/postgres/convert.go
+++ b/internal/postgres/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@ package postgres
 
 import (
 	"fmt"
-	"harbourbridge/internal"
-	"harbourbridge/spanner/ddl"
 	"reflect"
 	"strings"
 	"time"
 
 	nodes "github.com/lfittl/pg_query_go/nodes"
+
+	"harbourbridge/internal"
+	"harbourbridge/spanner/ddl"
 )
 
 // Conv contains all schema and data conversion state.

--- a/internal/postgres/convert_test.go
+++ b/internal/postgres/convert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
 package postgres
 
 import (
-	"harbourbridge/spanner/ddl"
 	"strings"
 	"testing"
 
 	pg_query "github.com/lfittl/pg_query_go"
 	nodes "github.com/lfittl/pg_query_go/nodes"
 	"github.com/stretchr/testify/assert"
+
+	"harbourbridge/spanner/ddl"
 )
 
 // This file contains very basic tests of Conv API functionality.

--- a/internal/progress.go
+++ b/internal/progress.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/progress_test.go
+++ b/internal/progress_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/reader.go
+++ b/internal/reader.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/reader_test.go
+++ b/internal/reader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/verbose.go
+++ b/internal/verbose.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/spanner/batchwriter.go
+++ b/spanner/batchwriter.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/spanner/batchwriter_test.go
+++ b/spanner/batchwriter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/spanner/ddl/ast_test.go
+++ b/spanner/ddl/ast_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Change 2019 to 2020 in Copyright notice.
Also fix ordering/grouping of imports.