### PR TITLE
fix: fix the issue of importing local subpackage and module name.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module harbourbridge
+module github.com/cloudspannerecosystem/harbourbridge
 
 go 1.13
 

--- a/internal/postgres/convert.go
+++ b/internal/postgres/convert.go
@@ -22,8 +22,8 @@ import (
 
 	nodes "github.com/lfittl/pg_query_go/nodes"
 
-	"harbourbridge/internal"
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 // Conv contains all schema and data conversion state.

--- a/internal/postgres/convert_test.go
+++ b/internal/postgres/convert_test.go
@@ -22,7 +22,7 @@ import (
 	nodes "github.com/lfittl/pg_query_go/nodes"
 	"github.com/stretchr/testify/assert"
 
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 // This file contains very basic tests of Conv API functionality.

--- a/internal/postgres/data.go
+++ b/internal/postgres/data.go
@@ -25,7 +25,7 @@ import (
 
 	"cloud.google.com/go/civil"
 
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 // ConvertData maps the PostgreSQL data in vals into Spanner data,

--- a/internal/postgres/data_test.go
+++ b/internal/postgres/data_test.go
@@ -23,7 +23,7 @@ import (
 	"cloud.google.com/go/civil"
 	"github.com/stretchr/testify/assert"
 
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 func TestConvertData(t *testing.T) {

--- a/internal/postgres/process.go
+++ b/internal/postgres/process.go
@@ -23,7 +23,7 @@ import (
 	pg_query "github.com/lfittl/pg_query_go"
 	nodes "github.com/lfittl/pg_query_go/nodes"
 
-	"harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
 )
 
 // ProcessPgDump reads pg_dump data from r and does schema or data conversion,

--- a/internal/postgres/process_test.go
+++ b/internal/postgres/process_test.go
@@ -25,8 +25,8 @@ import (
 	pg_query "github.com/lfittl/pg_query_go"
 	"github.com/stretchr/testify/assert"
 
-	"harbourbridge/internal"
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 type spannerData struct {

--- a/internal/postgres/report.go
+++ b/internal/postgres/report.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"strings"
 
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 // GenerateReport analyzes schema and data conversion stats and writes a

--- a/internal/postgres/report_test.go
+++ b/internal/postgres/report_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
 )
 
 func TestReport(t *testing.T) {

--- a/internal/postgres/statement.go
+++ b/internal/postgres/statement.go
@@ -24,8 +24,8 @@ import (
 
 	nodes "github.com/lfittl/pg_query_go/nodes"
 
-	"harbourbridge/internal"
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 type copyOrInsert struct {

--- a/internal/postgres/statement_test.go
+++ b/internal/postgres/statement_test.go
@@ -20,7 +20,7 @@ import (
 	pg_query "github.com/lfittl/pg_query_go"
 	"github.com/stretchr/testify/assert"
 
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 // This is just a very basic smoke-test for processStatements.

--- a/internal/postgres/tablemap.go
+++ b/internal/postgres/tablemap.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
 )
 
 // GetSpannerTable maps a PostgreSQL table name into a legal Spanner table

--- a/main.go
+++ b/main.go
@@ -40,10 +40,10 @@ import (
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
 	instancepb "google.golang.org/genproto/googleapis/spanner/admin/instance/v1"
 
-	"harbourbridge/internal"
-	"harbourbridge/internal/postgres"
-	"harbourbridge/spanner"
-	"harbourbridge/spanner/ddl"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/internal/postgres"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 var (


### PR DESCRIPTION
### Problem

I got the following error when I try to install the tool: 

```bash
$ go get -u github.com/cloudspannerecosystem/harbourbridge                                                                                                 Mon 10 Feb 14:16:39 2020
package harbourbridge/internal: unrecognized import path "harbourbridge/internal" (import path does not begin with hostname)
package harbourbridge/internal/postgres: unrecognized import path "harbourbridge/internal/postgres" (import path does not begin with hostname)
package harbourbridge/spanner: unrecognized import path "harbourbridge/spanner" (import path does not begin with hostname)
package harbourbridge/spanner/ddl: unrecognized import path "harbourbridge/spanner/ddl" (import path does not begin with hostname)
```

### Changes

1. The convention in go is to use the absolute path, e.g., `github.com/<org>/<project>/<submodule>...` (I guess this is somehow based on `$GOPATH/src/`). 
2. The module name should also be the same way. 

References: 

* https://github.com/influxdata/influxdb
* https://golang.org/doc/code.html