### PR TITLE
Fix README typo for CHAR type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ The HarbourBridge tool maps PostgreSQL types to Spanner types as follows:
 | `BIGINT`           | `INT64`                |                               |
 | `BIGSERIAL`        | `INT64`                | a                             |
 | `BYTEA`            | `BYTES(MAX)`           |                               |
-| `CHAR`             | `STRING(MAX)`          |                               |
+| `CHAR`             | `STRING(1)`            | CHAR defaults to length 1     |
 | `CHAR(N)`          | `STRING(N)`            | c                             |
 | `DATE`             | `DATE`                 |                               |
 | `DOUBLE PRECISION` | `FLOAT64`              |                               |


### PR DESCRIPTION
CHAR with unspecified length is equivalent to CHAR(1).
See https://www.postgresql.org/docs/9.3/datatype-character.html.
Note: code does the right thing, but documentation said the wrong thing.