### PR TITLE
Revert "fix: update to exit early when the file is not parsable."

### DIFF
--- a/internal/postgres/process_test.go
+++ b/internal/postgres/process_test.go
@@ -530,20 +530,6 @@ func TestProcessPgDump_AddPrimaryKeys(t *testing.T) {
 	}
 }
 
-func TestProcessPgDump_WithUnparsableContent(t *testing.T) {
-	s := "This is unparsable content"
-	conv := MakeConv()
-	conv.SetLocation(time.UTC)
-	conv.SetSchemaMode()
-	err := ProcessPgDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil))
-	if err == nil {
-		t.Fatalf("Expect an error, but got nil")
-	}
-	if !strings.Contains(err.Error(), "Error parsing input") {
-		t.Fatalf("Expect a parsing error, but got %q", err)
-	}
-}
-
 func runProcessPgDump(s string) (*Conv, []spannerData) {
 	conv := MakeConv()
 	conv.SetLocation(time.UTC)

--- a/main.go
+++ b/main.go
@@ -94,10 +94,7 @@ func main() {
 	if filePrefix == "" {
 		filePrefix = dbName + "."
 	}
-	err = firstPass(f, n, conv)
-	if err != nil {
-		panic(fmt.Errorf("Failed to parse the data file: %v", err))
-	}
+	firstPass(f, n, conv)
 	writeSchemaFile(conv, now, filePrefix+schemaFile)
 	db, err := createDatabase(project, instance, dbName, now, conv)
 	if err != nil {
@@ -146,17 +143,13 @@ func report(bw *spanner.BatchWriter, bytesRead int64, now time.Time, db string, 
 	writeBadData(bw, conv, banner, filePrefix+badDataFile)
 }
 
-func firstPass(f *os.File, fileSize int64, conv *postgres.Conv) error {
+func firstPass(f *os.File, fileSize int64, conv *postgres.Conv) {
 	p := internal.NewProgress(fileSize, "Generating schema", internal.Verbose())
 	r := internal.NewReader(bufio.NewReader(f), p)
 	conv.SetSchemaMode() // Build schema and ignore data in pg_dump.
 	conv.SetDataSink(nil)
-	err := postgres.ProcessPgDump(conv, r)
-	if err != nil {
-		return err
-	}
+	postgres.ProcessPgDump(conv, r)
 	p.Done()
-	return nil
 }
 
 func secondPass(f *os.File, client *sp.Client, conv *postgres.Conv, totalRows int64) *spanner.BatchWriter {


### PR DESCRIPTION
Reverts cloudspannerecosystem/harbourbridge#42

This PR broke the build: actually it looks like its just the new test that is broken.
Going to do simple revert for the moment and fix issue on Monday.