### PR TITLE
fix: update to exit early when the file is not parsable.

### DIFF
--- a/internal/postgres/process.go
+++ b/internal/postgres/process.go
@@ -132,7 +132,7 @@ func readAndParseChunk(conv *Conv, r *internal.Reader) ([]byte, []nodes.Node, er
 			conv.stats.reparsed++
 		}
 		if r.EOF {
-			return nil, nil, fmt.Errorf("Error parsing input: %q", l)
+			return nil, nil, fmt.Errorf("Error parsing last %d line(s) of input", len(l))
 		}
 	}
 }

--- a/internal/postgres/process_test.go
+++ b/internal/postgres/process_test.go
@@ -530,6 +530,20 @@ func TestProcessPgDump_AddPrimaryKeys(t *testing.T) {
 	}
 }
 
+func TestProcessPgDump_WithUnparsableContent(t *testing.T) {
+	s := "This is unparsable content"
+	conv := MakeConv()
+	conv.SetLocation(time.UTC)
+	conv.SetSchemaMode()
+	err := ProcessPgDump(conv, internal.NewReader(bufio.NewReader(strings.NewReader(s)), nil))
+	if err == nil {
+		t.Fatalf("Expect an error, but got nil")
+	}
+	if !strings.Contains(err.Error(), "Error parsing input") {
+		t.Fatalf("Expect a parsing error, but got %q", err)
+	}
+}
+
 func runProcessPgDump(s string) (*Conv, []spannerData) {
 	conv := MakeConv()
 	conv.SetLocation(time.UTC)

--- a/internal/postgres/process_test.go
+++ b/internal/postgres/process_test.go
@@ -539,7 +539,7 @@ func TestProcessPgDump_WithUnparsableContent(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expect an error, but got nil")
 	}
-	if !strings.Contains(err.Error(), "Error parsing input") {
+	if !strings.Contains(err.Error(), "Error parsing") {
 		t.Fatalf("Expect a parsing error, but got %q", err)
 	}
 }


### PR DESCRIPTION
This is a revert for #44. The new added test is broken due to the last change, which has been fixed. 