### PR TITLE
chore: add a step to set the gcp credentials in CI config. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,13 @@ jobs:
 
     steps:
       - checkout
+
+      - run:
+          name: set credentials
+          command: |
+            echo $GCLOUD_SERVICE_KEY > $HOME/gcloud-service-key.json
+            echo 'export GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-service-key.json' >> $BASH_ENV
+
       - run: go test -v ./...
 
 workflows:


### PR DESCRIPTION
This change adds a step to CI config to read GCP credential file from the environment variable and set `GOOGLE_APPLICATION_CREDENTIALS` to the generated file. 