### PR TITLE
refactor: refactor the main.go

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -131,7 +131,7 @@ func TestIntegration_SimpleUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open the test data file: %v", err)
 	}
-	err = pgDumpToSpanner(projectID, instanceID, dbName, &ioStreams{f, os.Stdout}, filePrefix, now)
+	err = toSpanner("pgdump", projectID, instanceID, dbName, &ioStreams{in: f, out: os.Stdout}, filePrefix, now)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Basically, I refactor to have a main entrance `toSpanner()`, which includes the following abstract steps: 

1. Run schema conversion (`schemaConv()`)
2. Create spanner database
3. Run data conversion (`dataConv()`)
4. Generate report

Schema & data conversion will be routed to different methods based on the driver name. Currently, we support two drivers: 

* pgdump
* posgres

For example, `schemaConv` will choose different methods to run according to the driver name. 

* posgres: schemaConvFromSourceDB()
* pgdump: schemaConvFromFileStream()

schemaConvFromSourceDB() will intialize different driver config according to the driver name. E.g, if the driver name is "posgres", the program will call `pgDriverConfig()` for make a db connection. In the future, we only need to add a `mysqlDriverConfig()` for mysql extension. 

We can do the same thing for `dataConv`. 