### PR TITLE
Fix POSTGRES const typo: "posgres" --> "postgres".

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ const (
 	// PGDUMP is the driver name for pg_dump.
 	PGDUMP string = "pgdump"
 	// POSTGRES is the driver name for PostgreSQL.
-	POSTGRES string = "posgres"
+	POSTGRES string = "postgres"
 )
 
 var (


### PR DESCRIPTION
This was breaking the postgres driver option.