### PR TITLE
fix: the integration test failed due to unquoted date string

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -254,7 +254,7 @@ func checkDateBytesBool(ctx context.Context, t *testing.T, client *spanner.Clien
 			t.Fatal(err)
 		}
 	}
-	if got, want := date.String(), "\"2019-10-28\""; got != want {
+	if got, want := date.String(), "2019-10-28"; got != want {
 		t.Fatalf("date is not correct: got %v, want %v", got, want)
 	}
 	if got, want := string(bytesVal), "\x00\x01\x02\x03ޭ\xbe\xef"; got != want {


### PR DESCRIPTION
The integration test failed due to upgrading to a new version of spanner client library. The new version has removed quotes from the string of nullable date (https://code-review.googlesource.com/c/gocloud/+/47192). 