### PR TITLE
Fix pg_dump backslashes in IMPORT-FROM and fix several array issues.

### DIFF
--- a/internal/data.go
+++ b/internal/data.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
 
 	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
@@ -152,10 +153,10 @@ func convBool(val string) (bool, error) {
 }
 
 func convBytes(val string) ([]byte, error) {
-	if val[0:3] != `\\x` {
+	if val[0:2] != `\x` {
 		return []byte{}, fmt.Errorf("can't convert to bytes: doesn't start with \\x prefix")
 	}
-	b, err := hex.DecodeString(val[3:])
+	b, err := hex.DecodeString(val[2:])
 	if err != nil {
 		return b, fmt.Errorf("can't convert to bytes: %w", err)
 	}
@@ -228,6 +229,12 @@ func convTimestamp(srcTypeName string, location *time.Location, val string) (t t
 
 func convArray(spannerType ddl.ScalarType, srcTypeName string, location *time.Location, v string) (interface{}, error) {
 	v = strings.TrimSpace(v)
+	// Handle empty array. Note that we use an empty NullString array
+	// for all Spanner array types since this will be converted to the
+	// appropriate type by the Spanner client.
+	if v == "{}" {
+		return []spanner.NullString{}, nil
+	}
 	if v[0] != '{' || v[len(v)-1] != '}' {
 		return []interface{}{}, fmt.Errorf("unrecognized data format for array: expected {v1, v2, ...}")
 	}
@@ -238,18 +245,34 @@ func convArray(spannerType ddl.ScalarType, srcTypeName string, location *time.Lo
 	// Hence we have to do the following case analysis.
 	switch spannerType.(type) {
 	case ddl.Bool:
-		var r []bool
+		var r []spanner.NullBool
 		for _, s := range a {
+			if s == "NULL" {
+				r = append(r, spanner.NullBool{Valid: false})
+				continue
+			}
+			s, err := processQuote(s)
+			if err != nil {
+				return []spanner.NullBool{}, err
+			}
 			b, err := convBool(s)
 			if err != nil {
-				return []bool{}, err
+				return []spanner.NullBool{}, err
 			}
-			r = append(r, b)
+			r = append(r, spanner.NullBool{Bool: b, Valid: true})
 		}
 		return r, nil
 	case ddl.Bytes:
 		var r [][]byte
 		for _, s := range a {
+			if s == "NULL" {
+				r = append(r, nil)
+				continue
+			}
+			s, err := processQuote(s)
+			if err != nil {
+				return [][]byte{}, err
+			}
 			b, err := convBytes(s)
 			if err != nil {
 				return [][]byte{}, err
@@ -258,53 +281,108 @@ func convArray(spannerType ddl.ScalarType, srcTypeName string, location *time.Lo
 		}
 		return r, nil
 	case ddl.Date:
-		var r []civil.Date
+		var r []spanner.NullDate
 		for _, s := range a {
+			if s == "NULL" {
+				r = append(r, spanner.NullDate{Valid: false})
+				continue
+			}
+			s, err := processQuote(s)
+			if err != nil {
+				return []spanner.NullDate{}, err
+			}
 			d, err := convDate(s)
 			if err != nil {
-				return []civil.Date{}, err
+				return []spanner.NullDate{}, err
 			}
-			r = append(r, d)
+			r = append(r, spanner.NullDate{Date: d, Valid: true})
 		}
 		return r, nil
 	case ddl.Float64:
-		var r []float64
+		var r []spanner.NullFloat64
 		for _, s := range a {
+			if s == "NULL" {
+				r = append(r, spanner.NullFloat64{Valid: false})
+				continue
+			}
+			s, err := processQuote(s)
+			if err != nil {
+				return []spanner.NullFloat64{}, err
+			}
 			f, err := convFloat64(s)
 			if err != nil {
-				return []float64{}, err
+				return []spanner.NullFloat64{}, err
 			}
-			r = append(r, f)
+			r = append(r, spanner.NullFloat64{Float64: f, Valid: true})
 		}
 		return r, nil
 	case ddl.Int64:
-		var r []int64
+		var r []spanner.NullInt64
 		for _, s := range a {
+			if s == "NULL" {
+				r = append(r, spanner.NullInt64{Valid: false})
+				continue
+			}
+			s, err := processQuote(s)
+			if err != nil {
+				return []spanner.NullInt64{}, err
+			}
 			i, err := convInt64(s)
 			if err != nil {
 				return r, err
 			}
-			r = append(r, i)
+			r = append(r, spanner.NullInt64{Int64: i, Valid: true})
 		}
 		return r, nil
 	case ddl.String:
-		var r []string
+		var r []spanner.NullString
 		for _, s := range a {
-			r = append(r, s)
+			if s == "NULL" {
+				r = append(r, spanner.NullString{Valid: false})
+				continue
+			}
+			s, err := processQuote(s)
+			if err != nil {
+				return []spanner.NullString{}, err
+			}
+			r = append(r, spanner.NullString{StringVal: s, Valid: true})
 		}
 		return r, nil
 	case ddl.Timestamp:
-		var r []time.Time
+		var r []spanner.NullTime
 		for _, s := range a {
+			if s == "NULL" {
+				r = append(r, spanner.NullTime{Valid: false})
+				continue
+			}
+			s, err := processQuote(s)
+			if err != nil {
+				return []spanner.NullTime{}, err
+			}
 			t, err := convTimestamp(srcTypeName, location, s)
 			if err != nil {
-				return []time.Time{}, err
+				return []spanner.NullTime{}, err
 			}
-			r = append(r, t)
+			r = append(r, spanner.NullTime{Time: t, Valid: true})
 		}
 		return r, nil
 	}
 	return []interface{}{}, fmt.Errorf("array type conversion not implemented for type %v", reflect.TypeOf(spannerType))
+}
+
+// processQuote returns the unquoted version of s.
+// Note: The element values of PostgreSQL arrays may have double
+// quotes around them.  The array output routine will put double
+// quotes around element values if they are empty strings, contain
+// curly braces, delimiter characters, double quotes, backslashes, or
+// white space, or match the word NULL. Double quotes and backslashes
+// embedded in element values will be backslash-escaped.  See section
+// 8.14.6.of www.postgresql.org/docs/9.1/arrays.html.
+func processQuote(s string) (string, error) {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return strconv.Unquote(s)
+	}
+	return s, nil
 }
 
 func byteSize(r *row) int64 {

--- a/internal/data.go
+++ b/internal/data.go
@@ -118,6 +118,10 @@ func ConvertData(conv *Conv, srcTable string, srcCols []string, vals []string) (
 	return spTable, c, v, nil
 }
 
+// convScalar converts a source database string value to an
+// appropriate Spanner value. It is the caller's responsibility to
+// detect and handle NULL values: convScalar will return error if a
+// NULL value is passed.
 func convScalar(spannerType ddl.ScalarType, srcTypeName string, location *time.Location, val string) (interface{}, error) {
 	// Whitespace within the val string is considered part of the data value.
 	// Note that many of the underlying conversions functions we use (like
@@ -227,6 +231,12 @@ func convTimestamp(srcTypeName string, location *time.Location, val string) (t t
 	return t, err
 }
 
+// convArray converts a source database string value (representing an
+// array) to an appropriate Spanner array value. It is the caller's
+// responsibility to detect and handle the case where the entire array
+// is NULL. However, convArray does handle the case where individual
+// array elements are NULL. In other words, convArray handles "{1,
+// NULL, 2}", but it does not handle "NULL" (it returns error).
 func convArray(spannerType ddl.ScalarType, srcTypeName string, location *time.Location, v string) (interface{}, error) {
 	v = strings.TrimSpace(v)
 	// Handle empty array. Note that we use an empty NullString array

--- a/internal/data_test.go
+++ b/internal/data_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cloudspannerecosystem/harbourbridge/schema"
@@ -69,21 +70,44 @@ func TestConvertData(t *testing.T) {
 		e       interface{} // Expected result.
 	}{
 		{"bool", ddl.Bool{}, false, "", "true", true},
-		{"bytes", ddl.Bytes{Len: ddl.MaxLength{}}, false, "", `\\x0001beef`, []byte{0x0, 0x1, 0xbe, 0xef}},
+		{"bytes", ddl.Bytes{Len: ddl.MaxLength{}}, false, "", `\x0001beef`, []byte{0x0, 0x1, 0xbe, 0xef}},
 		{"date", ddl.Date{}, false, "", "2019-10-29", getDate("2019-10-29")},
 		{"float64", ddl.Float64{}, false, "", "42.6", float64(42.6)},
 		{"int64", ddl.Int64{}, false, "", "42", int64(42)},
 		{"string", ddl.String{Len: ddl.MaxLength{}}, false, "", "eh", "eh"},
 		{"timestamptz", ddl.Timestamp{}, false, "timestamptz", "2019-10-29 05:30:00+10", getTime(t, "2019-10-29T05:30:00+10:00")},
 		{"timestamp", ddl.Timestamp{}, false, "timestamp", "2019-10-29 05:30:00", getTime(t, "2019-10-29T05:30:00Z")},
+
 		// Add cases for each array type, since each is a separate code path.
-		{"bool array", ddl.Bool{}, true, "", "{true,false}", []bool{true, false}},
-		{"bytes array", ddl.Bytes{Len: ddl.MaxLength{}}, true, "", `{\\x0001beef}`, [][]byte{{0x0, 0x1, 0xbe, 0xef}}},
-		{"date array", ddl.Date{}, true, "", "{2019-10-29,2019-10-28}", []civil.Date{getDate("2019-10-29"), getDate("2019-10-28")}},
-		{"float64 array", ddl.Float64{}, true, "", "{1.1,2.2,3.3}", []float64{1.1, 2.2, 3.3}},
-		{"int64 array", ddl.Int64{}, true, "", "{1,2,3}", []int64{1, 2, 3}},
-		{"string array", ddl.String{Len: ddl.MaxLength{}}, true, "", "{1,2,3}", []string{"1", "2", "3"}},
-		{"timestamp array", ddl.Timestamp{}, true, "timestamptz", "{2019-10-29 05:30:00+10}", []time.Time{getTime(t, "2019-10-29T05:30:00+10:00")}},
+		// Note: the PostgreSQL array output routine puts double quotes around
+		// elements if they have white space e.g. timestamps, bytea arrays.
+		{"bool array", ddl.Bool{}, true, "", "{true,false,NULL}", []spanner.NullBool{
+			spanner.NullBool{Bool: true, Valid: true}, spanner.NullBool{Bool: false, Valid: true},
+			spanner.NullBool{Valid: false}}},
+		{"bytes array", ddl.Bytes{Len: ddl.MaxLength{}}, true, "", `{"\\x0001beef",NULL}`, [][]byte{{0x0, 0x1, 0xbe, 0xef}, nil}},
+		{"date array", ddl.Date{}, true, "", "{2019-10-29,NULL,2019-10-28}", []spanner.NullDate{
+			spanner.NullDate{Date: getDate("2019-10-29"), Valid: true},
+			spanner.NullDate{Valid: false},
+			spanner.NullDate{Date: getDate("2019-10-28"), Valid: true}}},
+		{"float64 array", ddl.Float64{}, true, "", "{1.1,NULL,2.2,3.3}", []spanner.NullFloat64{
+			spanner.NullFloat64{Float64: 1.1, Valid: true},
+			spanner.NullFloat64{Valid: false},
+			spanner.NullFloat64{Float64: 2.2, Valid: true},
+			spanner.NullFloat64{Float64: 3.3, Valid: true}}},
+		{"int64 array", ddl.Int64{}, true, "", "{NULL,1,2,3}", []spanner.NullInt64{
+			spanner.NullInt64{Valid: false},
+			spanner.NullInt64{Int64: 1, Valid: true},
+			spanner.NullInt64{Int64: 2, Valid: true},
+			spanner.NullInt64{Int64: 3, Valid: true}}},
+		{"string array", ddl.String{Len: ddl.MaxLength{}}, true, "", `{1,NULL,3,"NULL"}`, []spanner.NullString{
+			spanner.NullString{StringVal: "1", Valid: true},
+			spanner.NullString{Valid: false},
+			spanner.NullString{StringVal: "3", Valid: true},
+			spanner.NullString{StringVal: "NULL", Valid: true}}},
+		{"timestamp array", ddl.Timestamp{}, true, "timestamptz", `{"2019-10-29 05:30:00+10",NULL}`, []spanner.NullTime{
+			spanner.NullTime{Time: getTime(t, "2019-10-29T05:30:00+10:00"), Valid: true},
+			spanner.NullTime{Valid: false}}},
+		{"empty array", ddl.String{Len: ddl.MaxLength{}}, true, "", "{}", []spanner.NullString{}},
 	}
 	tableName := "testtable"
 	for _, tc := range singleColTests {

--- a/internal/pgdump.go
+++ b/internal/pgdump.go
@@ -132,10 +132,15 @@ func processCopyBlock(conv *Conv, srcTable string, srcCols []string, r *Reader) 
 		if !conv.dataMode() {
 			continue
 		}
+		// Pgdump escapes backslash in copy-block statements. For example:
+		// a) a\"b becomes a\\"b in COPY-BLOCK (but 'a\"b' in INSERT-INTO)
+		// b) {"a\"b"} becomes {"a\\"b"} in COPY-BLOCK (but '{"a\"b"}' in INSERT-INTO)
+		// Note: a'b and {a'b} are unchanged in COPY-BLOCK and INSERT-INTO.
+		s := strings.ReplaceAll(string(b), `\\`, `\`)
 		// COPY-FROM blocks use tabs to separate data items. Note that space within data
 		// items is significant e.g. if a table row contains data items "a ", " b "
 		// it will be shown in the COPY-FROM block as "a \t b ".
-		ProcessDataRow(conv, srcTable, srcCols, strings.Split(strings.Trim(string(b), "\r\n"), "\t"))
+		ProcessDataRow(conv, srcTable, srcCols, strings.Split(strings.Trim(s, "\r\n"), "\t"))
 	}
 }
 

--- a/internal/pgdump_test.go
+++ b/internal/pgdump_test.go
@@ -433,7 +433,7 @@ COPY test (id, a, b, c, d, e) FROM stdin;
 					table: "test", cols: []string{"int8", "float8", "bool", "timestamp", "date", "bytea", "arr", "synth_id"},
 					vals: []interface{}{int64(7), float64(42.1), true, getTime(t, "2019-10-29T05:30:00Z"),
 						getDate("2019-10-29"), []byte{0x0, 0x1, 0xbe, 0xef},
-						[]spanner.NullInt64{spanner.NullInt64{Int64: 42, Valid: true}, spanner.NullInt64{Int64: 6, Valid: true}},
+						[]spanner.NullInt64{{Int64: 42, Valid: true}, {Int64: 6, Valid: true}},
 						bitReverse(0)}},
 				spannerData{table: "test", cols: []string{"int8", "synth_id"}, vals: []interface{}{int64(7), bitReverse(1)}},
 				spannerData{table: "test", cols: []string{"float8", "synth_id"}, vals: []interface{}{float64(42.1), bitReverse(2)}},
@@ -442,11 +442,7 @@ COPY test (id, a, b, c, d, e) FROM stdin;
 				spannerData{table: "test", cols: []string{"date", "synth_id"}, vals: []interface{}{getDate("2019-10-29"), bitReverse(5)}},
 				spannerData{table: "test", cols: []string{"bytea", "synth_id"}, vals: []interface{}{[]byte{0x0, 0x1, 0xbe, 0xef}, bitReverse(6)}},
 				spannerData{table: "test", cols: []string{"arr", "synth_id"},
-					vals: []interface{}{
-						[]spanner.NullInt64{
-							spanner.NullInt64{Int64: 42, Valid: true},
-							spanner.NullInt64{Int64: 6, Valid: true}},
-						bitReverse(7)}},
+					vals: []interface{}{[]spanner.NullInt64{{Int64: 42, Valid: true}, {Int64: 6, Valid: true}}, bitReverse(7)}},
 			},
 		},
 	}

--- a/internal/pgdump_test.go
+++ b/internal/pgdump_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/spanner"
 	pg_query "github.com/lfittl/pg_query_go"
 	"github.com/stretchr/testify/assert"
 
@@ -431,14 +432,21 @@ COPY test (id, a, b, c, d, e) FROM stdin;
 				spannerData{
 					table: "test", cols: []string{"int8", "float8", "bool", "timestamp", "date", "bytea", "arr", "synth_id"},
 					vals: []interface{}{int64(7), float64(42.1), true, getTime(t, "2019-10-29T05:30:00Z"),
-						getDate("2019-10-29"), []byte{0x0, 0x1, 0xbe, 0xef}, []int64{42, 6}, bitReverse(0)}},
+						getDate("2019-10-29"), []byte{0x0, 0x1, 0xbe, 0xef},
+						[]spanner.NullInt64{spanner.NullInt64{Int64: 42, Valid: true}, spanner.NullInt64{Int64: 6, Valid: true}},
+						bitReverse(0)}},
 				spannerData{table: "test", cols: []string{"int8", "synth_id"}, vals: []interface{}{int64(7), bitReverse(1)}},
 				spannerData{table: "test", cols: []string{"float8", "synth_id"}, vals: []interface{}{float64(42.1), bitReverse(2)}},
 				spannerData{table: "test", cols: []string{"bool", "synth_id"}, vals: []interface{}{true, bitReverse(3)}},
 				spannerData{table: "test", cols: []string{"timestamp", "synth_id"}, vals: []interface{}{getTime(t, "2019-10-29T05:30:00Z"), bitReverse(4)}},
 				spannerData{table: "test", cols: []string{"date", "synth_id"}, vals: []interface{}{getDate("2019-10-29"), bitReverse(5)}},
 				spannerData{table: "test", cols: []string{"bytea", "synth_id"}, vals: []interface{}{[]byte{0x0, 0x1, 0xbe, 0xef}, bitReverse(6)}},
-				spannerData{table: "test", cols: []string{"arr", "synth_id"}, vals: []interface{}{[]int64{42, 6}, bitReverse(7)}},
+				spannerData{table: "test", cols: []string{"arr", "synth_id"},
+					vals: []interface{}{
+						[]spanner.NullInt64{
+							spanner.NullInt64{Int64: 42, Valid: true},
+							spanner.NullInt64{Int64: 6, Valid: true}},
+						bitReverse(7)}},
 			},
 		},
 	}


### PR DESCRIPTION
Includes:
- fix for escape sequences in IMPORT-FROM statements (double-backslash issue)
- adds handling of quoted array values
- adds handling of empty arrays
- adds handling of NULL in arrays
