### PR TITLE
Complete information-schema mode: add data processing.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,7 @@ golang.org/x/tools v0.0.0-20200317043434-63da46f3035e/go.mod h1:Sl4aGygMT6LrqrWc
 golang.org/x/tools v0.0.0-20200318054722-11a475a590ac/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/internal/data_test.go
+++ b/internal/data_test.go
@@ -283,9 +283,9 @@ func buildConv(spTable ddl.CreateTable, srcTable schema.Table) *Conv {
 	conv.srcSchema[srcTable.Name] = srcTable
 	conv.toSource[spTable.Name] = nameAndCols{name: srcTable.Name, cols: make(map[string]string)}
 	conv.toSpanner[srcTable.Name] = nameAndCols{name: spTable.Name, cols: make(map[string]string)}
-	for _, c := range spTable.ColNames {
-		conv.toSource[spTable.Name].cols[c] = c
-		conv.toSpanner[srcTable.Name].cols[c] = c
+	for i := range spTable.ColNames {
+		conv.toSource[spTable.Name].cols[spTable.ColNames[i]] = srcTable.ColNames[i]
+		conv.toSpanner[srcTable.Name].cols[srcTable.ColNames[i]] = spTable.ColNames[i]
 	}
 	return conv
 }

--- a/internal/infoschema.go
+++ b/internal/infoschema.go
@@ -31,10 +31,8 @@ import (
 
 // TODO: All of the queries to get tables and table data should be in
 // a single transaction to ensure we obtain a consistent snapshot of
-// schema information across tables (pg_dump does something
-// similar). When we add SELECT queries to get data, we should wrap
-// those in the same transaction to ensure consistency of schema and
-// data.
+// schema information and table data (pg_dump does something
+// similar).
 
 // ProcessInfoSchema performs schema conversion for source database
 // 'db'. We assume that the source database supports information

--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func dataConv(driver string, ioHelper *ioStreams, client *sp.Client, conv *inter
 	}
 	switch driver {
 	case POSTGRES:
-		return dataFromSQL(config, client, conv)
+		return dataFromSQL(config, client, conv, driver)
 	case PGDUMP:
 		return dataFromPgDump(config, ioHelper, client, conv)
 	default:
@@ -234,12 +234,6 @@ func pgDriverConfig() (string, error) {
 }
 
 func schemaFromSQL(driver string) (*internal.Conv, error) {
-	fmt.Println(`###################################################################
-	Accessing a source DB via an database/sql driver is an experimental
-	feature that is not fully implemented. Currently we only do schema
-	conversion and we only support PostgreSQL.
-	###################################################################`)
-
 	driverConfig, err := driverConfig(driver)
 	if err != nil {
 		return nil, err
@@ -256,8 +250,42 @@ func schemaFromSQL(driver string) (*internal.Conv, error) {
 	return conv, nil
 }
 
-func dataFromSQL(config spanner.BatchWriterConfig, client *sp.Client, conv *internal.Conv) (*spanner.BatchWriter, error) {
-	return spanner.NewBatchWriter(config), nil
+func dataFromSQL(config spanner.BatchWriterConfig, client *sp.Client, conv *internal.Conv, driver string) (*spanner.BatchWriter, error) {
+	// TODO: Refactor to avoid redundant calls to driverConfig and
+	// Open in schemaFromSQL and dataFromSQL. Use single
+	// transaction for reading schema and data from source db to
+	// get consistent dump.
+	driverConfig, err := driverConfig(driver)
+	if err != nil {
+		return nil, err
+	}
+	sourceDB, err := sql.Open(driver, driverConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	internal.SetRowStats(conv, sourceDB)
+	totalRows := conv.Rows()
+	p := internal.NewProgress(totalRows, "Writing data to Spanner", internal.Verbose())
+	rows := int64(0)
+	config.Write = func(m []*sp.Mutation) error {
+		_, err := client.Apply(context.Background(), m)
+		if err != nil {
+			return err
+		}
+		atomic.AddInt64(&rows, int64(len(m)))
+		p.MaybeReport(atomic.LoadInt64(&rows))
+		return nil
+	}
+	writer := spanner.NewBatchWriter(config)
+	conv.SetDataMode()
+	conv.SetDataSink(
+		func(table string, cols []string, vals []interface{}) {
+			writer.AddRow(table, cols, vals)
+		})
+	internal.ProcessSqlData(conv, sourceDB)
+	writer.Flush()
+	return writer, nil
 }
 
 type ioStreams struct {

--- a/main.go
+++ b/main.go
@@ -252,9 +252,10 @@ func schemaFromSQL(driver string) (*internal.Conv, error) {
 
 func dataFromSQL(config spanner.BatchWriterConfig, client *sp.Client, conv *internal.Conv, driver string) (*spanner.BatchWriter, error) {
 	// TODO: Refactor to avoid redundant calls to driverConfig and
-	// Open in schemaFromSQL and dataFromSQL. Use single
-	// transaction for reading schema and data from source db to
-	// get consistent dump.
+	// Open in schemaFromSQL and dataFromSQL. Also refactor to
+	// share code with dataFromPgDump. Use single transaction for
+	// reading schema and data from source db to get consistent
+	// dump.
 	driverConfig, err := driverConfig(driver)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In information-schema mode we use SQL queries to get schema
information and data from a source database. A previous commit had
added schema processing (reading information_schema tables). This
commit adds the data processing part (reading data from tables using
"SELECT *" queries).