### PR TITLE
Fix DEFAULT NULL reporting issue in mysqldump

### DIFF
--- a/mysql/mysqldump.go
+++ b/mysql/mysqldump.go
@@ -341,7 +341,15 @@ func updateColsByOption(conv *internal.Conv, tableName string, col *ast.ColumnDe
 		case ast.ColumnOptionNotNull:
 			column.NotNull = true
 		case ast.ColumnOptionDefaultValue:
-			column.Ignored.Default = true
+			// If a data type specification includes no explicit DEFAULT
+			// value, MySQL determines if the column can take NULL as a value
+			// and the column is defined with DEFAULT NULL clause in mysqldump.
+			// This case is ignored from issue reporting of 'Default' value.
+			v, ok := elem.Expr.(*driver.ValueExpr)
+			nullDefault := ok && v.GetValue() == nil
+			if !nullDefault {
+				column.Ignored.Default = true
+			}
 		case ast.ColumnOptionUniqKey:
 			column.Unique = true
 		case ast.ColumnOptionCheck:


### PR DESCRIPTION
`DEFAULT NULL` is explicitly defined by MySQL ([LINK](https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html#:~:text=If%20a%20data%20type%20specification,with%20no%20explicit%20DEFAULT%20clause.)). Ignored this case from issue reporting of `DEFAULT` condition.