### PR TITLE
Fix : mysql-infoschema getTables() and mysqldump SET TIMEZONE issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -269,7 +269,8 @@ func schemaFromSQL(driver string) (*internal.Conv, error) {
 		return nil, err
 	}
 	conv := internal.MakeConv()
-	err = ProcessInfoSchema(driver, conv, sourceDB)
+	tableSchema := os.Getenv("MYSQLDATABASE")
+	err = ProcessInfoSchema(driver, conv, sourceDB, tableSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +291,8 @@ func dataFromSQL(driver string, config spanner.BatchWriterConfig, client *sp.Cli
 	if err != nil {
 		return nil, err
 	}
-	err = SetRowStats(driver, conv, sourceDB)
+	tableSchema := os.Getenv("MYSQLDATABASE")
+	err = SetRowStats(driver, conv, sourceDB, tableSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +314,7 @@ func dataFromSQL(driver string, config spanner.BatchWriterConfig, client *sp.Cli
 		func(table string, cols []string, vals []interface{}) {
 			writer.AddRow(table, cols, vals)
 		})
-	err = ProcessSQLData(driver, conv, sourceDB)
+	err = ProcessSQLData(driver, conv, sourceDB, tableSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -772,10 +774,10 @@ func ProcessDump(driver string, conv *internal.Conv, r *internal.Reader) error {
 }
 
 // ProcessInfoSchema invokes process infoschema function from a sql package based on driver selected.
-func ProcessInfoSchema(driver string, conv *internal.Conv, db *sql.DB) error {
+func ProcessInfoSchema(driver string, conv *internal.Conv, db *sql.DB, tableSchema string) error {
 	switch driver {
 	case MYSQL:
-		return mysql.ProcessInfoSchema(conv, db)
+		return mysql.ProcessInfoSchema(conv, db, tableSchema)
 	case POSTGRES:
 		return postgres.ProcessInfoSchema(conv, db)
 	default:
@@ -784,10 +786,10 @@ func ProcessInfoSchema(driver string, conv *internal.Conv, db *sql.DB) error {
 }
 
 // SetRowStats invokes SetRowStats function from a sql package based on driver selected.
-func SetRowStats(driver string, conv *internal.Conv, db *sql.DB) error {
+func SetRowStats(driver string, conv *internal.Conv, db *sql.DB, tableSchema string) error {
 	switch driver {
 	case MYSQL:
-		mysql.SetRowStats(conv, db)
+		mysql.SetRowStats(conv, db, tableSchema)
 	case POSTGRES:
 		postgres.SetRowStats(conv, db)
 	default:
@@ -797,10 +799,10 @@ func SetRowStats(driver string, conv *internal.Conv, db *sql.DB) error {
 }
 
 // ProcessSQLData invokes ProcessSQLData function from a sql package based on driver selected.
-func ProcessSQLData(driver string, conv *internal.Conv, db *sql.DB) error {
+func ProcessSQLData(driver string, conv *internal.Conv, db *sql.DB, tableSchema string) error {
 	switch driver {
 	case MYSQL:
-		mysql.ProcessSQLData(conv, db)
+		mysql.ProcessSQLData(conv, db, tableSchema)
 	case POSTGRES:
 		postgres.ProcessSQLData(conv, db)
 	default:

--- a/main.go
+++ b/main.go
@@ -774,7 +774,6 @@ func ProcessDump(driver string, conv *internal.Conv, r *internal.Reader) error {
 // ProcessInfoSchema invokes process infoschema function from a sql package based on driver selected.
 func ProcessInfoSchema(driver string, conv *internal.Conv, db *sql.DB) error {
 	switch driver {
-	// In MySQL, schema is the same as database name.
 	case MYSQL:
 		return mysql.ProcessInfoSchema(conv, db, os.Getenv("MYSQLDATABASE"))
 	case POSTGRES:

--- a/main.go
+++ b/main.go
@@ -269,8 +269,7 @@ func schemaFromSQL(driver string) (*internal.Conv, error) {
 		return nil, err
 	}
 	conv := internal.MakeConv()
-	tableSchema := os.Getenv("MYSQLDATABASE")
-	err = ProcessInfoSchema(driver, conv, sourceDB, tableSchema)
+	err = ProcessInfoSchema(driver, conv, sourceDB)
 	if err != nil {
 		return nil, err
 	}
@@ -291,8 +290,7 @@ func dataFromSQL(driver string, config spanner.BatchWriterConfig, client *sp.Cli
 	if err != nil {
 		return nil, err
 	}
-	tableSchema := os.Getenv("MYSQLDATABASE")
-	err = SetRowStats(driver, conv, sourceDB, tableSchema)
+	err = SetRowStats(driver, conv, sourceDB)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +312,7 @@ func dataFromSQL(driver string, config spanner.BatchWriterConfig, client *sp.Cli
 		func(table string, cols []string, vals []interface{}) {
 			writer.AddRow(table, cols, vals)
 		})
-	err = ProcessSQLData(driver, conv, sourceDB, tableSchema)
+	err = ProcessSQLData(driver, conv, sourceDB)
 	if err != nil {
 		return nil, err
 	}
@@ -774,10 +772,11 @@ func ProcessDump(driver string, conv *internal.Conv, r *internal.Reader) error {
 }
 
 // ProcessInfoSchema invokes process infoschema function from a sql package based on driver selected.
-func ProcessInfoSchema(driver string, conv *internal.Conv, db *sql.DB, tableSchema string) error {
+func ProcessInfoSchema(driver string, conv *internal.Conv, db *sql.DB) error {
 	switch driver {
+	// In MySQL, schema is the same as database name.
 	case MYSQL:
-		return mysql.ProcessInfoSchema(conv, db, tableSchema)
+		return mysql.ProcessInfoSchema(conv, db, os.Getenv("MYSQLDATABASE"))
 	case POSTGRES:
 		return postgres.ProcessInfoSchema(conv, db)
 	default:
@@ -786,10 +785,10 @@ func ProcessInfoSchema(driver string, conv *internal.Conv, db *sql.DB, tableSche
 }
 
 // SetRowStats invokes SetRowStats function from a sql package based on driver selected.
-func SetRowStats(driver string, conv *internal.Conv, db *sql.DB, tableSchema string) error {
+func SetRowStats(driver string, conv *internal.Conv, db *sql.DB) error {
 	switch driver {
 	case MYSQL:
-		mysql.SetRowStats(conv, db, tableSchema)
+		mysql.SetRowStats(conv, db, os.Getenv("MYSQLDATABASE"))
 	case POSTGRES:
 		postgres.SetRowStats(conv, db)
 	default:
@@ -799,10 +798,10 @@ func SetRowStats(driver string, conv *internal.Conv, db *sql.DB, tableSchema str
 }
 
 // ProcessSQLData invokes ProcessSQLData function from a sql package based on driver selected.
-func ProcessSQLData(driver string, conv *internal.Conv, db *sql.DB, tableSchema string) error {
+func ProcessSQLData(driver string, conv *internal.Conv, db *sql.DB) error {
 	switch driver {
 	case MYSQL:
-		mysql.ProcessSQLData(conv, db, tableSchema)
+		mysql.ProcessSQLData(conv, db, os.Getenv("MYSQLDATABASE"))
 	case POSTGRES:
 		postgres.ProcessSQLData(conv, db)
 	default:

--- a/mysql/infoschema.go
+++ b/mysql/infoschema.go
@@ -177,6 +177,7 @@ type schemaAndName struct {
 // embedded within it (dbName is part of the DSN passed to sql.Open),
 // but unfortunately there is no way to extract it from sql.DB.
 func getTables(db *sql.DB, dbName string) ([]schemaAndName, error) {
+	// In MySQL, schema is the same as database name.
 	q := "SELECT table_name FROM information_schema.tables where table_type = 'BASE TABLE' and table_schema=?"
 	rows, err := db.Query(q, dbName)
 	if err != nil {

--- a/mysql/mysqldump.go
+++ b/mysql/mysqldump.go
@@ -146,12 +146,16 @@ func processSetStmt(conv *internal.Conv, stmt *ast.SetStmt) {
 				switch val := value.(type) {
 				case *driver.ValueExpr:
 					if val.GetValue() == nil {
-						logStmtError(conv, stmt, fmt.Errorf("found nil value in set statement"))
+						logStmtError(conv, stmt, fmt.Errorf("found nil value in 'SET TIME_ZONE' statement"))
 						return
 					}
 					conv.TimezoneOffset = fmt.Sprintf("%v", val.GetValue())
 				default:
-					logStmtError(conv, stmt, fmt.Errorf("found %s type value in set statement", reflect.TypeOf(val)))
+					// mysqldump saves the value of TIME_ZONE (in OLD_TIME_ZONE) at
+					// the start of the dump, changes TIME_ZONE, dumps table schema
+					// and data, and then restores TIME_ZONE using OLD_TIME_ZONE at the
+					// end of the dump file. We track the setting of TIME_ZONE, but
+					// ignore the restore statements.
 					return
 				}
 			}


### PR DESCRIPTION
Changes done in this PR:

- Updated query to fetch table in `getTables()`. Added a conditon of table_schema = `dbName`. `dbName` is passed as function argument and it's value is set to MYSQLDATABASE(env variable)

- Remove ignored schemas.

- Removed `buildTableName()` function.

- Removed `logStmtError()` in mysqldump for the case when value in `SET TIMEZONE` is a variable expression.