### PR TITLE
Fix : pgdump driver inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 HarbourBridge is a stand-alone open source tool for Cloud Spanner evaluation,
 using data from an existing PostgreSQL or MySQL database. The tool ingests schema
-and data from either a pgdump/mysqldump file or directly from the source database,
+and data from either a pg_dump/mysqldump file or directly from the source database,
 automatically builds a Spanner schema, and creates a new Spanner database populated
 with data from the source database.
 
@@ -29,10 +29,10 @@ intended for production database migration.
 To use the tool on a PostgreSQL database called mydb, run
 
 ```sh
-# By default, the driver is "pgdump".
+# By default, the driver is "pg_dump".
 pg_dump mydb | harbourbridge
 # Or,
-pg_dump mydb | harbourbridge -driver=pgdump
+pg_dump mydb | harbourbridge -driver=pg_dump
 ```
 
 To use the tool on a MySQL database called mydb, run
@@ -124,7 +124,7 @@ The tool should now be installed as `$GOPATH/bin/harbourbridge`
 To use the tool on a PostgreSQL database called mydb, run
 
 ```sh
-pg_dump mydb | $GOPATH/bin/harbourbridge -driver=pgdump
+pg_dump mydb | $GOPATH/bin/harbourbridge -driver=pg_dump
 ```
 
 To use the tool on a MySQL database called mydb, run
@@ -242,7 +242,7 @@ created in this instance. If not specified, the tool automatically determines an
 appropriate instance using gcloud.
 
 `-driver` Specifies the driver to use for schema and data conversion. Supported drivers
-are _'postgres'_, _'pgdump'_, _'mysql'_ and _'mysqldump'_. By default, the driver is _'pgdump'_.
+are _'postgres'_, _'pg_dump'_, _'mysql'_ and _'mysqldump'_. By default, the driver is _'pg_dump'_.
 
 `-prefix` Specifies a file prefix for the report, schema, and bad-data files
 written by the tool. If no file prefix is specified, the name of the Spanner
@@ -283,9 +283,9 @@ HarbourBridge.
 First, check that the driver is correctly configured to connect to your
 database. Driver configuration varies depending on the driver used.
 
-#### 1.1 pgdump
+#### 1.1 pg_dump
 
-If you are using pg_dump (-driver=pgdump), check that pg_dump is
+If you are using pg_dump (-driver=pg_dump), check that pg_dump is
 correctly configured to connect to your PostgreSQL
 database. Note that pg_dump uses the same options as psql to connect to your
 database. See the [psql](https://www.postgresql.org/docs/9.3/app-psql.html) and

--- a/internal/report.go
+++ b/internal/report.go
@@ -432,7 +432,7 @@ func writeStmtStats(driverName string, conv *Conv, w *bufio.Writer) {
 		s := conv.Stats.Statement[x.statement]
 		fmt.Fprintf(w, "  %6d %6d %6d %6d  %s\n", s.schema, s.data, s.skip, s.Error, x.statement)
 	}
-	if driverName == "pgdump" {
+	if driverName == "pg_dump" {
 		w.WriteString("See github.com/lfittl/pg_query_go/nodes for definitions of statement types\n")
 		w.WriteString("(lfittl/pg_query_go is the library we use for parsing pg_dump output).\n")
 		w.WriteString("\n")
@@ -463,7 +463,7 @@ func writeUnexpectedConditions(driverName string, conv *Conv, w *bufio.Writer) {
 		w.WriteString("mysqldump output is highly permissive: almost any construct can appear at\n")
 		w.WriteString("any node in the AST tree. The list details all unexpected nodes and\n")
 		w.WriteString("conditions.\n")
-	case "pgdump":
+	case "pg_dump":
 		w.WriteString("For debugging only. This section provides details of unexpected conditions\n")
 		w.WriteString("encountered as we processed the pg_dump data. In particular, the AST node\n")
 		w.WriteString("representation used by the lfittl/pg_query_go library used for parsing\n")

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ import (
 
 const (
 	// PGDUMP is the driver name for pg_dump.
-	PGDUMP string = "pgdump"
+	PGDUMP string = "pg_dump"
 	// POSTGRES is the driver name for PostgreSQL.
 	POSTGRES string = "postgres"
 	// MYSQLDUMP is the driver name for mysqldump.
@@ -77,7 +77,7 @@ func init() {
 	flag.StringVar(&dbNameOverride, "dbname", "", "dbname: name to use for Spanner DB")
 	flag.StringVar(&instanceOverride, "instance", "", "instance: Spanner instance to use")
 	flag.StringVar(&filePrefix, "prefix", "", "prefix: file prefix for generated files")
-	flag.StringVar(&driverName, "driver", "pgdump", "driver name: flag for accessing source DB or dump files (accepted values are \"pgdump\", \"postgres\", \"mysqldump\", and \"mysql\")")
+	flag.StringVar(&driverName, "driver", "pg_dump", "driver name: flag for accessing source DB or dump files (accepted values are \"pg_dump\", \"postgres\", \"mysqldump\", and \"mysql\")")
 	flag.BoolVar(&verbose, "v", false, "verbose: print additional output")
 }
 
@@ -421,7 +421,7 @@ func getSeekable(f *os.File) (*os.File, int64, error) {
 	internal.VerbosePrintln("Creating a tmp file with a copy of stdin because stdin is not seekable.")
 
 	// Create file in os.TempDir. Its not clear this is a good idea e.g. if the
-	// pg_dump/mysql_dump output is large (tens of GBs) and os.TempDir points to a directory
+	// pg_dump/mysqldump output is large (tens of GBs) and os.TempDir points to a directory
 	// (such as /tmp) that's configured with a small amount of disk space.
 	// To workaround such limits on Unix, set $TMPDIR to a directory with lots
 	// of disk space.

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -18,26 +18,26 @@ on a PostgreSQL database (via go's database/sql package).
 To use HarbourBridge on a PostgreSQL database called mydb using pg_dump output,run:
 
 ```sh
-pg_dump mydb | harbourbridge -driver=pgdump
+pg_dump mydb | harbourbridge -driver=pg_dump
 ```
 
 The tool can also be applied to an existing pg_dump file:
 
 ```sh
-harbourbridge -driver=pgdump < my_pg_dump_file
+harbourbridge -driver=pg_dump < my_pg_dump_file
 ```
 
 To specify a particular Spanner instance to use, run:
 
 ```sh
-pg_dump mydb | harbourbridge -driver=pgdump -instance my-spanner-instance
+pg_dump mydb | harbourbridge -driver=pg_dump -instance my-spanner-instance
 ```
 
 By default, HarbourBridge will generate a new Spanner database name to populate.
 You can override this and specify the database name to use by:
 
 ```sh
-pg_dump mydb | harbourbridge -driver=pgdump -dbname my-spanner-database-name
+pg_dump mydb | harbourbridge -driver=pg_dump -dbname my-spanner-database-name
 ```
 
 HarbourBridge generates a report file, a schema file, and a bad-data file (if
@@ -45,14 +45,14 @@ there are bad-data rows). You can control where these files are written by
 specifying a file prefix. For example,
 
 ```sh
-pg_dump mydb | harbourbridge -driver=pgdump -prefix mydb.
+pg_dump mydb | harbourbridge -driver=pg_dump -prefix mydb.
 ```
 
 will write files `mydb.report.txt`, `mydb.schema.txt`, and
 `mydb.dropped.txt`. The prefix can also be a directory. For example,
 
 ```sh
-pg_dump mydb | harbourbridge -driver=pgdump -prefix ~/spanner-eval-mydb/
+pg_dump mydb | harbourbridge -driver=pg_dump -prefix ~/spanner-eval-mydb/
 ```
 
 would write the files into the directory `~/spanner-eval-mydb/`. Note

--- a/postgres/pgdump.go
+++ b/postgres/pgdump.go
@@ -133,7 +133,7 @@ func processCopyBlock(conv *internal.Conv, srcTable string, srcCols []string, r 
 		if !conv.DataMode() {
 			continue
 		}
-		// Pgdump escapes backslash in copy-block statements. For example:
+		// pg_dump escapes backslash in copy-block statements. For example:
 		// a) a\"b becomes a\\"b in COPY-BLOCK (but 'a\"b' in INSERT-INTO)
 		// b) {"a\"b"} becomes {"a\\"b"} in COPY-BLOCK (but '{"a\"b"}' in INSERT-INTO)
 		// Note: a'b and {a'b} are unchanged in COPY-BLOCK and INSERT-INTO.

--- a/postgres/report_test.go
+++ b/postgres/report_test.go
@@ -55,7 +55,7 @@ func TestReport(t *testing.T) {
 	conv.Stats.Unexpected["Testing unexpected messages"] = 5
 	buf := new(bytes.Buffer)
 	w := bufio.NewWriter(buf)
-	internal.GenerateReport("pgdump", conv, w, badWrites)
+	internal.GenerateReport("pg_dump", conv, w, badWrites)
 	w.Flush()
 	// Print copy of report to stdout (shows up when running go test -v).
 	fmt.Print(buf.String())
@@ -70,7 +70,7 @@ Summary of Conversion
 Schema conversion: OK (some columns did not map cleanly + some missing primary keys).
 Data conversion: POOR (66% of 6000 rows written to Spanner).
 
-The remainder of this report provides stats on the pgdump statements processed,
+The remainder of this report provides stats on the pg_dump statements processed,
 followed by a table-by-table listing of schema and data conversion details. For
 background on the schema and data conversion process used, and explanations of
 the terms and notes used in this report, see HarbourBridge's README.
@@ -78,7 +78,7 @@ the terms and notes used in this report, see HarbourBridge's README.
 ----------------------------
 Statements Processed
 ----------------------------
-Analysis of statements in pgdump output, broken down by statement type.
+Analysis of statements in pg_dump output, broken down by statement type.
   schema: statements successfully processed for Spanner schema information.
     data: statements successfully processed for data.
     skip: statements not relevant for Spanner schema or data.


### PR DESCRIPTION
There is inconsistency in postgres dump command ('pg_dump') and driver name ('pgdump'). 
For consistency, updated `pgdump` --> `pg_dump`. 