### PR TITLE
Fix : MySQL reserved keywords and spaces issue in schema and table name

### DIFF
--- a/mysql/infoschema.go
+++ b/mysql/infoschema.go
@@ -76,7 +76,7 @@ func ProcessSQLData(conv *internal.Conv, db *sql.DB, dbName string) {
 		// MySQL schema and name can be arbitrary strings.
 		// Ideally we would pass schema/name as a query parameter,
 		// but MySQL doesn't support this. So we quote it instead.
-		q := fmt.Sprintf(`SELECT %s FROM %s.%s;`, colNameList, t.schema, t.name)
+		q := fmt.Sprintf("SELECT %s FROM `%s`.`%s`;", colNameList, t.schema, t.name)
 		rows, err := db.Query(q)
 		if err != nil {
 			conv.Unexpected(fmt.Sprintf("Couldn't get data for table %s : err = %s", t.name, err))
@@ -147,7 +147,7 @@ func SetRowStats(conv *internal.Conv, db *sql.DB, dbName string) {
 		// MySQL schema and name can be arbitrary strings.
 		// Ideally we would pass schema/name as a query parameter,
 		// but MySQL doesn't support this. So we quote it instead.
-		q := fmt.Sprintf(`SELECT COUNT(*) FROM %s.%s;`, t.schema, t.name)
+		q := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`%s`;", t.schema, t.name)
 		tableName := t.name
 		rows, err := db.Query(q)
 		if err != nil {

--- a/mysql/infoschema_test.go
+++ b/mysql/infoschema_test.go
@@ -151,7 +151,7 @@ func TestProcessSQLData(t *testing.T) {
 			cols:  []string{"table_name"},
 			rows:  [][]driver.Value{{"te st"}},
 		}, {
-			query: "SELECT (.+) FROM test.te st",
+			query: "SELECT (.+) FROM `test`.`te st`",
 			cols:  []string{"a a", " b", " c "},
 			rows: [][]driver.Value{
 				{42.3, 3, "cat"},
@@ -233,7 +233,7 @@ func TestProcessSQLData_MultiCol(t *testing.T) {
 			cols:  []string{"table_name"},
 			rows:  [][]driver.Value{{"test"}},
 		}, {
-			query: "SELECT (.+) FROM test.test",
+			query: "SELECT (.+) FROM `test`.`test`",
 			cols:  []string{"a", "b", "c"},
 			rows: [][]driver.Value{
 				{"cat", 42.3, nil},
@@ -282,11 +282,11 @@ func TestSetRowStats(t *testing.T) {
 			cols:  []string{"table_name"},
 			rows:  [][]driver.Value{{"test1"}, {"test2"}},
 		}, {
-			query: `SELECT COUNT[(][*][)] FROM test.test1`,
+			query: "SELECT COUNT[(][*][)] FROM `test`.`test1`",
 			cols:  []string{"count"},
 			rows:  [][]driver.Value{{5}},
 		}, {
-			query: `SELECT COUNT[(][*][)] FROM test.test2`,
+			query: "SELECT COUNT[(][*][)] FROM `test`.`test2`",
 			cols:  []string{"count"},
 			rows:  [][]driver.Value{{142}},
 		},


### PR DESCRIPTION
To handle case when MySQL reserved keywords or spaces are used in schema name(database) or table name, we have quoted schema and table name with backticks (`).