### PR TITLE
Fix: 'Delimiter' error and ignore stored program statements

### DIFF
--- a/internal/report.go
+++ b/internal/report.go
@@ -393,15 +393,15 @@ func ignoredStatements(conv *Conv) (l []string) {
 		switch s {
 		case "CreateFunctionStmt":
 			l = append(l, "functions")
-		case "CreateSeqStmt":
+		case "CreateSeqStmt", "CreateSequenceStmt":
 			l = append(l, "sequences")
-		case "CreatePLangStmt":
+		case "CreatePLangStmt", "CreateProcedureStmt":
 			l = append(l, "procedures")
 		case "CreateTrigStmt":
 			l = append(l, "triggers")
-		case "IndexStmt":
+		case "IndexStmt", "CreateIndexStmt":
 			l = append(l, "(non-primary) indexes")
-		case "ViewStmt":
+		case "ViewStmt", "CreateViewStmt":
 			l = append(l, "views")
 		}
 	}

--- a/mysql/report_test.go
+++ b/mysql/report_test.go
@@ -91,7 +91,7 @@ Analysis of statements in mysqldump output, broken down by statement type.
   --------------------------------------
   schema   data   skip  error  statement
   --------------------------------------
-       5      0      0      0  *ast.CreateTableStmt
+       5      0      0      0  CreateTableStmt
 See https://github.com/pingcap/parser for definitions of statement types
 (pingcap/parser is the library we use for parsing mysqldump output).
 


### PR DESCRIPTION
Changes included in this PR:

- Trimmed `*ast.` prefix from StmtNodes.

- Reporting of View, Index and Sequence statement.

- Handle stored programs (`function`,`procedure` and `trigger`) and `DELIMITER` statement as they are not supported by Pingcap parser. Added `skipUnsupported()` function to skip these statements.

- Refactored `handleSpatialDatatype()` to handle 'SPATIAL INDEX/KEY' and 'SRID'(spatial reference identifier) attribute.