### PR TITLE
fix: fix handling of pg_dump inserts when columns not specified

### DIFF
--- a/postgres/pgdump.go
+++ b/postgres/pgdump.go
@@ -62,7 +62,13 @@ func ProcessPgDump(conv *internal.Conv, r *internal.Reader) error {
 			case copyFrom:
 				processCopyBlock(conv, ci.table, ci.cols, r)
 			case insert:
-				ProcessDataRow(conv, ci.table, ci.cols, ci.vals)
+				// Handle INSERT statements where columns are not
+				// specified i.e. an insert for all table columns.
+				if len(ci.cols) == 0 {
+					ProcessDataRow(conv, ci.table, conv.SrcSchema[ci.table].ColNames, ci.vals)
+				} else {
+					ProcessDataRow(conv, ci.table, ci.cols, ci.vals)
+				}
 			}
 		}
 		if r.EOF {

--- a/postgres/pgdump_test.go
+++ b/postgres/pgdump_test.go
@@ -291,6 +291,14 @@ func TestProcessPgDump(t *testing.T) {
 				spannerData{table: "test", cols: []string{"a", "b", "n"}, vals: []interface{}{"a42", "b6", int64(2)}}},
 		},
 		{
+			name: "INSERT with no cols",
+			input: "CREATE TABLE test (a text NOT NULL, b text NOT NULL, n bigint);\n" +
+				"ALTER TABLE ONLY test ADD CONSTRAINT test_pkey PRIMARY KEY (a, b);" +
+				"INSERT INTO test VALUES ('a42', 'b6', 2);",
+			expectedData: []spannerData{
+				spannerData{table: "test", cols: []string{"a", "b", "n"}, vals: []interface{}{"a42", "b6", int64(2)}}},
+		},
+		{
 			name: "INSERT with no primary key",
 			input: "CREATE TABLE test (a text NOT NULL, b text NOT NULL, n bigint);\n" +
 				"INSERT INTO test (a, b, n) VALUES ('a42', 'b6', 2);",


### PR DESCRIPTION
Handle pg_dump inserts of the form:

 INSERT INTO test VALUES (1, "hello", "bye");

When columns are not specified, we should use all columns in the table.