### PR TITLE
Fix: Update message for foreign keys.

### DIFF
--- a/internal/report.go
+++ b/internal/report.go
@@ -189,7 +189,7 @@ func buildTableReportBody(conv *Conv, srcTable string, issues map[string][]Schem
 				case DefaultValue:
 					l = append(l, fmt.Sprintf("%s e.g. column '%s'", issueDB[i].brief, srcCol))
 				case ForeignKey:
-					l = append(l, fmt.Sprintf("Column '%s' uses foreign keys which Spanner does not support", srcCol))
+					l = append(l, fmt.Sprintf("Column '%s' uses foreign keys which HarbourBridge does not support yet", srcCol))
 				case AutoIncrement:
 					l = append(l, fmt.Sprintf("Column '%s' is an autoincrement column. %s", srcCol, issueDB[i].brief))
 				case Timestamp:

--- a/mysql/report_test.go
+++ b/mysql/report_test.go
@@ -133,7 +133,7 @@ Schema conversion: POOR (many columns did not map cleanly).
 Data conversion: NONE (no data rows found).
 
 Warning
-1) Column 'a' uses foreign keys which Spanner does not support.
+1) Column 'a' uses foreign keys which HarbourBridge does not support yet.
 
 ----------------------------
 Table no_pk

--- a/postgres/report_test.go
+++ b/postgres/report_test.go
@@ -135,7 +135,7 @@ Schema conversion: POOR (many columns did not map cleanly).
 Data conversion: NONE (no data rows found).
 
 Warning
-1) Column 'a' uses foreign keys which Spanner does not support.
+1) Column 'a' uses foreign keys which HarbourBridge does not support yet.
 
 ----------------------------
 Table no_pk


### PR DESCRIPTION
HarbourBridge currently reports "Column mycol uses foreign keys which Spanner does not support", but this is no longer accurate since Spanner does support foreign keys. We haven't added this to HarbourBridge yet (but it's coming soon as part of user-guided schema migration).