### PR TITLE
feature: data-only conversion mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,13 @@ messages about the conversion.
 `-schema-only` Specifies that only schema processing will be performed.
 Any data in the source database will be ignored.
 
+`-data-only` Specifies that only data migration will be performed.
+A spanner database will be created based on the schema state provided
+by a session file (`-session`) and data will be migrated.
+
+`-session` Specifies a session file that contains all schema and data 
+conversion state endcoded as JSON.
+
 ## Example Usage
 
 Details on HarbourBridge example usage for PostgreSQL and MySQL can be


### PR DESCRIPTION
Changes included in this PR:

- Support for data-only conversion mode by specifying a -data-only flag while running the tool.

- A spanner database will be created based on the schema state provided by a session file (`-session`) and then data will be migrated.

Sample Usage:
```sh
$ harbourbridge --data-only --session=sessionFile.json --instance=test-instance --driver=mysqldump < mysqlDumpFile.sql
```

