### PR TITLE
Feature index

### DIFF
--- a/internal/convert.go
+++ b/internal/convert.go
@@ -179,6 +179,9 @@ func (conv *Conv) GetDDL(c ddl.Config) []string {
 	var ddl []string
 	for _, t := range tables {
 		ddl = append(ddl, conv.SpSchema[t].PrintCreateTable(c))
+		for _, i := range conv.SpSchema[t].Indexes {
+			ddl = append(ddl, i.PrintCreateIndex(conv.SpSchema[t].Name, c))
+		}
 	}
 
 	// Append foreign key constraints to DDL.

--- a/internal/mapping_test.go
+++ b/internal/mapping_test.go
@@ -119,3 +119,30 @@ func TestGetSpannerKeyName(t *testing.T) {
 		assert.Equal(t, tc.spKeyName, spKeyName, tc.name)
 	}
 }
+
+func TestGetSpannerIndexKeyName(t *testing.T) {
+	schemaIndexKeys := make(map[string]bool)
+
+	basicTests := []struct {
+		name       string // Name of test.
+		srcKeyName string // Source index key name.
+		spKeyName  string // Expected Spanner index key name.
+	}{
+		{"Good name", "index1", "index1"},
+		{"Collision", "index1", "index1_1"},
+		{"Collision 2", "index1", "index1_2"},
+		{"Bad name", "in\ndex", "in_dex"},
+		{"Bad name 2", "i\nn\ndex", "i_n_dex"},
+		{"Collision 3", "index", "index"},
+		{"Collision 4", "index", "index_6"},
+		{"Good name", "in_dex", "in_dex_7"},
+		{"Collision 5", "index_6", "index_6_8"},
+		{"Bad name with collision", "in\tdex", "in_dex_9"},
+		{"Bad name with collision 2", "in\ndex", "in_dex_10"},
+		{"Bad name with collision 3", "in?dex", "in_dex_11"},
+	}
+	for _, tc := range basicTests {
+		spKeyName := GetSpannerIndexKeyName(tc.srcKeyName, schemaIndexKeys)
+		assert.Equal(t, tc.spKeyName, spKeyName, tc.name)
+	}
+}

--- a/mysql/infoschema.go
+++ b/mysql/infoschema.go
@@ -387,7 +387,7 @@ func getIndexes(conv *internal.Conv, db *sql.DB, table schemaAndName) (indexes [
 		WHERE TABLE_SCHEMA = ?
 			AND TABLE_NAME = ?
 			AND INDEX_NAME != 'PRIMARY' 
-		ORDER BY SEQ_IN_INDEX;`
+		ORDER BY INDEX_NAME, SEQ_IN_INDEX;`
 	rows, err := db.Query(q, table.schema, table.name)
 	if err != nil {
 		return nil, err

--- a/mysql/infoschema_test.go
+++ b/mysql/infoschema_test.go
@@ -97,7 +97,12 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
 			args:  []driver.Value{"test", "cart"},
 			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION", "NON_UNIQUE"},
-			rows:  [][]driver.Value{{"index1", "userid", 1, "A", "0"}, {"index2", "userid", 1, "A", "1"}, {"index2", "productid", 2, "D", "1"}},
+			rows: [][]driver.Value{
+				{"index1", "userid", 1, "A", "0"},
+				{"index2", "userid", 1, "A", "1"},
+				{"index2", "productid", 2, "D", "1"},
+				{"index3", "productid", 1, "A", "0"},
+				{"index3", "userid", 2, "D", "0"}},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"test", "test"},
@@ -167,7 +172,8 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"productid"}, ReferTable: "product", ReferColumns: []string{"product_id"}},
 				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}},
 			Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}}},
-				ddl.CreateIndex{Name: "index2", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: true}}}}},
+				ddl.CreateIndex{Name: "index2", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: true}}},
+				ddl.CreateIndex{Name: "index3", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "productid", Desc: false}, ddl.IndexKey{Col: "userid", Desc: true}}}}},
 		"test": ddl.CreateTable{
 			Name:     "test",
 			ColNames: []string{"id", "s", "txt", "b", "bs", "bl", "c", "c8", "d", "dec", "f8", "f4", "i8", "i4", "i2", "si", "ts", "tz", "vc", "vc6"},

--- a/mysql/infoschema_test.go
+++ b/mysql/infoschema_test.go
@@ -69,7 +69,7 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 		}, {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
 			args:  []driver.Value{"test", "user"},
-			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION"},
+			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION", "NON_UNIQUE"},
 		},
 		{
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
@@ -96,8 +96,8 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 		}, {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
 			args:  []driver.Value{"test", "cart"},
-			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION"},
-			rows:  [][]driver.Value{{"index1", "userid", 1, "A"}, {"index2", "userid", 1, "A"}, {"index2", "productid", 2, "A"}},
+			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION", "NON_UNIQUE"},
+			rows:  [][]driver.Value{{"index1", "userid", 1, "A", "0"}, {"index2", "userid", 1, "A", "1"}, {"index2", "productid", 2, "D", "1"}},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"test", "test"},
@@ -137,7 +137,7 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 		}, {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
 			args:  []driver.Value{"test", "test"},
-			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION"},
+			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION", "NON_UNIQUE"},
 		},
 	}
 	db := mkMockDB(t, ms)
@@ -166,8 +166,8 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "productid"}, ddl.IndexKey{Col: "userid"}},
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"productid"}, ReferTable: "product", ReferColumns: []string{"product_id"}},
 				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}},
-			Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}}},
-				ddl.CreateIndex{Name: "index2", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: false}}}}},
+			Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}}},
+				ddl.CreateIndex{Name: "index2", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: true}}}}},
 		"test": ddl.CreateTable{
 			Name:     "test",
 			ColNames: []string{"id", "s", "txt", "b", "bs", "bl", "c", "c8", "d", "dec", "f8", "f4", "i8", "i4", "i2", "si", "ts", "tz", "vc", "vc6"},
@@ -297,7 +297,7 @@ func TestProcessSQLData_MultiCol(t *testing.T) {
 		}, {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
 			args:  []driver.Value{"test", "test"},
-			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION"},
+			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION", "NON_UNIQUE"},
 		},
 		// Note: go-sqlmock mocks specify an ordered sequence
 		// of queries and results.  This (repeated) entry is

--- a/mysql/infoschema_test.go
+++ b/mysql/infoschema_test.go
@@ -67,6 +67,11 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 				{"address", "addressid", "address_id", "fk_test"},
 			},
 		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
+			args:  []driver.Value{"test", "user"},
+			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION"},
+		},
+		{
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"test", "cart"},
 			cols:  []string{"column_name", "data_type", "column_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale", "extra"},
@@ -88,6 +93,11 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			rows: [][]driver.Value{
 				{"product", "productid", "product_id", "fk_test2"},
 				{"user", "userid", "user_id", "fk_test3"}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
+			args:  []driver.Value{"test", "cart"},
+			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION"},
+			rows:  [][]driver.Value{{"index1", "userid", 1, "A"}, {"index2", "userid", 1, "A"}, {"index2", "productid", 2, "A"}},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"test", "test"},
@@ -124,6 +134,10 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			cols:  []string{"REFERENCED_TABLE_NAME", "COLUMN_NAME", "REFERENCED_COLUMN_NAME", "CONSTRAINT_NAME"},
 			rows: [][]driver.Value{{"test_ref", "id", "ref_id", "fk_test4"},
 				{"test_ref", "txt", "ref_txt", "fk_test4"}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
+			args:  []driver.Value{"test", "test"},
+			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION"},
 		},
 	}
 	db := mkMockDB(t, ms)
@@ -151,7 +165,9 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			},
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "productid"}, ddl.IndexKey{Col: "userid"}},
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"productid"}, ReferTable: "product", ReferColumns: []string{"product_id"}},
-				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}}},
+				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}},
+			Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}}},
+				ddl.CreateIndex{Name: "index2", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: false}}}}},
 		"test": ddl.CreateTable{
 			Name:     "test",
 			ColNames: []string{"id", "s", "txt", "b", "bs", "bl", "c", "c8", "d", "dec", "f8", "f4", "i8", "i4", "i2", "si", "ts", "tz", "vc", "vc6"},
@@ -278,6 +294,10 @@ func TestProcessSQLData_MultiCol(t *testing.T) {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
 			args:  []driver.Value{"test", "test"},
 			cols:  []string{"REFERENCED_TABLE_NAME", "COLUMN_NAME", "REFERENCED_COLUMN_NAME", "CONSTRAINT_NAME"},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.STATISTICS (.+)",
+			args:  []driver.Value{"test", "test"},
+			cols:  []string{"INDEX_NAME", "COLUMN_NAME", "SEQ_IN_INDEX", "COLLATION"},
 		},
 		// Note: go-sqlmock mocks specify an ordered sequence
 		// of queries and results.  This (repeated) entry is

--- a/mysql/mysqldump.go
+++ b/mysql/mysqldump.go
@@ -146,17 +146,6 @@ func processStatement(conv *internal.Conv, stmt ast.StmtNode) bool {
 		if conv.SchemaMode() {
 			processCreateIndex(conv, s)
 		}
-
-		//fmt.Println(s.IndexName)
-
-		//fmt.Println(s.KeyType)
-		// // Index key types.
-		// const (
-		// 	IndexKeyTypeNone IndexKeyType = iota
-		// 	IndexKeyTypeUnique
-		// 	IndexKeyTypeSpatial
-		// 	IndexKeyTypeFullText
-		// )
 	default:
 		conv.SkipStatement(NodeType(stmt))
 	}

--- a/mysql/mysqldump.go
+++ b/mysql/mysqldump.go
@@ -279,6 +279,10 @@ func processConstraint(conv *internal.Conv, table string, constraint *ast.Constr
 
 // toSchemaKeys converts a string list of MySQL primary keys to
 // schema primary keys.
+// This function is also used for converting MySQL index key to
+// schema index keys, mysqldump parser is not able to parse order
+// of the key (i.e, ascending/descending), so we map all keys to
+// ascending.
 func toSchemaKeys(columns []*ast.IndexPartSpecification) (keys []schema.Key) {
 	for _, colname := range columns {
 		// MySQL primary keys have no notation of ascending/descending.

--- a/mysql/mysqldump.go
+++ b/mysql/mysqldump.go
@@ -236,7 +236,7 @@ func processCreateTable(conv *internal.Conv, stmt *ast.CreateTableStmt) {
 		if constraint.fk.Columns != nil {
 			fkeys = append(fkeys, constraint.fk)
 		}
-		if col.Unique {
+		if constraint.isUniqueKey {
 			index = append(index, schema.Index{Name: "", Unique: true, Keys: []schema.Key{schema.Key{Column: colname, Desc: false}}})
 		}
 	}
@@ -364,7 +364,7 @@ func processAlterTable(conv *internal.Conv, stmt *ast.AlterTableStmt) {
 					ctable.ForeignKeys = append(ctable.ForeignKeys, constraint.fk)
 					conv.SrcSchema[tableName] = ctable
 				}
-				if col.Unique {
+				if constraint.isUniqueKey {
 					ctable := conv.SrcSchema[tableName]
 					ctable.Indexes = append(ctable.Indexes, schema.Index{Name: "", Unique: true, Keys: []schema.Key{schema.Key{Column: colname, Desc: false}}})
 					conv.SrcSchema[tableName] = ctable
@@ -421,8 +421,9 @@ func processColumn(conv *internal.Conv, tableName string, col *ast.ColumnDef) (s
 }
 
 type columnConstraint struct {
-	isPk bool
-	fk   schema.ForeignKey
+	isPk        bool
+	isUniqueKey bool
+	fk          schema.ForeignKey
 }
 
 // updateColsByOption is specifially for ColDef constraints.
@@ -453,6 +454,7 @@ func updateColsByOption(conv *internal.Conv, tableName string, col *ast.ColumnDe
 			}
 		case ast.ColumnOptionUniqKey:
 			column.Unique = true
+			cc.isUniqueKey = true
 		case ast.ColumnOptionCheck:
 			column.Ignored.Check = true
 		case ast.ColumnOptionReference:

--- a/mysql/mysqldump_test.go
+++ b/mysql/mysqldump_test.go
@@ -344,7 +344,51 @@ func TestProcessMySQLDump_MultiCol(t *testing.T) {
 						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
 					},
 					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
-					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+		},
+		{
+			name: "Create table with unique index keys",
+			input: "CREATE TABLE test (" +
+				"a smallint DEFAULT NULL," +
+				"b text DEFAULT NULL," +
+				"c text DEFAULT NULL," +
+				"UNIQUE KEY custom_index (b, c)" +
+				");\n",
+			expectedSchema: map[string]ddl.CreateTable{
+				"test": ddl.CreateTable{
+					Name:     "test",
+					ColNames: []string{"a", "b", "c", "synth_id"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"a":        ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+						"b":        ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"c":        ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+		},
+		{
+			name: "Create table with multiple index keys with different order",
+			input: "CREATE TABLE test (" +
+				"a smallint DEFAULT NULL," +
+				"b text DEFAULT NULL," +
+				"c text DEFAULT NULL," +
+				"UNIQUE KEY custom_index (b, c)," +
+				"KEY custom_index2 (c, a)" +
+				");\n",
+			expectedSchema: map[string]ddl.CreateTable{
+				"test": ddl.CreateTable{
+					Name:     "test",
+					ColNames: []string{"a", "b", "c", "synth_id"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"a":        ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+						"b":        ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"c":        ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Pks: []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}},
+						ddl.CreateIndex{Name: "custom_index2", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "c", Desc: false}, ddl.IndexKey{Col: "a", Desc: false}}}}}},
 		},
 		{
 			name: "Alter table add index keys",
@@ -365,7 +409,7 @@ func TestProcessMySQLDump_MultiCol(t *testing.T) {
 						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
 					},
 					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
-					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
 		},
 		{
 			name: "Create index statement",
@@ -386,7 +430,7 @@ func TestProcessMySQLDump_MultiCol(t *testing.T) {
 						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
 					},
 					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
-					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
 		},
 		{
 			name:  "Create table with mysql schema",

--- a/mysql/mysqldump_test.go
+++ b/mysql/mysqldump_test.go
@@ -326,6 +326,69 @@ func TestProcessMySQLDump_MultiCol(t *testing.T) {
 					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"e", "f"}, ReferTable: "test", ReferColumns: []string{"a", "b"}}}}},
 		},
 		{
+			name: "Create table with index keys",
+			input: "CREATE TABLE test (" +
+				"a smallint DEFAULT NULL," +
+				"b text DEFAULT NULL," +
+				"c text DEFAULT NULL," +
+				"KEY custom_index (b, c)" +
+				");\n",
+			expectedSchema: map[string]ddl.CreateTable{
+				"test": ddl.CreateTable{
+					Name:     "test",
+					ColNames: []string{"a", "b", "c", "synth_id"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"a":        ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+						"b":        ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"c":        ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+		},
+		{
+			name: "Alter table add index keys",
+			input: "CREATE TABLE test (" +
+				"a smallint DEFAULT NULL," +
+				"b text DEFAULT NULL," +
+				"c text DEFAULT NULL" +
+				");\n" +
+				"ALTER TABLE test ADD INDEX custom_index (b, c);\n",
+			expectedSchema: map[string]ddl.CreateTable{
+				"test": ddl.CreateTable{
+					Name:     "test",
+					ColNames: []string{"a", "b", "c", "synth_id"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"a":        ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+						"b":        ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"c":        ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+		},
+		{
+			name: "Create index statement",
+			input: "CREATE TABLE test (" +
+				"a smallint DEFAULT NULL," +
+				"b text DEFAULT NULL," +
+				"c text DEFAULT NULL" +
+				");\n" +
+				"CREATE INDEX custom_index ON test (b, c);\n",
+			expectedSchema: map[string]ddl.CreateTable{
+				"test": ddl.CreateTable{
+					Name:     "test",
+					ColNames: []string{"a", "b", "c", "synth_id"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"a":        ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+						"b":        ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"c":        ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+		},
+		{
 			name:  "Create table with mysql schema",
 			input: "CREATE TABLE myschema.test (a text PRIMARY KEY, b text);\n",
 			expectedSchema: map[string]ddl.CreateTable{

--- a/mysql/toddl.go
+++ b/mysql/toddl.go
@@ -258,7 +258,7 @@ func cvtIndexes(conv *internal.Conv, srcTable string, srcIndexes []schema.Index)
 			conv.Unexpected(fmt.Sprintf("Can't map source index name for spanner index name %s", srcIndex.Name))
 			continue
 		}
-		spIndexes = append(spIndexes, ddl.CreateIndex{Name: spKeyName, Keys: spKeys})
+		spIndexes = append(spIndexes, ddl.CreateIndex{Name: spKeyName, Unique: srcIndex.Unique, Keys: spKeys})
 	}
 	return spIndexes
 }

--- a/mysql/toddl_test.go
+++ b/mysql/toddl_test.go
@@ -41,6 +41,7 @@ func TestToSpannerType(t *testing.T) {
 		},
 		PrimaryKeys: []schema.Key{schema.Key{Column: "a"}},
 		ForeignKeys: []schema.ForeignKey{schema.ForeignKey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"b"}}},
+		Indexes:     []schema.Index{schema.Index{Name: "index1", Unique: true, Keys: []schema.Key{schema.Key{Column: "a", Desc: false}, schema.Key{Column: "d", Desc: true}}}},
 	}
 	conv.SrcSchema[name] = srcSchema
 	assert.Nil(t, schemaToDDL(conv))
@@ -57,8 +58,9 @@ func TestToSpannerType(t *testing.T) {
 			"e": ddl.ColumnDef{Name: "e", T: ddl.Type{Name: ddl.Float64}},
 			"f": ddl.ColumnDef{Name: "f", T: ddl.Type{Name: ddl.Timestamp}},
 		},
-		Pks: []ddl.IndexKey{ddl.IndexKey{Col: "a"}},
-		Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"b"}}},
+		Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "a"}},
+		Fks:     []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"b"}}},
+		Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "a", Desc: false}, ddl.IndexKey{Col: "d", Desc: true}}}},
 	}
 	assert.Equal(t, expected, actual)
 	expectedIssues := map[string][]internal.SchemaIssue{

--- a/postgres/infoschema.go
+++ b/postgres/infoschema.go
@@ -422,35 +422,35 @@ func getForeignKeys(conv *internal.Conv, db *sql.DB, table schemaAndName) (forei
 
 // getIndexes return list of all the indexes.
 func getIndexes(conv *internal.Conv, db *sql.DB, table schemaAndName) (indexes []schema.Index, err error) {
-	q := `SELECT     
-           irel.relname AS index_name,
-           a.attname AS column_name,
-           1 + Array_position(i.indkey, a.attnum) AS column_position,
- 		   i.indisunique AS is_unique,
-           CASE o.OPTION & 1 WHEN 1 THEN 'DESC' ELSE 'ASC' END AS order
-	FROM pg_index AS i
-	JOIN pg_class AS trel
-	ON trel.oid = i.indrelid
-	JOIN pg_namespace AS tnsp
-	ON trel.relnamespace = tnsp.oid
-	JOIN pg_class AS irel
-	ON irel.oid = i.indexrelid
-	CROSS JOIN LATERAL UNNEST (i.indkey) WITH ordinality AS c (colnum, ordinality)
-	LEFT JOIN LATERAL UNNEST (i.indoption) WITH ordinality AS o (OPTION, ordinality)
-	ON c.ordinality = o.ordinality
-	JOIN pg_attribute AS a
-	ON trel.oid = a.attrelid
-	AND a.attnum = c.colnum
-	WHERE tnsp.nspname= $1
-	AND trel.relname= $2
-	AND i.indisprimary = false
-	GROUP BY tnsp.nspname,
-           trel.relname,
-           irel.relname,
-           a.attname,
-           array_position(i.indkey, a.attnum),
-           o.OPTION,i.indisunique
-	ORDER BY irel.relname, array_position(i.indkey, a.attnum);`
+	q := `SELECT
+			irel.relname AS index_name,
+			a.attname AS column_name,
+			1 + Array_position(i.indkey, a.attnum) AS column_position,
+			i.indisunique AS is_unique,
+			CASE o.OPTION & 1 WHEN 1 THEN 'DESC' ELSE 'ASC' END AS order
+		FROM pg_index AS i
+		JOIN pg_class AS trel
+		ON trel.oid = i.indrelid
+		JOIN pg_namespace AS tnsp
+		ON trel.relnamespace = tnsp.oid
+		JOIN pg_class AS irel
+		ON irel.oid = i.indexrelid
+		CROSS JOIN LATERAL UNNEST (i.indkey) WITH ordinality AS c (colnum, ordinality)
+		LEFT JOIN LATERAL UNNEST (i.indoption) WITH ordinality AS o (OPTION, ordinality)
+		ON c.ordinality = o.ordinality
+		JOIN pg_attribute AS a
+		ON trel.oid = a.attrelid
+			AND a.attnum = c.colnum
+		WHERE tnsp.nspname= $1
+			AND trel.relname= $2
+			AND i.indisprimary = false
+		GROUP BY tnsp.nspname,
+           		trel.relname,
+           		irel.relname,
+           		a.attname,
+           		array_position(i.indkey, a.attnum),
+           		o.OPTION,i.indisunique
+		ORDER BY irel.relname, array_position(i.indkey, a.attnum);`
 	rows, err := db.Query(q, table.schema, table.name)
 	if err != nil {
 		return nil, err

--- a/postgres/infoschema.go
+++ b/postgres/infoschema.go
@@ -459,11 +459,15 @@ func getIndexes(conv *internal.Conv, db *sql.DB, table schemaAndName) (indexes [
 	var name, col, seq, isUnique, collation string
 	m := make(map[string][]schema.Key)
 	unique := make(map[string]bool)
+	var keyNames []string
 	for rows.Next() {
 		err := rows.Scan(&name, &col, &seq, &isUnique, &collation)
 		if err != nil {
 			conv.Unexpected(fmt.Sprintf("Can't scan: %v", err))
 			continue
+		}
+		if _, found := m[name]; !found {
+			keyNames = append(keyNames, name)
 		}
 		isDesc := false
 		if collation == "DESC" {
@@ -474,8 +478,9 @@ func getIndexes(conv *internal.Conv, db *sql.DB, table schemaAndName) (indexes [
 		}
 		m[name] = append(m[name], schema.Key{Column: col, Desc: isDesc})
 	}
-	for k, v := range m {
-		indexes = append(indexes, schema.Index{Name: k, Unique: unique[k], Keys: v})
+	sort.Strings(keyNames)
+	for _, k := range keyNames {
+		indexes = append(indexes, schema.Index{Name: k, Unique: unique[k], Keys: m[k]})
 	}
 	return indexes, nil
 }

--- a/postgres/infoschema.go
+++ b/postgres/infoschema.go
@@ -454,7 +454,7 @@ GROUP BY   tnsp.nspname,
            a.attname,
            array_position(i.indkey, a.attnum),
            o.OPTION,i.indisunique
-ORDER BY array_position(i.indkey, a.attnum);`
+ORDER BY  irel.relname, array_position(i.indkey, a.attnum);`
 	rows, err := db.Query(q, table.schema, table.name)
 	if err != nil {
 		return nil, err

--- a/postgres/infoschema.go
+++ b/postgres/infoschema.go
@@ -420,41 +420,37 @@ func getForeignKeys(conv *internal.Conv, db *sql.DB, table schemaAndName) (forei
 	return foreignKeys, nil
 }
 
-// getIndexes return list all the indexes.
+// getIndexes return list of all the indexes.
 func getIndexes(conv *internal.Conv, db *sql.DB, table schemaAndName) (indexes []schema.Index, err error) {
 	q := `SELECT     
-           irel.relname                           AS index_name,
-           a.attname                              AS column_name,
+           irel.relname AS index_name,
+           a.attname AS column_name,
            1 + Array_position(i.indkey, a.attnum) AS column_position,
- 			i.indisunique AS is_unique,
-           CASE o.OPTION
-                                 & 1
-                      WHEN 1 THEN 'DESC'
-                      ELSE 'ASC'
-           END      AS order
-FROM       pg_index AS i
-join       pg_class AS trel
-ON         trel.oid = i.indrelid
-join       pg_namespace AS tnsp
-ON         trel.relnamespace = tnsp.oid
-join       pg_class AS irel
-ON         irel.oid = i.indexrelid
-cross join lateral unnest (i.indkey) WITH ordinality    AS c (colnum, ordinality)
-left join  lateral unnest (i.indoption) WITH ordinality AS o (OPTION, ordinality)
-ON         c.ordinality = o.ordinality
-join       pg_attribute AS a
-ON         trel.oid = a.attrelid
-AND        a.attnum = c.colnum
-WHERE      tnsp.nspname= $1
-AND        trel.relname= $2
-AND        i.indisprimary = false
-GROUP BY   tnsp.nspname,
+ 		   i.indisunique AS is_unique,
+           CASE o.OPTION & 1 WHEN 1 THEN 'DESC' ELSE 'ASC' END AS order
+	FROM pg_index AS i
+	JOIN pg_class AS trel
+	ON trel.oid = i.indrelid
+	JOIN pg_namespace AS tnsp
+	ON trel.relnamespace = tnsp.oid
+	JOIN pg_class AS irel
+	ON irel.oid = i.indexrelid
+	CROSS JOIN LATERAL UNNEST (i.indkey) WITH ordinality AS c (colnum, ordinality)
+	LEFT JOIN LATERAL UNNEST (i.indoption) WITH ordinality AS o (OPTION, ordinality)
+	ON c.ordinality = o.ordinality
+	JOIN pg_attribute AS a
+	ON trel.oid = a.attrelid
+	AND a.attnum = c.colnum
+	WHERE tnsp.nspname= $1
+	AND trel.relname= $2
+	AND i.indisprimary = false
+	GROUP BY tnsp.nspname,
            trel.relname,
            irel.relname,
            a.attname,
            array_position(i.indkey, a.attnum),
            o.OPTION,i.indisunique
-ORDER BY  irel.relname, array_position(i.indkey, a.attnum);`
+	ORDER BY irel.relname, array_position(i.indkey, a.attnum);`
 	rows, err := db.Query(q, table.schema, table.name)
 	if err != nil {
 		return nil, err

--- a/postgres/infoschema_test.go
+++ b/postgres/infoschema_test.go
@@ -98,7 +98,12 @@ func TestProcessInfoSchema(t *testing.T) {
 			query: "SELECT (.+) FROM pg_index (.+)",
 			args:  []driver.Value{"public", "cart"},
 			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
-			rows:  [][]driver.Value{{"index1", "userid", 1, "f", "ASC"}, {"index2", "userid", 1, "t", "ASC"}, {"index2", "productid", 2, "t", "DESC"}},
+			rows: [][]driver.Value{{"index1", "userid", 1, "f", "ASC"},
+				{"index2", "userid", 1, "t", "ASC"},
+				{"index2", "productid", 2, "t", "DESC"},
+				{"index3", "productid", 1, "t", "DESC"},
+				{"index3", "userid", 2, "t", "ASC"},
+			},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"public", "test"},
@@ -169,7 +174,8 @@ func TestProcessInfoSchema(t *testing.T) {
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"productid"}, ReferTable: "product", ReferColumns: []string{"product_id"}},
 				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}},
 			Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}}},
-				ddl.CreateIndex{Name: "index2", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: true}}}},
+				ddl.CreateIndex{Name: "index2", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: true}}},
+				ddl.CreateIndex{Name: "index3", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "productid", Desc: true}, ddl.IndexKey{Col: "userid", Desc: false}}}},
 		},
 		"test": ddl.CreateTable{
 			Name:     "test",

--- a/postgres/infoschema_test.go
+++ b/postgres/infoschema_test.go
@@ -67,6 +67,10 @@ func TestProcessInfoSchema(t *testing.T) {
 			rows: [][]driver.Value{
 				{"public", "address", "addressid", "address_id", "fk_test"},
 			},
+		}, {
+			query: "SELECT (.+) JOIN pg_catalog.pg_index (.+)",
+			args:  []driver.Value{"public", "user"},
+			cols:  []string{"index_name", "column_name", "column_position"},
 		},
 		{
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
@@ -90,6 +94,11 @@ func TestProcessInfoSchema(t *testing.T) {
 			rows: [][]driver.Value{
 				{"public", "product", "productid", "product_id", "fk_test2"},
 				{"public", "user", "userid", "user_id", "fk_test3"}},
+		}, {
+			query: "SELECT (.+) JOIN pg_catalog.pg_index (.+)",
+			args:  []driver.Value{"public", "cart"},
+			cols:  []string{"index_name", "column_name", "column_position"},
+			rows:  [][]driver.Value{{"index1", "userid", 1}, {"index2", "userid", 1}, {"index2", "productid", 2}},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"public", "test"},
@@ -127,6 +136,10 @@ func TestProcessInfoSchema(t *testing.T) {
 			cols:  []string{"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "REF_COLUMN_NAME", "CONSTRAINT_NAME"},
 			rows: [][]driver.Value{{"public", "test_ref", "id", "ref_id", "fk_test4"},
 				{"public", "test_ref", "bs", "ref_bs", "fk_test4"}},
+		}, {
+			query: "SELECT (.+) JOIN pg_catalog.pg_index (.+)",
+			args:  []driver.Value{"public", "test"},
+			cols:  []string{"index_name", "column_name", "column_position"},
 		},
 	}
 	db := mkMockDB(t, ms)
@@ -154,7 +167,10 @@ func TestProcessInfoSchema(t *testing.T) {
 			},
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "productid"}, ddl.IndexKey{Col: "userid"}},
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"productid"}, ReferTable: "product", ReferColumns: []string{"product_id"}},
-				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}}},
+				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}},
+			Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}}},
+				ddl.CreateIndex{Name: "index2", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: false}}}},
+		},
 		"test": ddl.CreateTable{
 			Name:     "test",
 			ColNames: []string{"id", "aint", "atext", "b", "bs", "by", "c", "c8", "d", "f8", "f4", "i8", "i4", "i2", "num", "s", "ts", "tz", "txt", "vc", "vc6"},
@@ -357,6 +373,11 @@ func TestConvertSqlRow_MultiCol(t *testing.T) {
 			query: "SELECT (.+) FROM PG_CLASS (.+) JOIN PG_NAMESPACE (.+) JOIN PG_CONSTRAINT (.+)",
 			args:  []driver.Value{"public", "test"},
 			cols:  []string{"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "REF_COLUMN_NAME", "CONSTRAINT_NAME"},
+		},
+		{
+			query: "SELECT (.+) JOIN pg_catalog.pg_index (.+)",
+			args:  []driver.Value{"public", "test"},
+			cols:  []string{"index_name", "column_name", "column_position"},
 		},
 		// Note: go-sqlmock mocks specify an ordered sequence
 		// of queries and results.  This (repeated) entry is

--- a/postgres/infoschema_test.go
+++ b/postgres/infoschema_test.go
@@ -68,7 +68,7 @@ func TestProcessInfoSchema(t *testing.T) {
 				{"public", "address", "addressid", "address_id", "fk_test"},
 			},
 		}, {
-			query: "SELECT (.+) FROM       pg_index (.+)",
+			query: "SELECT (.+) FROM pg_index (.+)",
 			args:  []driver.Value{"public", "user"},
 			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
 		},
@@ -95,7 +95,7 @@ func TestProcessInfoSchema(t *testing.T) {
 				{"public", "product", "productid", "product_id", "fk_test2"},
 				{"public", "user", "userid", "user_id", "fk_test3"}},
 		}, {
-			query: "SELECT (.+) FROM       pg_index (.+)",
+			query: "SELECT (.+) FROM pg_index (.+)",
 			args:  []driver.Value{"public", "cart"},
 			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
 			rows:  [][]driver.Value{{"index1", "userid", 1, "f", "ASC"}, {"index2", "userid", 1, "t", "ASC"}, {"index2", "productid", 2, "t", "DESC"}},
@@ -137,7 +137,7 @@ func TestProcessInfoSchema(t *testing.T) {
 			rows: [][]driver.Value{{"public", "test_ref", "id", "ref_id", "fk_test4"},
 				{"public", "test_ref", "bs", "ref_bs", "fk_test4"}},
 		}, {
-			query: "SELECT (.+) FROM       pg_index (.+)",
+			query: "SELECT (.+) FROM pg_index (.+)",
 			args:  []driver.Value{"public", "test"},
 			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
 		},
@@ -375,7 +375,7 @@ func TestConvertSqlRow_MultiCol(t *testing.T) {
 			cols:  []string{"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "REF_COLUMN_NAME", "CONSTRAINT_NAME"},
 		},
 		{
-			query: "SELECT (.+) FROM       pg_index (.+)",
+			query: "SELECT (.+) FROM pg_index (.+)",
 			args:  []driver.Value{"public", "test"},
 			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
 		},

--- a/postgres/infoschema_test.go
+++ b/postgres/infoschema_test.go
@@ -68,9 +68,9 @@ func TestProcessInfoSchema(t *testing.T) {
 				{"public", "address", "addressid", "address_id", "fk_test"},
 			},
 		}, {
-			query: "SELECT (.+) JOIN pg_catalog.pg_index (.+)",
+			query: "SELECT (.+) FROM       pg_index (.+)",
 			args:  []driver.Value{"public", "user"},
-			cols:  []string{"index_name", "column_name", "column_position"},
+			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
 		},
 		{
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
@@ -95,10 +95,10 @@ func TestProcessInfoSchema(t *testing.T) {
 				{"public", "product", "productid", "product_id", "fk_test2"},
 				{"public", "user", "userid", "user_id", "fk_test3"}},
 		}, {
-			query: "SELECT (.+) JOIN pg_catalog.pg_index (.+)",
+			query: "SELECT (.+) FROM       pg_index (.+)",
 			args:  []driver.Value{"public", "cart"},
-			cols:  []string{"index_name", "column_name", "column_position"},
-			rows:  [][]driver.Value{{"index1", "userid", 1}, {"index2", "userid", 1}, {"index2", "productid", 2}},
+			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
+			rows:  [][]driver.Value{{"index1", "userid", 1, "f", "ASC"}, {"index2", "userid", 1, "t", "ASC"}, {"index2", "productid", 2, "t", "DESC"}},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"public", "test"},
@@ -137,9 +137,9 @@ func TestProcessInfoSchema(t *testing.T) {
 			rows: [][]driver.Value{{"public", "test_ref", "id", "ref_id", "fk_test4"},
 				{"public", "test_ref", "bs", "ref_bs", "fk_test4"}},
 		}, {
-			query: "SELECT (.+) JOIN pg_catalog.pg_index (.+)",
+			query: "SELECT (.+) FROM       pg_index (.+)",
 			args:  []driver.Value{"public", "test"},
-			cols:  []string{"index_name", "column_name", "column_position"},
+			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
 		},
 	}
 	db := mkMockDB(t, ms)
@@ -168,8 +168,8 @@ func TestProcessInfoSchema(t *testing.T) {
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "productid"}, ddl.IndexKey{Col: "userid"}},
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"productid"}, ReferTable: "product", ReferColumns: []string{"product_id"}},
 				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}},
-			Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}}},
-				ddl.CreateIndex{Name: "index2", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: false}}}},
+			Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Unique: false, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}}},
+				ddl.CreateIndex{Name: "index2", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "userid", Desc: false}, ddl.IndexKey{Col: "productid", Desc: true}}}},
 		},
 		"test": ddl.CreateTable{
 			Name:     "test",
@@ -375,9 +375,9 @@ func TestConvertSqlRow_MultiCol(t *testing.T) {
 			cols:  []string{"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "REF_COLUMN_NAME", "CONSTRAINT_NAME"},
 		},
 		{
-			query: "SELECT (.+) JOIN pg_catalog.pg_index (.+)",
+			query: "SELECT (.+) FROM       pg_index (.+)",
 			args:  []driver.Value{"public", "test"},
-			cols:  []string{"index_name", "column_name", "column_position"},
+			cols:  []string{"index_name", "column_name", "column_position", "is_unique", "order"},
 		},
 		// Note: go-sqlmock mocks specify an ordered sequence
 		// of queries and results.  This (repeated) entry is

--- a/postgres/pgdump.go
+++ b/postgres/pgdump.go
@@ -220,7 +220,7 @@ func processIndexStmt(conv *internal.Conv, n nodes.IndexStmt) {
 		for _, ip := range n.IndexParams.Items {
 			cols = append(cols, *ip.(nodes.IndexElem).Name)
 		}
-		ctable.Indexes = append(ctable.Indexes, schema.Index{Name: *n.Idxname, Keys: toIndexKeys(conv, tableName, n.IndexParams.Items)})
+		ctable.Indexes = append(ctable.Indexes, schema.Index{Name: *n.Idxname, Unique: *&n.Unique, Keys: toIndexKeys(conv, tableName, n.IndexParams.Items)})
 		conv.SrcSchema[tableName] = ctable
 	} else {
 		conv.SkipStatement(prNodes([]nodes.Node{n}))
@@ -619,6 +619,10 @@ func updateSchema(conv *internal.Conv, table string, cs []constraint, stmtType s
 		case nodes.CONSTR_FOREIGN:
 			ct := conv.SrcSchema[table]
 			ct.ForeignKeys = append(ct.ForeignKeys, toForeignKeys(c)) // Append to previous foreign keys.
+			conv.SrcSchema[table] = ct
+		case nodes.CONSTR_UNIQUE:
+			ct := conv.SrcSchema[table]
+			ct.Indexes = append(ct.Indexes, schema.Index{Name: "", Unique: true, Keys: toSchemaKeys(conv, table, c.cols)})
 			conv.SrcSchema[table] = ct
 		default:
 			ct := conv.SrcSchema[table]

--- a/postgres/pgdump_test.go
+++ b/postgres/pgdump_test.go
@@ -294,6 +294,48 @@ func TestProcessPgDump(t *testing.T) {
 					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
 		},
 		{
+			name: "Create index statement with order",
+			input: "CREATE TABLE test (" +
+				"a smallint," +
+				"b text," +
+				"c text" +
+				");\n" +
+				"CREATE INDEX custom_index ON test (b DESC, c ASC);\n",
+			expectedSchema: map[string]ddl.CreateTable{
+				"test": ddl.CreateTable{
+					Name:     "test",
+					ColNames: []string{"a", "b", "c", "synth_id"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"a":        ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+						"b":        ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"c":        ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: true}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+		},
+		{
+			name: "Create index statement with different sequence order",
+			input: "CREATE TABLE test (" +
+				"a smallint," +
+				"b text," +
+				"c text" +
+				");\n" +
+				"CREATE INDEX custom_index ON test (c DESC, b ASC);\n",
+			expectedSchema: map[string]ddl.CreateTable{
+				"test": ddl.CreateTable{
+					Name:     "test",
+					ColNames: []string{"a", "b", "c", "synth_id"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"a":        ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+						"b":        ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"c":        ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "c", Desc: true}, ddl.IndexKey{Col: "b", Desc: false}}}}}},
+		},
+		{
 			name:  "Create table with pg schema",
 			input: "CREATE TABLE myschema.test (a text PRIMARY KEY, b text);\n",
 			expectedSchema: map[string]ddl.CreateTable{

--- a/postgres/pgdump_test.go
+++ b/postgres/pgdump_test.go
@@ -273,6 +273,27 @@ func TestProcessPgDump(t *testing.T) {
 						ddl.Foreignkey{Name: "fk_test2", Columns: []string{"f"}, ReferTable: "test2", ReferColumns: []string{"c"}}}}},
 		},
 		{
+			name: "Create index statement",
+			input: "CREATE TABLE test (" +
+				"a smallint," +
+				"b text," +
+				"c text" +
+				");\n" +
+				"CREATE INDEX custom_index ON test (b, c);\n",
+			expectedSchema: map[string]ddl.CreateTable{
+				"test": ddl.CreateTable{
+					Name:     "test",
+					ColNames: []string{"a", "b", "c", "synth_id"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"a":        ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+						"b":        ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"c":        ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+						"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}},
+					Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "custom_index", Keys: []ddl.IndexKey{ddl.IndexKey{Col: "b", Desc: false}, ddl.IndexKey{Col: "c", Desc: false}}}}}},
+		},
+		{
 			name:  "Create table with pg schema",
 			input: "CREATE TABLE myschema.test (a text PRIMARY KEY, b text);\n",
 			expectedSchema: map[string]ddl.CreateTable{

--- a/postgres/toddl.go
+++ b/postgres/toddl.go
@@ -30,6 +30,8 @@ import (
 // the Spanner schema to conv.SpSchema.
 func schemaToDDL(conv *internal.Conv) error {
 	schemaForeignKeys := make(map[string]bool)
+	schemaIndexKeys := make(map[string]bool)
+
 	for _, srcTable := range conv.SrcSchema {
 		spTableName, err := internal.GetSpannerTable(conv, srcTable.Name)
 		if err != nil {
@@ -78,7 +80,7 @@ func schemaToDDL(conv *internal.Conv) error {
 			ColDefs:  spColDef,
 			Pks:      cvtPrimaryKeys(conv, srcTable.Name, srcTable.PrimaryKeys),
 			Fks:      cvtForeignKeys(conv, srcTable.Name, srcTable.ForeignKeys, schemaForeignKeys),
-			Indexes:  cvtIndexes(conv, srcTable.Name, srcTable.Indexes),
+			Indexes:  cvtIndexes(conv, srcTable.Name, srcTable.Indexes, schemaIndexKeys),
 			Comment:  comment}
 	}
 	return nil
@@ -219,7 +221,7 @@ func cvtForeignKeys(conv *internal.Conv, srcTable string, srcKeys []schema.Forei
 	return spKeys
 }
 
-func cvtIndexes(conv *internal.Conv, srcTable string, srcIndexes []schema.Index) []ddl.CreateIndex {
+func cvtIndexes(conv *internal.Conv, srcTable string, srcIndexes []schema.Index, schemaIndexKeys map[string]bool) []ddl.CreateIndex {
 	var spIndexes []ddl.CreateIndex
 	for _, srcIndex := range srcIndexes {
 		var spKeys []ddl.IndexKey
@@ -240,11 +242,7 @@ func cvtIndexes(conv *internal.Conv, srcTable string, srcIndexes []schema.Index)
 			}
 			srcIndex.Name = fmt.Sprintf("Index_%s_%x-%x", srcTable, b[0:2], b[2:4])
 		}
-		spKeyName, err := internal.GetSpannerIndexKeyName(conv, srcIndex.Name, spIndexes)
-		if err != nil {
-			conv.Unexpected(fmt.Sprintf("Can't map source index name for spanner index name %s", srcIndex.Name))
-			continue
-		}
+		spKeyName := internal.GetSpannerIndexKeyName(srcIndex.Name, schemaIndexKeys)
 		spIndexes = append(spIndexes, ddl.CreateIndex{Name: spKeyName, Unique: srcIndex.Unique, Keys: spKeys})
 	}
 	return spIndexes

--- a/postgres/toddl.go
+++ b/postgres/toddl.go
@@ -15,6 +15,7 @@
 package postgres
 
 import (
+	"crypto/rand"
 	"fmt"
 	"strconv"
 	"unicode"
@@ -77,6 +78,7 @@ func schemaToDDL(conv *internal.Conv) error {
 			ColDefs:  spColDef,
 			Pks:      cvtPrimaryKeys(conv, srcTable.Name, srcTable.PrimaryKeys),
 			Fks:      cvtForeignKeys(conv, srcTable.Name, srcTable.ForeignKeys, schemaForeignKeys),
+			Indexes:  cvtIndexes(conv, srcTable.Name, srcTable.Indexes),
 			Comment:  comment}
 	}
 	return nil
@@ -215,4 +217,35 @@ func cvtForeignKeys(conv *internal.Conv, srcTable string, srcKeys []schema.Forei
 		spKeys = append(spKeys, spKey)
 	}
 	return spKeys
+}
+
+func cvtIndexes(conv *internal.Conv, srcTable string, srcIndexes []schema.Index) []ddl.CreateIndex {
+	var spIndexes []ddl.CreateIndex
+	for _, srcIndex := range srcIndexes {
+		var spKeys []ddl.IndexKey
+		for _, k := range srcIndex.Keys {
+			spCol, err := internal.GetSpannerCol(conv, srcTable, k.Column, true)
+			if err != nil {
+				conv.Unexpected(fmt.Sprintf("Can't map index for table %s", srcTable))
+				continue
+			}
+			spKeys = append(spKeys, ddl.IndexKey{Col: spCol, Desc: k.Desc})
+		}
+		if srcIndex.Name == "" {
+			b := make([]byte, 4)
+			_, err := rand.Read(b)
+			if err != nil {
+				conv.Unexpected(fmt.Sprintf("Can't map index for table %s", srcTable))
+				continue
+			}
+			srcIndex.Name = fmt.Sprintf("Index_%s_%x-%x", srcTable, b[0:2], b[2:4])
+		}
+		spKeyName, err := internal.GetSpannerIndexKeyName(conv, srcIndex.Name, spIndexes)
+		if err != nil {
+			conv.Unexpected(fmt.Sprintf("Can't map source index name for spanner index name %s", srcIndex.Name))
+			continue
+		}
+		spIndexes = append(spIndexes, ddl.CreateIndex{Name: spKeyName, Keys: spKeys})
+	}
+	return spIndexes
 }

--- a/postgres/toddl.go
+++ b/postgres/toddl.go
@@ -245,7 +245,7 @@ func cvtIndexes(conv *internal.Conv, srcTable string, srcIndexes []schema.Index)
 			conv.Unexpected(fmt.Sprintf("Can't map source index name for spanner index name %s", srcIndex.Name))
 			continue
 		}
-		spIndexes = append(spIndexes, ddl.CreateIndex{Name: spKeyName, Keys: spKeys})
+		spIndexes = append(spIndexes, ddl.CreateIndex{Name: spKeyName, Unique: srcIndex.Unique, Keys: spKeys})
 	}
 	return spIndexes
 }

--- a/postgres/toddl_test.go
+++ b/postgres/toddl_test.go
@@ -43,6 +43,7 @@ func TestToSpannerType(t *testing.T) {
 		},
 		PrimaryKeys: []schema.Key{schema.Key{Column: "a"}},
 		ForeignKeys: []schema.ForeignKey{schema.ForeignKey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"b"}}},
+		Indexes:     []schema.Index{schema.Index{Name: "index1", Unique: true, Keys: []schema.Key{schema.Key{Column: "a", Desc: false}, schema.Key{Column: "d", Desc: true}}}},
 	}
 	conv.SrcSchema[name] = srcSchema
 	assert.Nil(t, schemaToDDL(conv))
@@ -59,8 +60,9 @@ func TestToSpannerType(t *testing.T) {
 			"e": ddl.ColumnDef{Name: "e", T: ddl.Type{Name: ddl.Float64}},
 			"f": ddl.ColumnDef{Name: "f", T: ddl.Type{Name: ddl.Timestamp}},
 		},
-		Pks: []ddl.IndexKey{ddl.IndexKey{Col: "a"}},
-		Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"b"}}},
+		Pks:     []ddl.IndexKey{ddl.IndexKey{Col: "a"}},
+		Fks:     []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"b"}}},
+		Indexes: []ddl.CreateIndex{ddl.CreateIndex{Name: "index1", Unique: true, Keys: []ddl.IndexKey{ddl.IndexKey{Col: "a", Desc: false}, ddl.IndexKey{Col: "d", Desc: true}}}},
 	}
 	assert.Equal(t, expected, actual)
 	expectedIssues := map[string][]internal.SchemaIssue{

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -74,8 +74,9 @@ type Key struct {
 
 // Index represents a database index.
 type Index struct {
-	Name string
-	Keys []Key
+	Name   string
+	Unique bool
+	Keys   []Key
 }
 
 // Type represents the type of a column.

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -212,7 +212,8 @@ type CreateIndex struct {
 	/* Since CreateIndex is part of CreateTable,
 	storing Table name is not required */
 	// Table string
-	Keys []IndexKey
+	Unique bool
+	Keys   []IndexKey
 	// We have no requirements for unique and null-filtered options and
 	// storing/interleaving clauses yet, so we omit them for now.
 }
@@ -223,7 +224,11 @@ func (ci CreateIndex) PrintCreateIndex(Table string, c Config) string {
 	for _, p := range ci.Keys {
 		keys = append(keys, p.PrintIndexKey(c))
 	}
-	return fmt.Sprintf("CREATE INDEX %s ON %s (%s)", c.quote(ci.Name), c.quote(Table), strings.Join(keys, ", "))
+	var unique string
+	if ci.Unique == true {
+		unique = "UNIQUE"
+	}
+	return fmt.Sprintf("CREATE %s INDEX %s ON %s (%s)", unique, c.quote(ci.Name), c.quote(Table), strings.Join(keys, ", "))
 }
 
 // PrintForeignKeyAlterTable unparses the foreign keys using ALTER TABLE.

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -209,7 +209,7 @@ func (ct CreateTable) PrintCreateTable(config Config) string {
 //     create index: CREATE [UNIQUE] [NULL_FILTERED] INDEX index_name ON table_name ( key_part [, ...] ) [ storing_clause ] [ , interleave_clause ]
 type CreateIndex struct {
 	Name string
-	/* Since CreateIndex is part of CreateTable,
+	/* Since CreateIndex is printed along with CreateTable,
 	storing Table name is not required */
 	// Table string
 	Unique bool

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -167,6 +167,7 @@ type CreateTable struct {
 	ColDefs  map[string]ColumnDef // Provides definition of columns (a map for simpler/faster lookup during type processing)
 	Pks      []IndexKey
 	Fks      []Foreignkey
+	Indexes  []CreateIndex
 	Comment  string
 }
 
@@ -207,20 +208,22 @@ func (ct CreateTable) PrintCreateTable(config Config) string {
 // CreateIndex encodes the following DDL definition:
 //     create index: CREATE [UNIQUE] [NULL_FILTERED] INDEX index_name ON table_name ( key_part [, ...] ) [ storing_clause ] [ , interleave_clause ]
 type CreateIndex struct {
-	Name  string
-	Table string
-	Keys  []IndexKey
+	Name string
+	/* Since CreateIndex is part of CreateTable,
+	storing Table name is not required */
+	// Table string
+	Keys []IndexKey
 	// We have no requirements for unique and null-filtered options and
 	// storing/interleaving clauses yet, so we omit them for now.
 }
 
 // PrintCreateIndex unparses a CREATE INDEX statement.
-func (ci CreateIndex) PrintCreateIndex(c Config) string {
+func (ci CreateIndex) PrintCreateIndex(Table string, c Config) string {
 	var keys []string
 	for _, p := range ci.Keys {
 		keys = append(keys, p.PrintIndexKey(c))
 	}
-	return fmt.Sprintf("CREATE INDEX %s ON %s (%s)", c.quote(ci.Name), c.quote(ci.Table), strings.Join(keys, ", "))
+	return fmt.Sprintf("CREATE INDEX %s ON %s (%s)", c.quote(ci.Name), c.quote(Table), strings.Join(keys, ", "))
 }
 
 // PrintForeignKeyAlterTable unparses the foreign keys using ALTER TABLE.

--- a/spanner/ddl/ast_test.go
+++ b/spanner/ddl/ast_test.go
@@ -85,6 +85,7 @@ func TestPrintCreateTable(t *testing.T) {
 		cds,
 		[]IndexKey{IndexKey{Col: "col1", Desc: true}},
 		nil,
+		nil,
 		"",
 	}
 	tests := []struct {
@@ -103,19 +104,19 @@ func TestPrintCreateTable(t *testing.T) {
 func TestPrintCreateIndex(t *testing.T) {
 	ci := CreateIndex{
 		"myindex",
-		"mytable",
 		[]IndexKey{IndexKey{Col: "col1", Desc: true}, IndexKey{Col: "col2"}},
 	}
 	tests := []struct {
 		name       string
+		table      string
 		protectIds bool
 		expected   string
 	}{
-		{"no quote", false, "CREATE INDEX myindex ON mytable (col1 DESC, col2)"},
-		{"quote", true, "CREATE INDEX `myindex` ON `mytable` (`col1` DESC, `col2`)"},
+		{"no quote", "mytable", false, "CREATE INDEX myindex ON mytable (col1 DESC, col2)"},
+		{"quote", "mytable", true, "CREATE INDEX `myindex` ON `mytable` (`col1` DESC, `col2`)"},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, normalizeSpace(tc.expected), normalizeSpace(ci.PrintCreateIndex(Config{ProtectIds: tc.protectIds})))
+		assert.Equal(t, normalizeSpace(tc.expected), normalizeSpace(ci.PrintCreateIndex(tc.table, Config{ProtectIds: tc.protectIds})))
 	}
 }
 

--- a/spanner/ddl/ast_test.go
+++ b/spanner/ddl/ast_test.go
@@ -102,21 +102,30 @@ func TestPrintCreateTable(t *testing.T) {
 }
 
 func TestPrintCreateIndex(t *testing.T) {
-	ci := CreateIndex{
-		"myindex",
-		[]IndexKey{IndexKey{Col: "col1", Desc: true}, IndexKey{Col: "col2"}},
-	}
+	ci := []CreateIndex{
+		CreateIndex{
+			"myindex",
+			false,
+			[]IndexKey{IndexKey{Col: "col1", Desc: true}, IndexKey{Col: "col2"}},
+		},
+		CreateIndex{
+			"myindex2",
+			true,
+			[]IndexKey{IndexKey{Col: "col1", Desc: true}, IndexKey{Col: "col2"}},
+		}}
 	tests := []struct {
 		name       string
 		table      string
 		protectIds bool
 		expected   string
+		index      CreateIndex
 	}{
-		{"no quote", "mytable", false, "CREATE INDEX myindex ON mytable (col1 DESC, col2)"},
-		{"quote", "mytable", true, "CREATE INDEX `myindex` ON `mytable` (`col1` DESC, `col2`)"},
+		{"no quote non unique", "mytable", false, "CREATE INDEX myindex ON mytable (col1 DESC, col2)", ci[0]},
+		{"quote non unique", "mytable", true, "CREATE INDEX `myindex` ON `mytable` (`col1` DESC, `col2`)", ci[0]},
+		{"unique key", "mytable", true, "CREATE UNIQUE INDEX `myindex2` ON `mytable` (`col1` DESC, `col2`)", ci[1]},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, normalizeSpace(tc.expected), normalizeSpace(ci.PrintCreateIndex(tc.table, Config{ProtectIds: tc.protectIds})))
+		assert.Equal(t, normalizeSpace(tc.expected), normalizeSpace(tc.index.PrintCreateIndex(tc.table, Config{ProtectIds: tc.protectIds})))
 	}
 }
 


### PR DESCRIPTION
> This PR is for the new feature: Index keys, changes included in this PR:
> *`internal/convert.go` - print indexes along with create table.
> *`internal/mapping.go` - added GetSpannerIndexKeyName to convert source key name to spanner key name avoiding collision.  
> * `mysql/infoschema.go` - support for index key getIndexes function
> * `mysql/mysqldump.go` - support for index key, we process CREATE INDEX statements, along with indexes mentioned in CREATE TABLE and ALTER TABLE, we also convert UNIQUE constraint to UNIQUE index.
> * `mysql/toddl.go` - support for index key
> * `postgres/infoschema.go` - support for index key getIndexes function
> * `postgres/pg_dump.go` - support for index key, we process CREATE INDEX statements, we also convert UNIQUE constraint to UNIQUE index. 
> * `postgres/toddl.go` - support for index key

> Note: we convert all unique constraint to unique secondary index in spanner as mentioned [here](https://cloud.google.com/spanner/docs/migrating-postgres-spanner#indexes) . this applies to both postgres and mysql.
> Note: we skip ordering of keys in mysqldump (i.e, ascending/descending) as mysqldump parser is not able to parse this order.
> This PR is completed except README

> * [ ]  Update README

