### PR TITLE
fix: foreign key reference case sensitivity

### DIFF
--- a/internal/mapping.go
+++ b/internal/mapping.go
@@ -186,18 +186,15 @@ func resolveFks(conv *Conv, table string, fks []ddl.Foreignkey) []ddl.Foreignkey
 	var resolved []ddl.Foreignkey
 	for _, fk := range fks {
 		var err error
-		fk.Columns, err = resolveColRefs(conv, table, fk.Columns)
-		if err != nil {
+		if fk.Columns, err = resolveColRefs(conv, table, fk.Columns); err != nil {
 			conv.Unexpected(fmt.Sprintf("Can't resolve Columns in foreign key constraint: %s", err))
 			continue
 		}
-		fk.ReferTable, err = resolveTableRef(conv, fk.ReferTable)
-		if err != nil {
+		if fk.ReferTable, err = resolveTableRef(conv, fk.ReferTable); err != nil {
 			conv.Unexpected(fmt.Sprintf("Can't resolve ReferTable in foreign key constraint: %s", err))
 			continue
 		}
-		fk.ReferColumns, err = resolveColRefs(conv, fk.ReferTable, fk.ReferColumns)
-		if err != nil {
+		if fk.ReferColumns, err = resolveColRefs(conv, fk.ReferTable, fk.ReferColumns); err != nil {
 			conv.Unexpected(fmt.Sprintf("Can't resolve ReferColumns in foreign key constraint: %s", err))
 			continue
 		}

--- a/internal/mapping.go
+++ b/internal/mapping.go
@@ -172,7 +172,7 @@ func GetSpannerKeyName(srcKeyName string, schemaForeignKeys map[string]bool) str
 // in the Spanner Schema. Note: Spanner requires that DDL references match
 // the case of the referenced object, but this is not so for many source databases.
 //
-// TODO: expand ResolveRefs to primary keys and indexes.
+// TODO: Expand ResolveRefs to primary keys and indexes.
 func ResolveRefs(conv *Conv) {
 	for table, spTable := range conv.SpSchema {
 		spTable.Fks = resolveFks(conv, table, spTable.Fks)
@@ -182,7 +182,8 @@ func ResolveRefs(conv *Conv) {
 
 // resolveFks returns resolved version of fks.
 // Foreign key constraints that can't be resolved are dropped.
-func resolveFks(conv *Conv, table string, fks []ddl.Foreignkey) (resolved []ddl.Foreignkey) {
+func resolveFks(conv *Conv, table string, fks []ddl.Foreignkey) []ddl.Foreignkey {
+	var resolved []ddl.Foreignkey
 	for _, fk := range fks {
 		var err error
 		fk.Columns, err = resolveColRefs(conv, table, fk.Columns)
@@ -211,7 +212,7 @@ func resolveTableRef(conv *Conv, tableRef string) (string, error) {
 	}
 	// Do case-insensitive search for tableRef.
 	tr := strings.ToLower(tableRef)
-	for t, _ := range conv.SpSchema {
+	for t := range conv.SpSchema {
 		if strings.ToLower(t) == tr {
 			return t, nil
 		}

--- a/internal/mapping_test.go
+++ b/internal/mapping_test.go
@@ -121,7 +121,7 @@ func TestGetSpannerKeyName(t *testing.T) {
 	}
 }
 
-func TestCheckCaseSensitiveReferences(t *testing.T) {
+func TestResolveRefs(t *testing.T) {
 	basicTests := []struct {
 		name             string                     // Name of test.
 		spSchema         map[string]ddl.CreateTable // Spanner schema.
@@ -294,7 +294,7 @@ func TestCheckCaseSensitiveReferences(t *testing.T) {
 	for _, tc := range basicTests {
 		conv := MakeConv()
 		conv.SpSchema = tc.spSchema
-		CheckCaseSensitiveReferences(conv)
+		ResolveRefs(conv)
 		assert.Equal(t, tc.expectedSpSchema, conv.SpSchema, tc.name)
 		assert.Equal(t, tc.unexpecteds, conv.Unexpecteds())
 		conv = nil

--- a/internal/mapping_test.go
+++ b/internal/mapping_test.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"testing"
 
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -117,5 +118,185 @@ func TestGetSpannerKeyName(t *testing.T) {
 	for _, tc := range basicTests {
 		spKeyName := GetSpannerKeyName(tc.srcKeyName, schemaForeignKeys)
 		assert.Equal(t, tc.spKeyName, spKeyName, tc.name)
+	}
+}
+
+func TestCheckCaseSensitiveReferences(t *testing.T) {
+	basicTests := []struct {
+		name             string                     // Name of test.
+		spSchema         map[string]ddl.CreateTable // Spanner schema.
+		expectedSpSchema map[string]ddl.CreateTable // Expected Spanner schema.
+		unexpecteds      int64                      // Expected unexpected conditions
+	}{
+		{
+			name: "Table name case mismatch",
+			spSchema: map[string]ddl.CreateTable{
+				"a": ddl.CreateTable{
+					Name:     "a",
+					ColNames: []string{"acol1", "acol2"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"acol1": ddl.ColumnDef{Name: "acol1", T: ddl.Type{Name: ddl.Int64}},
+						"acol2": ddl.ColumnDef{Name: "acol2", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"acol1"}, ReferTable: "bB", ReferColumns: []string{"bcol1"}}},
+				},
+				"bb": ddl.CreateTable{
+					Name:     "bb",
+					ColNames: []string{"bcol1", "bcol2", "bcol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"bcol1": ddl.ColumnDef{Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
+						"bcol2": ddl.ColumnDef{Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
+						"bcol3": ddl.ColumnDef{Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+				},
+			},
+			expectedSpSchema: map[string]ddl.CreateTable{
+				"a": ddl.CreateTable{
+					Name:     "a",
+					ColNames: []string{"acol1", "acol2"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"acol1": ddl.ColumnDef{Name: "acol1", T: ddl.Type{Name: ddl.Int64}},
+						"acol2": ddl.ColumnDef{Name: "acol2", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"acol1"}, ReferTable: "bb", ReferColumns: []string{"bcol1"}}},
+				},
+				"bb": ddl.CreateTable{
+					Name:     "bb",
+					ColNames: []string{"bcol1", "bcol2", "bcol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"bcol1": ddl.ColumnDef{Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
+						"bcol2": ddl.ColumnDef{Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
+						"bcol3": ddl.ColumnDef{Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+				},
+			},
+			unexpecteds: 0,
+		},
+		{
+			name: "Column name case mismatch",
+			spSchema: map[string]ddl.CreateTable{
+				"bb": ddl.CreateTable{
+					Name:     "bb",
+					ColNames: []string{"bcol1", "bcol2", "bcol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"bcol1": ddl.ColumnDef{Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
+						"bcol2": ddl.ColumnDef{Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
+						"bcol3": ddl.ColumnDef{Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"bcol2", "bcol3"}, ReferTable: "cc", ReferColumns: []string{"cCol1", "ccol2"}}},
+				},
+				"cc": ddl.CreateTable{
+					Name:     "cc",
+					ColNames: []string{"ccol1", "ccol2", "ccol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"ccol1": ddl.ColumnDef{Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
+						"ccol2": ddl.ColumnDef{Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
+						"ccol3": ddl.ColumnDef{Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+				},
+			},
+			expectedSpSchema: map[string]ddl.CreateTable{
+				"bb": ddl.CreateTable{
+					Name:     "bb",
+					ColNames: []string{"bcol1", "bcol2", "bcol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"bcol1": ddl.ColumnDef{Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
+						"bcol2": ddl.ColumnDef{Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
+						"bcol3": ddl.ColumnDef{Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"bcol2", "bcol3"}, ReferTable: "cc", ReferColumns: []string{"ccol1", "ccol2"}}},
+				},
+				"cc": ddl.CreateTable{
+					Name:     "cc",
+					ColNames: []string{"ccol1", "ccol2", "ccol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"ccol1": ddl.ColumnDef{Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
+						"ccol2": ddl.ColumnDef{Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
+						"ccol3": ddl.ColumnDef{Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+				},
+			},
+			unexpecteds: 0,
+		},
+		{
+			name: "Column name not found after lower case check",
+			spSchema: map[string]ddl.CreateTable{
+				"cc": ddl.CreateTable{
+					Name:     "cc",
+					ColNames: []string{"ccol1", "ccol2", "ccol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"ccol1": ddl.ColumnDef{Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
+						"ccol2": ddl.ColumnDef{Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
+						"ccol3": ddl.ColumnDef{Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test3", Columns: []string{"ccol2", "ccol3"}, ReferTable: "dd", ReferColumns: []string{"dcol1", "dcol2"}}},
+				},
+				"dd": ddl.CreateTable{
+					Name:     "dd",
+					ColNames: []string{"dcol1", "ddcol2", "dcol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"dcol1":  ddl.ColumnDef{Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
+						"ddcol2": ddl.ColumnDef{Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
+						"dcol3":  ddl.ColumnDef{Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+				},
+			},
+			expectedSpSchema: map[string]ddl.CreateTable{
+				"cc": ddl.CreateTable{
+					Name:     "cc",
+					ColNames: []string{"ccol1", "ccol2", "ccol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"ccol1": ddl.ColumnDef{Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
+						"ccol2": ddl.ColumnDef{Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
+						"ccol3": ddl.ColumnDef{Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+				},
+				"dd": ddl.CreateTable{
+					Name:     "dd",
+					ColNames: []string{"dcol1", "ddcol2", "dcol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"dcol1":  ddl.ColumnDef{Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
+						"ddcol2": ddl.ColumnDef{Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
+						"dcol3":  ddl.ColumnDef{Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+				},
+			},
+			unexpecteds: 1,
+		},
+		{
+			name: "Table name not found after lower case check",
+			spSchema: map[string]ddl.CreateTable{
+				"dd": ddl.CreateTable{
+					Name:     "dd",
+					ColNames: []string{"dcol1", "ddcol2", "dcol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"dcol1":  ddl.ColumnDef{Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
+						"ddcol2": ddl.ColumnDef{Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
+						"dcol3":  ddl.ColumnDef{Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test4", Columns: []string{"dcol3"}, ReferTable: "ee", ReferColumns: []string{"ecol1"}}},
+				},
+			},
+			expectedSpSchema: map[string]ddl.CreateTable{
+				"dd": ddl.CreateTable{
+					Name:     "dd",
+					ColNames: []string{"dcol1", "ddcol2", "dcol3"},
+					ColDefs: map[string]ddl.ColumnDef{
+						"dcol1":  ddl.ColumnDef{Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
+						"ddcol2": ddl.ColumnDef{Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
+						"dcol3":  ddl.ColumnDef{Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
+					},
+				},
+			},
+			unexpecteds: 1,
+		},
+	}
+	for _, tc := range basicTests {
+		conv := MakeConv()
+		conv.SpSchema = tc.spSchema
+		CheckCaseSensitiveReferences(conv)
+		assert.Equal(t, tc.expectedSpSchema, conv.SpSchema, tc.name)
+		assert.Equal(t, tc.unexpecteds, conv.Unexpecteds())
+		conv = nil
 	}
 }

--- a/mysql/infoschema_test.go
+++ b/mysql/infoschema_test.go
@@ -43,7 +43,9 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			rows: [][]driver.Value{
 				{"user"},
 				{"cart"},
-				{"test"}},
+				{"product"},
+				{"test"},
+				{"test_ref"}},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"test", "user"},
@@ -51,20 +53,20 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			rows: [][]driver.Value{
 				{"user_id", "text", "text", "NO", nil, nil, nil, nil, nil},
 				{"name", "text", "text", "NO", nil, nil, nil, nil, nil},
-				{"addressid", "bigint", "bigint", "YES", nil, nil, nil, nil, nil}},
+				{"ref", "bigint", "bigint", "NO", nil, nil, nil, nil, nil}},
 		}, {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
 			args:  []driver.Value{"test", "user"},
 			cols:  []string{"column_name", "constraint_type"},
 			rows: [][]driver.Value{
 				{"user_id", "PRIMARY KEY"},
-				{"addressid", "FOREIGN KEY"}},
+				{"ref", "FOREIGN KEY"}},
 		}, {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
 			args:  []driver.Value{"test", "user"},
 			cols:  []string{"REFERENCED_TABLE_NAME", "COLUMN_NAME", "REFERENCED_COLUMN_NAME", "CONSTRAINT_NAME"},
 			rows: [][]driver.Value{
-				{"address", "addressid", "address_id", "fk_test"},
+				{"test", "ref", "id", "fk_test"},
 			},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
@@ -88,6 +90,23 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			rows: [][]driver.Value{
 				{"product", "productid", "product_id", "fk_test2"},
 				{"user", "userid", "user_id", "fk_test3"}},
+		}, {
+			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
+			args:  []driver.Value{"test", "product"},
+			cols:  []string{"column_name", "data_type", "column_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale", "extra"},
+			rows: [][]driver.Value{
+				{"product_id", "text", "text", "NO", nil, nil, nil, nil, nil},
+				{"product_name", "text", "text", "NO", nil, nil, nil, nil, nil}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"test", "product"},
+			cols:  []string{"column_name", "constraint_type"},
+			rows: [][]driver.Value{
+				{"product_id", "PRIMARY KEY"}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"test", "product"},
+			cols:  []string{"REFERENCED_TABLE_NAME", "COLUMN_NAME", "REFERENCED_COLUMN_NAME", "CONSTRAINT_NAME"},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"test", "test"},
@@ -124,6 +143,25 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			cols:  []string{"REFERENCED_TABLE_NAME", "COLUMN_NAME", "REFERENCED_COLUMN_NAME", "CONSTRAINT_NAME"},
 			rows: [][]driver.Value{{"test_ref", "id", "ref_id", "fk_test4"},
 				{"test_ref", "txt", "ref_txt", "fk_test4"}},
+		}, {
+			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
+			args:  []driver.Value{"test", "test_ref"},
+			cols:  []string{"column_name", "data_type", "column_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale", "extra"},
+			rows: [][]driver.Value{
+				{"ref_id", "bigint", "bigint", "NO", nil, nil, 64, 0, nil},
+				{"ref_txt", "text", "text", "NO", nil, nil, nil, nil, nil},
+				{"abc", "text", "text", "NO", nil, nil, nil, nil, nil}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"test", "test_ref"},
+			cols:  []string{"column_name", "constraint_type"},
+			rows: [][]driver.Value{
+				{"ref_id", "PRIMARY KEY"},
+				{"ref_txt", "PRIMARY KEY"}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"test", "test_ref"},
+			cols:  []string{"REFERENCED_TABLE_NAME", "COLUMN_NAME", "REFERENCED_COLUMN_NAME", "CONSTRAINT_NAME"},
 		},
 	}
 	db := mkMockDB(t, ms)
@@ -133,14 +171,14 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 	expectedSchema := map[string]ddl.CreateTable{
 		"user": ddl.CreateTable{
 			Name:     "user",
-			ColNames: []string{"user_id", "name", "addressid"},
+			ColNames: []string{"user_id", "name", "ref"},
 			ColDefs: map[string]ddl.ColumnDef{
-				"user_id":   ddl.ColumnDef{Name: "user_id", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
-				"name":      ddl.ColumnDef{Name: "name", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
-				"addressid": ddl.ColumnDef{Name: "addressid", T: ddl.Type{Name: ddl.Int64}},
+				"user_id": ddl.ColumnDef{Name: "user_id", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+				"name":    ddl.ColumnDef{Name: "name", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+				"ref":     ddl.ColumnDef{Name: "ref", T: ddl.Type{Name: ddl.Int64}, NotNull: true},
 			},
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "user_id"}},
-			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"addressid"}, ReferTable: "address", ReferColumns: []string{"address_id"}}}},
+			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"ref"}, ReferTable: "test", ReferColumns: []string{"id"}}}},
 		"cart": ddl.CreateTable{
 			Name:     "cart",
 			ColNames: []string{"productid", "userid", "quantity"},
@@ -152,6 +190,14 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "productid"}, ddl.IndexKey{Col: "userid"}},
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"productid"}, ReferTable: "product", ReferColumns: []string{"product_id"}},
 				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}}},
+		"product": ddl.CreateTable{
+			Name:     "product",
+			ColNames: []string{"product_id", "product_name"},
+			ColDefs: map[string]ddl.ColumnDef{
+				"product_id":   ddl.ColumnDef{Name: "product_id", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+				"product_name": ddl.ColumnDef{Name: "product_name", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+			},
+			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "product_id"}}},
 		"test": ddl.CreateTable{
 			Name:     "test",
 			ColNames: []string{"id", "s", "txt", "b", "bs", "bl", "c", "c8", "d", "dec", "f8", "f4", "i8", "i4", "i2", "si", "ts", "tz", "vc", "vc6"},
@@ -179,6 +225,15 @@ func TestProcessInfoSchemaMYSQL(t *testing.T) {
 			},
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "id"}},
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test4", Columns: []string{"id", "txt"}, ReferTable: "test_ref", ReferColumns: []string{"ref_id", "ref_txt"}}}},
+		"test_ref": ddl.CreateTable{
+			Name:     "test_ref",
+			ColNames: []string{"ref_id", "ref_txt", "abc"},
+			ColDefs: map[string]ddl.ColumnDef{
+				"ref_id":  ddl.ColumnDef{Name: "ref_id", T: ddl.Type{Name: ddl.Int64}, NotNull: true},
+				"ref_txt": ddl.ColumnDef{Name: "ref_txt", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+				"abc":     ddl.ColumnDef{Name: "abc", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+			},
+			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "ref_id"}, ddl.IndexKey{Col: "ref_txt"}}},
 	}
 	assert.Equal(t, expectedSchema, stripSchemaComments(conv.SpSchema))
 	assert.Equal(t, len(conv.Issues["cart"]), 0)

--- a/mysql/toddl.go
+++ b/mysql/toddl.go
@@ -86,7 +86,7 @@ func schemaToDDL(conv *internal.Conv) error {
 			Fks:      cvtForeignKeys(conv, srcTable.Name, srcTable.ForeignKeys, schemaForeignKeys),
 			Comment:  comment}
 	}
-	internal.CheckCaseSensitiveReferences(conv)
+	internal.ResolveRefs(conv)
 	return nil
 }
 

--- a/mysql/toddl.go
+++ b/mysql/toddl.go
@@ -17,7 +17,6 @@ package mysql
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"unicode"
 
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
@@ -87,6 +86,7 @@ func schemaToDDL(conv *internal.Conv) error {
 			Fks:      cvtForeignKeys(conv, srcTable.Name, srcTable.ForeignKeys, schemaForeignKeys),
 			Comment:  comment}
 	}
+	internal.CheckCaseSensitiveReferences(conv)
 	return nil
 }
 
@@ -215,22 +215,10 @@ func cvtForeignKeys(conv *internal.Conv, srcTable string, srcKeys []schema.Forei
 				conv.Unexpected(fmt.Sprintf("Can't map foreign key for table: %s, referenced table: %s, column: %s", srcTable, key.ReferTable, col))
 				continue
 			}
-			if _, found := conv.SpSchema[spReferTable].ColDefs[spReferCol]; !found {
-				// Spanner foreign key referenced columns are case sensitive, so
-				// if we don't find column with direct look up, we compare referenced
-				// column with all columns with lower case in referenced table.
-				for _, refCol := range conv.SpSchema[spReferTable].ColNames {
-					if strings.ToLower(refCol) == strings.ToLower(spReferCol) {
-						spReferCol = refCol
-						break
-					}
-				}
-			}
 			spCols = append(spCols, spCol)
 			spReferCols = append(spReferCols, spReferCol)
 		}
 		spKeyName := internal.GetSpannerKeyName(key.Name, schemaForeignKeys)
-
 		spKey := ddl.Foreignkey{
 			Name:         spKeyName,
 			Columns:      spCols,

--- a/mysql/toddl_test.go
+++ b/mysql/toddl_test.go
@@ -40,9 +40,30 @@ func TestToSpannerType(t *testing.T) {
 			"f": schema.Column{Name: "f", Type: schema.Type{Name: "timestamp"}},
 		},
 		PrimaryKeys: []schema.Key{schema.Key{Column: "a"}},
-		ForeignKeys: []schema.ForeignKey{schema.ForeignKey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"b"}}},
+		ForeignKeys: []schema.ForeignKey{schema.ForeignKey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"dref"}},
+			schema.ForeignKey{Name: "fk_test2", Columns: []string{"a"}, ReferTable: "ref_table2", ReferColumns: []string{"aRef"}}},
 	}
 	conv.SrcSchema[name] = srcSchema
+	conv.SpSchema["ref_table"] = ddl.CreateTable{
+		Name:     "ref_table",
+		ColNames: []string{"dref", "b", "c"},
+		ColDefs: map[string]ddl.ColumnDef{
+			"dref": ddl.ColumnDef{Name: "dref", T: ddl.Type{Name: ddl.String, Len: int64(6)}},
+			"b":    ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.Float64}},
+			"c":    ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.Bool}},
+		},
+		Pks: []ddl.IndexKey{ddl.IndexKey{Col: "dref"}},
+	}
+	conv.SpSchema["ref_table2"] = ddl.CreateTable{
+		Name:     "ref_table2",
+		ColNames: []string{"aref", "b", "c"},
+		ColDefs: map[string]ddl.ColumnDef{
+			"aref": ddl.ColumnDef{Name: "aref", T: ddl.Type{Name: ddl.Int64}},
+			"b":    ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.Float64}},
+			"c":    ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.Bool}},
+		},
+		Pks: []ddl.IndexKey{ddl.IndexKey{Col: "aref"}},
+	}
 	assert.Nil(t, schemaToDDL(conv))
 	actual := conv.SpSchema[name]
 	dropComments(&actual) // Don't test comment.
@@ -58,7 +79,8 @@ func TestToSpannerType(t *testing.T) {
 			"f": ddl.ColumnDef{Name: "f", T: ddl.Type{Name: ddl.Timestamp}},
 		},
 		Pks: []ddl.IndexKey{ddl.IndexKey{Col: "a"}},
-		Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"b"}}},
+		Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"dref"}},
+			ddl.Foreignkey{Name: "fk_test2", Columns: []string{"a"}, ReferTable: "ref_table2", ReferColumns: []string{"aref"}}},
 	}
 	assert.Equal(t, expected, actual)
 	expectedIssues := map[string][]internal.SchemaIssue{

--- a/postgres/infoschema_test.go
+++ b/postgres/infoschema_test.go
@@ -43,7 +43,9 @@ func TestProcessInfoSchema(t *testing.T) {
 			rows: [][]driver.Value{
 				{"public", "user"},
 				{"public", "cart"},
-				{"public", "test"}},
+				{"public", "product"},
+				{"public", "test"},
+				{"public", "test_ref"}},
 		},
 		{
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
@@ -52,20 +54,20 @@ func TestProcessInfoSchema(t *testing.T) {
 			rows: [][]driver.Value{
 				{"user_id", "text", nil, "NO", nil, nil, nil, nil},
 				{"name", "text", nil, "NO", nil, nil, nil, nil},
-				{"addressid", "bigint", nil, "YES", nil, nil, nil, nil}},
+				{"ref", "bigint", nil, "YES", nil, nil, nil, nil}},
 		}, {
 			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
 			args:  []driver.Value{"public", "user"},
 			cols:  []string{"column_name", "constraint_type"},
 			rows: [][]driver.Value{
 				{"user_id", "PRIMARY KEY"},
-				{"addressid", "FOREIGN KEY"}},
+				{"ref", "FOREIGN KEY"}},
 		}, {
 			query: "SELECT (.+) FROM PG_CLASS (.+) JOIN PG_NAMESPACE (.+) JOIN PG_CONSTRAINT (.+)",
 			args:  []driver.Value{"public", "user"},
 			cols:  []string{"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "REF_COLUMN_NAME", "CONSTRAINT_NAME"},
 			rows: [][]driver.Value{
-				{"public", "address", "addressid", "address_id", "fk_test"},
+				{"public", "test", "ref", "id", "fk_test"},
 			},
 		},
 		{
@@ -92,6 +94,23 @@ func TestProcessInfoSchema(t *testing.T) {
 				{"public", "user", "userid", "user_id", "fk_test3"}},
 		}, {
 			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
+			args:  []driver.Value{"public", "product"},
+			cols:  []string{"column_name", "data_type", "data_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale"},
+			rows: [][]driver.Value{
+				{"product_id", "text", nil, "NO", nil, nil, nil, nil},
+				{"product_name", "text", nil, "NO", nil, nil, nil, nil}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"public", "product"},
+			cols:  []string{"column_name", "constraint_type"},
+			rows: [][]driver.Value{
+				{"product_id", "PRIMARY KEY"}},
+		}, {
+			query: "SELECT (.+) FROM PG_CLASS (.+) JOIN PG_NAMESPACE (.+) JOIN PG_CONSTRAINT (.+)",
+			args:  []driver.Value{"public", "product"},
+			cols:  []string{"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "REF_COLUMN_NAME", "CONSTRAINT_NAME"},
+		}, {
+			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
 			args:  []driver.Value{"public", "test"},
 			cols:  []string{"column_name", "data_type", "data_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale"},
 			rows: [][]driver.Value{
@@ -113,7 +132,7 @@ func TestProcessInfoSchema(t *testing.T) {
 				{"s", "integer", nil, "NO", "nextval('test11_s_seq'::regclass)", nil, 32, 0},
 				{"ts", "timestamp without time zone", nil, "YES", nil, nil, nil, nil},
 				{"tz", "timestamp with time zone", nil, "YES", nil, nil, nil, nil},
-				{"txt", "text", nil, "YES", nil, nil, nil, nil},
+				{"txt", "text", nil, "NO", nil, nil, nil, nil},
 				{"vc", "character varying", nil, "YES", nil, nil, nil, nil},
 				{"vc6", "character varying", nil, "YES", nil, 6, nil, nil}},
 		}, {
@@ -126,7 +145,26 @@ func TestProcessInfoSchema(t *testing.T) {
 			args:  []driver.Value{"public", "test"},
 			cols:  []string{"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "REF_COLUMN_NAME", "CONSTRAINT_NAME"},
 			rows: [][]driver.Value{{"public", "test_ref", "id", "ref_id", "fk_test4"},
-				{"public", "test_ref", "bs", "ref_bs", "fk_test4"}},
+				{"public", "test_ref", "txt", "ref_txt", "fk_test4"}},
+		}, {
+			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
+			args:  []driver.Value{"public", "test_ref"},
+			cols:  []string{"column_name", "data_type", "data_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale"},
+			rows: [][]driver.Value{
+				{"ref_id", "bigint", nil, "NO", nil, nil, 64, 0},
+				{"ref_txt", "text", nil, "NO", nil, nil, nil, nil},
+				{"abc", "text", nil, "NO", nil, nil, nil, nil}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"public", "test_ref"},
+			cols:  []string{"column_name", "constraint_type"},
+			rows: [][]driver.Value{
+				{"ref_id", "PRIMARY KEY"},
+				{"ref_txt", "PRIMARY KEY"}},
+		}, {
+			query: "SELECT (.+) FROM PG_CLASS (.+) JOIN PG_NAMESPACE (.+) JOIN PG_CONSTRAINT (.+)",
+			args:  []driver.Value{"public", "test_ref"},
+			cols:  []string{"TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME", "REF_COLUMN_NAME", "CONSTRAINT_NAME"},
 		},
 	}
 	db := mkMockDB(t, ms)
@@ -136,14 +174,14 @@ func TestProcessInfoSchema(t *testing.T) {
 	expectedSchema := map[string]ddl.CreateTable{
 		"user": ddl.CreateTable{
 			Name:     "user",
-			ColNames: []string{"user_id", "name", "addressid"},
+			ColNames: []string{"user_id", "name", "ref"},
 			ColDefs: map[string]ddl.ColumnDef{
-				"user_id":   ddl.ColumnDef{Name: "user_id", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
-				"name":      ddl.ColumnDef{Name: "name", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
-				"addressid": ddl.ColumnDef{Name: "addressid", T: ddl.Type{Name: ddl.Int64}},
+				"user_id": ddl.ColumnDef{Name: "user_id", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+				"name":    ddl.ColumnDef{Name: "name", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+				"ref":     ddl.ColumnDef{Name: "ref", T: ddl.Type{Name: ddl.Int64}},
 			},
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "user_id"}},
-			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"addressid"}, ReferTable: "address", ReferColumns: []string{"address_id"}}}},
+			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"ref"}, ReferTable: "test", ReferColumns: []string{"id"}}}},
 		"cart": ddl.CreateTable{
 			Name:     "cart",
 			ColNames: []string{"productid", "userid", "quantity"},
@@ -155,6 +193,14 @@ func TestProcessInfoSchema(t *testing.T) {
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "productid"}, ddl.IndexKey{Col: "userid"}},
 			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"productid"}, ReferTable: "product", ReferColumns: []string{"product_id"}},
 				ddl.Foreignkey{Name: "fk_test3", Columns: []string{"userid"}, ReferTable: "user", ReferColumns: []string{"user_id"}}}},
+		"product": ddl.CreateTable{
+			Name:     "product",
+			ColNames: []string{"product_id", "product_name"},
+			ColDefs: map[string]ddl.ColumnDef{
+				"product_id":   ddl.ColumnDef{Name: "product_id", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+				"product_name": ddl.ColumnDef{Name: "product_name", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+			},
+			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "product_id"}}},
 		"test": ddl.CreateTable{
 			Name:     "test",
 			ColNames: []string{"id", "aint", "atext", "b", "bs", "by", "c", "c8", "d", "f8", "f4", "i8", "i4", "i2", "num", "s", "ts", "tz", "txt", "vc", "vc6"},
@@ -177,13 +223,21 @@ func TestProcessInfoSchema(t *testing.T) {
 				"s":     ddl.ColumnDef{Name: "s", T: ddl.Type{Name: ddl.Int64}, NotNull: true},
 				"ts":    ddl.ColumnDef{Name: "ts", T: ddl.Type{Name: ddl.Timestamp}},
 				"tz":    ddl.ColumnDef{Name: "tz", T: ddl.Type{Name: ddl.Timestamp}},
-				"txt":   ddl.ColumnDef{Name: "txt", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+				"txt":   ddl.ColumnDef{Name: "txt", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
 				"vc":    ddl.ColumnDef{Name: "vc", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
 				"vc6":   ddl.ColumnDef{Name: "vc6", T: ddl.Type{Name: ddl.String, Len: int64(6)}},
 			},
 			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "id"}},
-			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test4", Columns: []string{"id", "bs"}, ReferTable: "test_ref", ReferColumns: []string{"ref_id", "ref_bs"}}},
-		},
+			Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test4", Columns: []string{"id", "txt"}, ReferTable: "test_ref", ReferColumns: []string{"ref_id", "ref_txt"}}}},
+		"test_ref": ddl.CreateTable{
+			Name:     "test_ref",
+			ColNames: []string{"ref_id", "ref_txt", "abc"},
+			ColDefs: map[string]ddl.ColumnDef{
+				"ref_id":  ddl.ColumnDef{Name: "ref_id", T: ddl.Type{Name: ddl.Int64}, NotNull: true},
+				"ref_txt": ddl.ColumnDef{Name: "ref_txt", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+				"abc":     ddl.ColumnDef{Name: "abc", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, NotNull: true},
+			},
+			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "ref_id"}, ddl.IndexKey{Col: "ref_txt"}}},
 	}
 	assert.Equal(t, expectedSchema, stripSchemaComments(conv.SpSchema))
 	assert.Equal(t, len(conv.Issues["cart"]), 0)

--- a/postgres/toddl.go
+++ b/postgres/toddl.go
@@ -17,6 +17,7 @@ package postgres
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"unicode"
 
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
@@ -202,11 +203,21 @@ func cvtForeignKeys(conv *internal.Conv, srcTable string, srcKeys []schema.Forei
 				conv.Unexpected(fmt.Sprintf("Can't map foreign key for table: %s, referenced table: %s, column: %s", srcTable, key.ReferTable, col))
 				continue
 			}
+			if _, found := conv.SpSchema[spReferTable].ColDefs[spReferCol]; !found {
+				// Spanner foreign key referenced columns are case sensitive, so
+				// if we don't find column with direct look up, we compare referenced
+				// column with all columns with lower case in referenced table.
+				for _, refCol := range conv.SpSchema[spReferTable].ColNames {
+					if strings.ToLower(refCol) == strings.ToLower(spReferCol) {
+						spReferCol = refCol
+						break
+					}
+				}
+			}
 			spCols = append(spCols, spCol)
 			spReferCols = append(spReferCols, spReferCol)
 		}
 		spKeyName := internal.GetSpannerKeyName(key.Name, schemaForeignKeys)
-
 		spKey := ddl.Foreignkey{
 			Name:         spKeyName,
 			Columns:      spCols,

--- a/postgres/toddl.go
+++ b/postgres/toddl.go
@@ -79,7 +79,7 @@ func schemaToDDL(conv *internal.Conv) error {
 			Fks:      cvtForeignKeys(conv, srcTable.Name, srcTable.ForeignKeys, schemaForeignKeys),
 			Comment:  comment}
 	}
-	internal.CheckCaseSensitiveReferences(conv)
+	internal.ResolveRefs(conv)
 	return nil
 }
 

--- a/postgres/toddl.go
+++ b/postgres/toddl.go
@@ -17,7 +17,6 @@ package postgres
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"unicode"
 
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
@@ -80,6 +79,7 @@ func schemaToDDL(conv *internal.Conv) error {
 			Fks:      cvtForeignKeys(conv, srcTable.Name, srcTable.ForeignKeys, schemaForeignKeys),
 			Comment:  comment}
 	}
+	internal.CheckCaseSensitiveReferences(conv)
 	return nil
 }
 
@@ -202,17 +202,6 @@ func cvtForeignKeys(conv *internal.Conv, srcTable string, srcKeys []schema.Forei
 			if err1 != nil || err2 != nil {
 				conv.Unexpected(fmt.Sprintf("Can't map foreign key for table: %s, referenced table: %s, column: %s", srcTable, key.ReferTable, col))
 				continue
-			}
-			if _, found := conv.SpSchema[spReferTable].ColDefs[spReferCol]; !found {
-				// Spanner foreign key referenced columns are case sensitive, so
-				// if we don't find column with direct look up, we compare referenced
-				// column with all columns with lower case in referenced table.
-				for _, refCol := range conv.SpSchema[spReferTable].ColNames {
-					if strings.ToLower(refCol) == strings.ToLower(spReferCol) {
-						spReferCol = refCol
-						break
-					}
-				}
 			}
 			spCols = append(spCols, spCol)
 			spReferCols = append(spReferCols, spReferCol)


### PR DESCRIPTION
Fixes #99 

This PR is fixing the above mentioned issue, and includes following changes:

(1) mysql/toddl.go and postgres/toddl.go: added check for referenced column if column does not exist, checking the possible type mismatched column with lower case column names. added tests for the same.