### PR TITLE
Upgrade emulator version to 1.2.0 and remove the args from github act…

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -17,14 +17,10 @@ jobs:
 
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.1.1
+        image: gcr.io/cloud-spanner-emulator/emulator:1.2.0
         ports:
           - 9010:9010
           - 9020:9020
-        # needed because numeric support isn't on by default in emulator:1.1.1
-        # note: future versions will default enable this and deprecate the flag
-        # TODO: upgrade emuator version, confirm enable_numeric_type is no longer needed and delete it
-        args: ["-enable_numeric_type"]
       postgres:
         image: postgres:9.6
         env:


### PR DESCRIPTION
Fixes the issue with integration tests not running due to following failure:

The workflow is not valid. .github/workflows/integration-tests-against-emulator.yaml (Line: 26, Col: 9): Unexpected value 'args'
.github/workflows/integration-tests-against-emulator.yaml#L26
