### PR TITLE
Fix handling of numeric data for driver=postgres.

### DIFF
--- a/postgres/infoschema.go
+++ b/postgres/infoschema.go
@@ -581,6 +581,11 @@ func cvtSQLScalar(conv *internal.Conv, srcCd schema.Column, spCd ddl.ColumnDef, 
 		case string:
 			return convFloat64(v)
 		}
+	case ddl.Numeric:
+		switch v := val.(type) {
+		case []byte: // Note: PostgreSQL uses []byte for numeric.
+			return convNumeric(string(v))
+		}
 	case ddl.String:
 		switch v := val.(type) {
 		case bool:

--- a/postgres/infoschema_test.go
+++ b/postgres/infoschema_test.go
@@ -360,6 +360,7 @@ func TestConvertSqlRow_SingleCol(t *testing.T) {
 		{name: "float64 string", srcType: schema.Type{Name: "text"}, spType: ddl.Type{Name: ddl.Float64}, in: "42.6", e: float64(42.6)},
 		{name: "float64 int", srcType: schema.Type{Name: "bigint"}, spType: ddl.Type{Name: ddl.Float64}, in: int64(42), e: float64(42)},
 		{name: "float64 byte", srcType: schema.Type{Name: "numeric"}, spType: ddl.Type{Name: ddl.Float64}, in: []byte("42.6"), e: float64(42.6)},
+		{name: "numeric", srcType: schema.Type{Name: "numeric"}, spType: ddl.Type{Name: ddl.Numeric}, in: []byte("999.99999"), e: "999.999990000"},
 		{name: "string", srcType: schema.Type{Name: "text"}, spType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, in: "eh", e: "eh"},
 		{name: "string bool", srcType: schema.Type{Name: "bool"}, spType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, in: true, e: "true"},
 		{name: "string byte", srcType: schema.Type{Name: "bytea"}, spType: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, in: []byte("abc"), e: "abc"},


### PR DESCRIPTION
PR#104 (support NUMERIC) missed a data conversion case. Specifically, it did not cover the case when driver=postgres (aka infoschema processing with PostgreSQL).

This PR fixes the issue and adds a test case.

Notes:
1) The missed case was only for Postgres. It didn't occur for MySQL because for MySQL we use a simpler (but slightly more expensive) string-based-processing that allows us to directly call ProcessDataRow.
1) We have a long-term plan to consolidate the processing of postgres and mysql information schema processing, and in particular, to use the simpler string-based processing of mysql everywhere. This would have avoided this issue!