### PR TITLE
[Cleanup] Remove use of maxExpectedMods, cleans up the corresponding TODO

### DIFF
--- a/dynamodb/toddl.go
+++ b/dynamodb/toddl.go
@@ -74,12 +74,6 @@ func schemaToDDL(conv *internal.Conv) error {
 // mapping.  toSpannerType returns the Spanner type and a list of type
 // conversion issues encountered.
 func toSpannerType(conv *internal.Conv, id string, mods []int64) (ddl.Type, []internal.SchemaIssue) {
-	maxExpectedMods := func(n int) {
-		if len(mods) > n {
-			conv.Unexpected(fmt.Sprintf("Found %d mods while processing type id=%s", len(mods), id))
-		}
-	}
-	maxExpectedMods(0)
 	switch id {
 	case typeNumber:
 		return ddl.Type{Name: ddl.Numeric}, nil

--- a/mysql/toddl.go
+++ b/mysql/toddl.go
@@ -112,30 +112,20 @@ func schemaToDDL(conv *internal.Conv) error {
 // mapping.  toSpannerType returns the Spanner type and a list of type
 // conversion issues encountered.
 func toSpannerType(conv *internal.Conv, id string, mods []int64) (ddl.Type, []internal.SchemaIssue) {
-	maxExpectedMods := func(n int) {
-		if len(mods) > n {
-			conv.Unexpected(fmt.Sprintf("Found %d mods while processing type id=%s", len(mods), id))
-		}
-	}
 	switch id {
 	case "bool", "boolean":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Bool}, nil
 	case "tinyint":
-		maxExpectedMods(1)
 		// tinyint(1) is a bool in MySQL
 		if len(mods) > 0 && mods[0] == 1 {
 			return ddl.Type{Name: ddl.Bool}, nil
 		}
 		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Widened}
 	case "double":
-		maxExpectedMods(2)
 		return ddl.Type{Name: ddl.Float64}, nil
 	case "float":
-		maxExpectedMods(2)
 		return ddl.Type{Name: ddl.Float64}, []internal.SchemaIssue{internal.Widened}
 	case "numeric", "decimal":
-		maxExpectedMods(2)
 		// MySQL's NUMERIC type can store up to 65 digits, with up to 30 after the
 		// the decimal point. Spanner's NUMERIC type can store up to 29 digits before the
 		// decimal point and up to 9 after the decimal point -- it is equivalent to
@@ -145,46 +135,33 @@ func toSpannerType(conv *internal.Conv, id string, mods []int64) (ddl.Type, []in
 		// capabilities between MySQL and Spanner NUMERIC.
 		return ddl.Type{Name: ddl.Numeric}, nil
 	case "bigint":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Int64}, nil
 	case "smallint", "mediumint", "integer", "int":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Widened}
 	case "bit":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
 	case "varchar", "char":
-		maxExpectedMods(1)
 		if len(mods) > 0 {
 			return ddl.Type{Name: ddl.String, Len: mods[0]}, nil
 		}
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 	case "text", "tinytext", "mediumtext", "longtext":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 	case "set", "enum":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
-	case "json":
-		maxExpectedMods(0)
+	case "json":)
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 	case "binary", "varbinary":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
 	case "tinyblob", "mediumblob", "blob", "longblob":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
 	case "date":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Date}, nil
 	case "datetime":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Timestamp}, []internal.SchemaIssue{internal.Datetime}
 	case "timestamp":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Timestamp}, nil
 	case "time", "year":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.Time}
 	}
 	return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.NoGoodType}

--- a/mysql/toddl.go
+++ b/mysql/toddl.go
@@ -149,7 +149,7 @@ func toSpannerType(conv *internal.Conv, id string, mods []int64) (ddl.Type, []in
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 	case "set", "enum":
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
-	case "json":)
+	case "json":
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 	case "binary", "varbinary":
 		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil

--- a/postgres/toddl.go
+++ b/postgres/toddl.go
@@ -105,51 +105,32 @@ func schemaToDDL(conv *internal.Conv) error {
 // mapping.  toSpannerType returns the Spanner type and a list of type
 // conversion issues encountered.
 func toSpannerType(conv *internal.Conv, id string, mods []int64) (ddl.Type, []internal.SchemaIssue) {
-	// TODO: Remove use of maxExpectedMods. It was added as a sanity check for the
-	// initial version of HarbourBridge. It has now out-lived its usefulness: it isn't
-	// uncovering issues (and it's unlikely to) and it's cluttering code.
-	maxExpectedMods := func(n int) {
-		if len(mods) > n {
-			conv.Unexpected(fmt.Sprintf("Found %d mods while processing type id=%s", len(mods), id))
-		}
-	}
 	switch id {
 	case "bool", "boolean":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Bool}, nil
 	case "bigserial":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Serial}
 	case "bpchar", "character": // Note: Postgres internal name for char is bpchar (aka blank padded char).
-		maxExpectedMods(1)
 		if len(mods) > 0 {
 			return ddl.Type{Name: ddl.String, Len: mods[0]}, nil
 		}
 		// Note: bpchar without length specifier is equivalent to bpchar(1)
 		return ddl.Type{Name: ddl.String, Len: 1}, nil
 	case "bytea":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
 	case "date":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Date}, nil
 	case "float8", "double precision":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Float64}, nil
 	case "float4", "real":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Float64}, []internal.SchemaIssue{internal.Widened}
 	case "int8", "bigint":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Int64}, nil
 	case "int4", "integer":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Widened}
 	case "int2", "smallint":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Widened}
 	case "numeric":
-		maxExpectedMods(2)
 		// PostgreSQL's NUMERIC type can have a specified precision of up to 1000
 		// digits (and scale can be anything from 0 up to the value of 'precision').
 		// If precision and scale are not specified, then values of any precision
@@ -164,20 +145,15 @@ func toSpannerType(conv *internal.Conv, id string, mods []int64) (ddl.Type, []in
 		// capabilities between PostgreSQL and Spanner NUMERIC.
 		return ddl.Type{Name: ddl.Numeric}, nil
 	case "serial":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Serial}
 	case "text":
-		maxExpectedMods(0)
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 	case "timestamptz", "timestamp with time zone":
-		maxExpectedMods(1)
 		return ddl.Type{Name: ddl.Timestamp}, nil
 	case "timestamp", "timestamp without time zone":
-		maxExpectedMods(1)
 		// Map timestamp without timezone to Spanner timestamp.
 		return ddl.Type{Name: ddl.Timestamp}, []internal.SchemaIssue{internal.Timestamp}
 	case "varchar", "character varying":
-		maxExpectedMods(1)
 		if len(mods) > 0 {
 			return ddl.Type{Name: ddl.String, Len: mods[0]}, nil
 		}


### PR DESCRIPTION
Performing this cleanup in preparation of refactoring common code out of dynamodb/tolddl.go, mysql/toddl.go, postgres/toddl.go.