### PR TITLE
[refactor] Move spanner ddl functionality to spanner/ddl package.

### DIFF
--- a/internal/mapping_test.go
+++ b/internal/mapping_test.go
@@ -139,50 +139,50 @@ func TestGetSpannerId(t *testing.T) {
 
 func TestResolveRefs(t *testing.T) {
 	basicTests := []struct {
-		name             string                     // Name of test.
-		spSchema         map[string]ddl.CreateTable // Spanner schema.
-		expectedSpSchema map[string]ddl.CreateTable // Expected Spanner schema.
-		unexpecteds      int64                      // Expected unexpected conditions
+		name             string     // Name of test.
+		spSchema         ddl.Schema // Spanner schema.
+		expectedSpSchema ddl.Schema // Expected Spanner schema.
+		unexpecteds      int64      // Expected unexpected conditions
 	}{
 		{
 			name: "Table name case mismatch",
 			spSchema: map[string]ddl.CreateTable{
-				"a": ddl.CreateTable{
+				"a": {
 					Name:     "a",
 					ColNames: []string{"acol1", "acol2"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"acol1": ddl.ColumnDef{Name: "acol1", T: ddl.Type{Name: ddl.Int64}},
-						"acol2": ddl.ColumnDef{Name: "acol2", T: ddl.Type{Name: ddl.Int64}},
+						"acol1": {Name: "acol1", T: ddl.Type{Name: ddl.Int64}},
+						"acol2": {Name: "acol2", T: ddl.Type{Name: ddl.Int64}},
 					},
-					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"acol1"}, ReferTable: "bB", ReferColumns: []string{"bcol1"}}},
+					Fks: []ddl.Foreignkey{{Name: "fk_test", Columns: []string{"acol1"}, ReferTable: "bB", ReferColumns: []string{"bcol1"}}},
 				},
-				"bb": ddl.CreateTable{
+				"bb": {
 					Name:     "bb",
 					ColNames: []string{"bcol1", "bcol2", "bcol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"bcol1": ddl.ColumnDef{Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
-						"bcol2": ddl.ColumnDef{Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
-						"bcol3": ddl.ColumnDef{Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
+						"bcol1": {Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
+						"bcol2": {Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
+						"bcol3": {Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
 					},
 				},
 			},
 			expectedSpSchema: map[string]ddl.CreateTable{
-				"a": ddl.CreateTable{
+				"a": {
 					Name:     "a",
 					ColNames: []string{"acol1", "acol2"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"acol1": ddl.ColumnDef{Name: "acol1", T: ddl.Type{Name: ddl.Int64}},
-						"acol2": ddl.ColumnDef{Name: "acol2", T: ddl.Type{Name: ddl.Int64}},
+						"acol1": {Name: "acol1", T: ddl.Type{Name: ddl.Int64}},
+						"acol2": {Name: "acol2", T: ddl.Type{Name: ddl.Int64}},
 					},
-					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"acol1"}, ReferTable: "bb", ReferColumns: []string{"bcol1"}}},
+					Fks: []ddl.Foreignkey{{Name: "fk_test", Columns: []string{"acol1"}, ReferTable: "bb", ReferColumns: []string{"bcol1"}}},
 				},
-				"bb": ddl.CreateTable{
+				"bb": {
 					Name:     "bb",
 					ColNames: []string{"bcol1", "bcol2", "bcol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"bcol1": ddl.ColumnDef{Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
-						"bcol2": ddl.ColumnDef{Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
-						"bcol3": ddl.ColumnDef{Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
+						"bcol1": {Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
+						"bcol2": {Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
+						"bcol3": {Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
 					},
 				},
 			},
@@ -191,44 +191,44 @@ func TestResolveRefs(t *testing.T) {
 		{
 			name: "Column name case mismatch",
 			spSchema: map[string]ddl.CreateTable{
-				"bb": ddl.CreateTable{
+				"bb": {
 					Name:     "bb",
 					ColNames: []string{"bcol1", "bcol2", "bcol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"bcol1": ddl.ColumnDef{Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
-						"bcol2": ddl.ColumnDef{Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
-						"bcol3": ddl.ColumnDef{Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
+						"bcol1": {Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
+						"bcol2": {Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
+						"bcol3": {Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
 					},
-					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"bcol2", "bcol3"}, ReferTable: "cc", ReferColumns: []string{"cCol1", "ccol2"}}},
+					Fks: []ddl.Foreignkey{{Name: "fk_test2", Columns: []string{"bcol2", "bcol3"}, ReferTable: "cc", ReferColumns: []string{"cCol1", "ccol2"}}},
 				},
-				"cc": ddl.CreateTable{
+				"cc": {
 					Name:     "cc",
 					ColNames: []string{"ccol1", "ccol2", "ccol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"ccol1": ddl.ColumnDef{Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
-						"ccol2": ddl.ColumnDef{Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
-						"ccol3": ddl.ColumnDef{Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
+						"ccol1": {Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
+						"ccol2": {Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
+						"ccol3": {Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
 					},
 				},
 			},
 			expectedSpSchema: map[string]ddl.CreateTable{
-				"bb": ddl.CreateTable{
+				"bb": {
 					Name:     "bb",
 					ColNames: []string{"bcol1", "bcol2", "bcol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"bcol1": ddl.ColumnDef{Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
-						"bcol2": ddl.ColumnDef{Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
-						"bcol3": ddl.ColumnDef{Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
+						"bcol1": {Name: "bcol1", T: ddl.Type{Name: ddl.Int64}},
+						"bcol2": {Name: "bcol2", T: ddl.Type{Name: ddl.Int64}},
+						"bcol3": {Name: "bcol3", T: ddl.Type{Name: ddl.Int64}},
 					},
-					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test2", Columns: []string{"bcol2", "bcol3"}, ReferTable: "cc", ReferColumns: []string{"ccol1", "ccol2"}}},
+					Fks: []ddl.Foreignkey{{Name: "fk_test2", Columns: []string{"bcol2", "bcol3"}, ReferTable: "cc", ReferColumns: []string{"ccol1", "ccol2"}}},
 				},
-				"cc": ddl.CreateTable{
+				"cc": {
 					Name:     "cc",
 					ColNames: []string{"ccol1", "ccol2", "ccol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"ccol1": ddl.ColumnDef{Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
-						"ccol2": ddl.ColumnDef{Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
-						"ccol3": ddl.ColumnDef{Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
+						"ccol1": {Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
+						"ccol2": {Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
+						"ccol3": {Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
 					},
 				},
 			},
@@ -237,43 +237,43 @@ func TestResolveRefs(t *testing.T) {
 		{
 			name: "Column name not found after lower case check",
 			spSchema: map[string]ddl.CreateTable{
-				"cc": ddl.CreateTable{
+				"cc": {
 					Name:     "cc",
 					ColNames: []string{"ccol1", "ccol2", "ccol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"ccol1": ddl.ColumnDef{Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
-						"ccol2": ddl.ColumnDef{Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
-						"ccol3": ddl.ColumnDef{Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
+						"ccol1": {Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
+						"ccol2": {Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
+						"ccol3": {Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
 					},
-					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test3", Columns: []string{"ccol2", "ccol3"}, ReferTable: "dd", ReferColumns: []string{"dcol1", "dcol2"}}},
+					Fks: []ddl.Foreignkey{{Name: "fk_test3", Columns: []string{"ccol2", "ccol3"}, ReferTable: "dd", ReferColumns: []string{"dcol1", "dcol2"}}},
 				},
-				"dd": ddl.CreateTable{
+				"dd": {
 					Name:     "dd",
 					ColNames: []string{"dcol1", "ddcol2", "dcol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"dcol1":  ddl.ColumnDef{Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
-						"ddcol2": ddl.ColumnDef{Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
-						"dcol3":  ddl.ColumnDef{Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
+						"dcol1":  {Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
+						"ddcol2": {Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
+						"dcol3":  {Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
 					},
 				},
 			},
 			expectedSpSchema: map[string]ddl.CreateTable{
-				"cc": ddl.CreateTable{
+				"cc": {
 					Name:     "cc",
 					ColNames: []string{"ccol1", "ccol2", "ccol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"ccol1": ddl.ColumnDef{Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
-						"ccol2": ddl.ColumnDef{Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
-						"ccol3": ddl.ColumnDef{Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
+						"ccol1": {Name: "ccol1", T: ddl.Type{Name: ddl.Int64}},
+						"ccol2": {Name: "ccol2", T: ddl.Type{Name: ddl.Int64}},
+						"ccol3": {Name: "ccol3", T: ddl.Type{Name: ddl.Int64}},
 					},
 				},
-				"dd": ddl.CreateTable{
+				"dd": {
 					Name:     "dd",
 					ColNames: []string{"dcol1", "ddcol2", "dcol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"dcol1":  ddl.ColumnDef{Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
-						"ddcol2": ddl.ColumnDef{Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
-						"dcol3":  ddl.ColumnDef{Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
+						"dcol1":  {Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
+						"ddcol2": {Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
+						"dcol3":  {Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
 					},
 				},
 			},
@@ -282,25 +282,25 @@ func TestResolveRefs(t *testing.T) {
 		{
 			name: "Table name not found after lower case check",
 			spSchema: map[string]ddl.CreateTable{
-				"dd": ddl.CreateTable{
+				"dd": {
 					Name:     "dd",
 					ColNames: []string{"dcol1", "ddcol2", "dcol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"dcol1":  ddl.ColumnDef{Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
-						"ddcol2": ddl.ColumnDef{Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
-						"dcol3":  ddl.ColumnDef{Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
+						"dcol1":  {Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
+						"ddcol2": {Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
+						"dcol3":  {Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
 					},
-					Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test4", Columns: []string{"dcol3"}, ReferTable: "ee", ReferColumns: []string{"ecol1"}}},
+					Fks: []ddl.Foreignkey{{Name: "fk_test4", Columns: []string{"dcol3"}, ReferTable: "ee", ReferColumns: []string{"ecol1"}}},
 				},
 			},
 			expectedSpSchema: map[string]ddl.CreateTable{
-				"dd": ddl.CreateTable{
+				"dd": {
 					Name:     "dd",
 					ColNames: []string{"dcol1", "ddcol2", "dcol3"},
 					ColDefs: map[string]ddl.ColumnDef{
-						"dcol1":  ddl.ColumnDef{Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
-						"ddcol2": ddl.ColumnDef{Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
-						"dcol3":  ddl.ColumnDef{Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
+						"dcol1":  {Name: "dcol1", T: ddl.Type{Name: ddl.Int64}},
+						"ddcol2": {Name: "ddcol2", T: ddl.Type{Name: ddl.Int64}},
+						"dcol3":  {Name: "dcol3", T: ddl.Type{Name: ddl.Int64}},
 					},
 				},
 			},

--- a/mysql/mysqldump_test.go
+++ b/mysql/mysqldump_test.go
@@ -831,7 +831,7 @@ func TestProcessMySQLDump_GetDDL(t *testing.T) {
 	c := ddl.Config{Tables: true}
 	// normalizeSpace isn't perfect, but it handles most of the
 	// usual discretionary space issues.
-	assert.Equal(t, normalizeSpace(expected), normalizeSpace(strings.Join(conv.GetDDL(c), " ")))
+	assert.Equal(t, normalizeSpace(expected), normalizeSpace(strings.Join(conv.SpSchema.GetDDL(c), " ")))
 }
 
 func TestProcessMySQLDump_Rows(t *testing.T) {

--- a/postgres/pgdump_test.go
+++ b/postgres/pgdump_test.go
@@ -707,7 +707,7 @@ func TestProcessPgDump_GetDDL(t *testing.T) {
 	// normalizeSpace isn't perfect, but it handles most of the
 	// usual discretionary space issues.
 	c := ddl.Config{Tables: true}
-	assert.Equal(t, normalizeSpace(expected), normalizeSpace(strings.Join(conv.GetDDL(c), " ")))
+	assert.Equal(t, normalizeSpace(expected), normalizeSpace(strings.Join(conv.SpSchema.GetDDL(c), " ")))
 }
 
 func TestProcessPgDump_Rows(t *testing.T) {


### PR DESCRIPTION
- Resolves an existing TODO as well.
- Moves the test cases to spanner/ddl package
- Simplifies composite literal definition in some of the source files that were touched in this PR. For more context, please see https://golang.org/cmd/gofmt/#hdr-The_simplify_command.