### PR TITLE
#132: fix nil-pointer dereference crash on startup

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -1169,6 +1169,7 @@ func init() {
 		}
 		postgresTypeMap[srcType] = l
 	}
+	sessionState.conv = internal.MakeConv()
 }
 
 func WebApp() {

--- a/web/web_startup_test.go
+++ b/web/web_startup_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Test robustness of API calls on startup.
+// See https://github.com/cloudspannerecosystem/harbourbridge/issues/132.
+// Note that this test has to be in a standalone test file.
+func TestDdlOnStartup(t *testing.T) {
+	req, err := http.NewRequest("GET", "/ddl", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(getDDL)
+	handler.ServeHTTP(rr, req)
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+}


### PR DESCRIPTION
We don't initialize sessionState.conv on harbourbridge startup. Normally this isn't an issue because the standard web ui workflows will set it appropriately before it is accessed. However, if pages are accessed out of order, we can, for example, call getDDL with sessionState.conv set to nil and crash.

The fix is to initialize sessionState.conv in the web.go init function -- it is initialized to a valid (but empty) conv struct.