### PR TITLE
#136: fix: Handle non-boolean values for boolean columns.

### DIFF
--- a/mysql/data.go
+++ b/mysql/data.go
@@ -77,7 +77,7 @@ func ConvertData(conv *internal.Conv, srcTable string, srcCols []string, srcSche
 		if spColDef.T.IsArray {
 			x, err = convArray(spColDef.T, srcColDef.Type.Name, vals[i])
 		} else {
-			x, err = convScalar(spColDef.T, srcColDef.Type.Name, conv.TimezoneOffset, vals[i])
+			x, err = convScalar(conv, spColDef.T, srcColDef.Type.Name, conv.TimezoneOffset, vals[i])
 		}
 		if err != nil {
 			return "", []string{}, []interface{}{}, err
@@ -98,7 +98,7 @@ func ConvertData(conv *internal.Conv, srcTable string, srcCols []string, srcSche
 // appropriate Spanner value. It is the caller's responsibility to
 // detect and handle NULL values: convScalar will return error if a
 // NULL value is passed.
-func convScalar(spannerType ddl.Type, srcTypeName string, TimezoneOffset string, val string) (interface{}, error) {
+func convScalar(conv *internal.Conv, spannerType ddl.Type, srcTypeName string, TimezoneOffset string, val string) (interface{}, error) {
 	// Whitespace within the val string is considered part of the data value.
 	// Note that many of the underlying conversions functions we use (like
 	// strconv.ParseFloat and strconv.ParseInt) return "invalid syntax"
@@ -106,7 +106,7 @@ func convScalar(spannerType ddl.Type, srcTypeName string, TimezoneOffset string,
 	// We do not expect mysqldump to generate such output.
 	switch spannerType.Name {
 	case ddl.Bool:
-		return convBool(val)
+		return convBool(conv, val)
 	case ddl.Bytes:
 		return convBytes(val)
 	case ddl.Date:
@@ -126,9 +126,19 @@ func convScalar(spannerType ddl.Type, srcTypeName string, TimezoneOffset string,
 	}
 }
 
-func convBool(val string) (bool, error) {
+func convBool(conv *internal.Conv, val string) (bool, error) {
 	b, err := strconv.ParseBool(val)
 	if err != nil {
+		// MySQL allows non-boolean values in boolean columns.
+		// If we can't parse as boolean, try to re-parse as INT64
+		// and treat as true if value is non-zero.
+		// Note: if ParseBool fails, then val is probably a non-zero number.
+		i, err2 := convInt64(val)
+		if err2 == nil {
+			b = i != 0
+			conv.Unexpected(fmt.Sprintf("Expected boolean value, but found integer value %v; mapping it to %v\n", val, b))
+			return b, err2
+		}
 		return b, fmt.Errorf("can't convert to bool: %w", err)
 	}
 	return b, err

--- a/mysql/data_test.go
+++ b/mysql/data_test.go
@@ -74,7 +74,13 @@ func TestConvertData(t *testing.T) {
 		in    string      // Input value for conversion.
 		e     interface{} // Expected result.
 	}{
-		{"bool", ddl.Type{Name: ddl.Bool}, "", "1", true},
+		{"bool 0", ddl.Type{Name: ddl.Bool}, "", "0", false},
+		{"bool 1", ddl.Type{Name: ddl.Bool}, "", "1", true},
+		{"bool true", ddl.Type{Name: ddl.Bool}, "", "true", true},
+		{"bool false", ddl.Type{Name: ddl.Bool}, "", "false", false},
+		{"bool 5", ddl.Type{Name: ddl.Bool}, "", "5", true},
+		{"bool -128", ddl.Type{Name: ddl.Bool}, "", "-128", true},
+		{"bool 127", ddl.Type{Name: ddl.Bool}, "", "127", true},
 		{"bytes", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, "", string([]byte{137, 80}), []byte{0x89, 0x50}}, // need some other approach to testblob type
 		{"date", ddl.Type{Name: ddl.Date}, "", "2019-10-29", getDate("2019-10-29")},
 		{"float64", ddl.Type{Name: ddl.Float64}, "", "42.6", float64(42.6)},
@@ -226,6 +232,11 @@ func TestConvertError(t *testing.T) {
 			name: "Error in bool",
 			cols: []string{"a", "b", "c"},
 			vals: []string{"6", "6.6", "truee"},
+		},
+		{
+			name: "Error in bool 128",
+			cols: []string{"a", "b", "c"},
+			vals: []string{"6", "6.6", "128"},
 		},
 	}
 	tableName := "testtable"


### PR DESCRIPTION
This PR changes the behaviour during data conversion for boolean columns with non-boolean values: instead of generating an error, we now try to convert an int to a bool.

Old behaviour: HarbourBridge generates an error and rejects rows when boolean columns have non-boolean values.

New behaviour: We try to parse the value as an int64. If that succeeds, then we convert the int to a bool (0 maps to false, everything else maps to true), and we log an "unexpected" event detailing the conversion. If the conversion to int64 fails, the behavior is the same as current behaviour (we log an error and drop the row).

Closes #136 