### PR TITLE
Handle negative expressions e.g., negative int64, float64 column values in mysqldump parser

### DIFF
--- a/mysql/mysqldump.go
+++ b/mysql/mysqldump.go
@@ -757,7 +757,7 @@ func getNegativeUnaryVals(valExpr *driver.ValueExpr) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("unexpected UnaryOperationExpr with value %v", val)
 		}
-		return fmt.Sprintf("-%v", floatVal), nil
+		return fmt.Sprintf("%v", -1*floatVal), nil
 	default:
 		return "", fmt.Errorf("unexpected UnaryOperationExpr value with type %T", val)
 	}

--- a/mysql/mysqldump.go
+++ b/mysql/mysqldump.go
@@ -25,8 +25,8 @@ import (
 	"github.com/cloudspannerecosystem/harbourbridge/schema"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
-	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/parser/opcode"
+	"github.com/pingcap/tidb/types"
 	driver "github.com/pingcap/tidb/types/parser_driver"
 )
 
@@ -751,7 +751,7 @@ func getVals(row []ast.ExprNode) ([]string, error) {
 func getNegativeUnaryVals(valExpr *driver.ValueExpr) (string, error) {
 	switch val := valExpr.GetValue().(type) {
 	case int64:
-		return fmt.Sprintf("%v", -1 * val), nil
+		return fmt.Sprintf("%v", -1*val), nil
 	case *types.MyDecimal:
 		floatVal, err := val.ToFloat64()
 		if err != nil {

--- a/mysql/mysqldump_test.go
+++ b/mysql/mysqldump_test.go
@@ -738,6 +738,15 @@ CREATE TABLE test (a text PRIMARY KEY, b text);`,
 			expectedData: []spannerData{
 				spannerData{table: "test", cols: []string{"id", "a", "b", "c", "d"}, vals: []interface{}{int64(1), int64(88), int64(44), int64(22), float64(444.9876)}}},
 		},
+		{
+			name: "Data conversion: negative values for smallint, mediumint, bigint, double",
+			input: `
+	CREATE TABLE test (id integer PRIMARY KEY, a smallint, b mediumint, c bigint, d double);
+	INSERT INTO test (id, a, b, c, d) VALUES (-1, -88, -44, -22, -444.9876);
+	`,
+			expectedData: []spannerData{
+				spannerData{table: "test", cols: []string{"id", "a", "b", "c", "d"}, vals: []interface{}{int64(-1), int64(-88), int64(-44), int64(-22), float64(-444.9876)}}},
+		},
 		// test with different timezone
 		{
 			name: "Data conversion:  text, timestamp, datetime, varchar",


### PR DESCRIPTION
Pingcap parser that we use to parse mysqldump returns an AST node with type ValueExpr for positive int64 and float64 values. Whereas, for negative values it returns an UnaryExpression which contains the unary operator and the corresponding operand value. We are adding handling for for UnaryExpressions with Minus operator e.g., "-123" or "-123.456" such that the same can be converted to valid int64 and float64 column types in the intermediate representation. 

Before this change, mysqldump parser would simply drop these rows altogether.