### PR TITLE
Renaming a column then reverting to original name raises error in the UI

### DIFF
--- a/frontend/js/services/Action.service.js
+++ b/frontend/js/services/Action.service.js
@@ -544,6 +544,18 @@ const Actions = (() => {
                 'UpdateCols': {}
             }
             let newColArrayForDuplicateCheck = [];
+            let columnsNamesArray = [];
+            // We follow this approach to create columnsNamesArray to ensure the order of column names in the array is the consistent with what is seen in the UI.
+            // This is needed later on where we compare the array index with tableColumnNumber.
+            jQuery(tableId).each(function(index) {
+                if (index > 1) {
+                    let srcColumnName = document.getElementById('src-column-name-' + tableNumber + tableColumnNumber + tableColumnNumber).innerHTML;
+                    let originalColumnName = data.ToSpanner[tableName].Cols[srcColumnName];
+                    columnsNamesArray.push(originalColumnName)
+                    tableColumnNumber++;
+                }
+            });
+            tableColumnNumber = 0;
             jQuery(tableId).each(function(index) {
                 if (index > 1) {
                     let newColumnName;
@@ -562,7 +574,6 @@ const Actions = (() => {
                         errorMessage.push("Column name(s) cannot be empty");
                         columnNameEmpty = true;
                     } else {
-                        let columnsNamesArray = Object.keys(data.ToSpanner[tableName].Cols);
                         columnNameExists = false;
                         for (let k = 0; k < columnsNamesArray.length; k++) {
                             if (k != tableColumnNumber && newColumnName === columnsNamesArray[k]) {

--- a/frontend/puppeteerTest.js
+++ b/frontend/puppeteerTest.js
@@ -92,6 +92,11 @@ puppeteer.launch(config.launchOptions).then(async(browser) => {
     */
     await resumeSession(page);
 
+    /*
+    14. Rename a column then revert back to original name
+    */
+    await renameAndRevertColumnName(page);
+    
     // Close Browser
     await browser.close();
 });
@@ -558,6 +563,65 @@ const resumeSession = async(page) => {
     await page.waitForTimeout(200);
 
     await passed(13);
+};
+
+const renameAndRevertColumnName = async(page) => {
+    // expand customer table
+    await page.waitForSelector(homePage.customerTable);
+    await page.click(homePage.customerTable);
+
+    await page.waitForTimeout(200);
+
+    // click edit schema button
+    await page.waitForSelector(homePage.customerEditSchemaButton);
+    await page.click(homePage.customerEditSchemaButton);
+
+    await page.waitForTimeout(200);
+
+    // Change the value of the 6th column (566 means table 5 column 6, 0-indexed)
+    // from "active" to "changed"
+    await page.waitForSelector("input#column-name-text-566");
+    await page.evaluate(
+        () => (document.getElementById("column-name-text-566").value = "changed")
+    );
+
+    await page.waitForTimeout(200);
+
+    // click save schema
+    await page.waitForSelector(homePage.customerEditSchemaButton);
+    await page.click(homePage.customerEditSchemaButton);
+
+    await page.waitForTimeout(200);
+
+    // again click edit schema
+    await page.waitForSelector(homePage.customerEditSchemaButton);
+    await page.click(homePage.customerEditSchemaButton);
+
+    await page.waitForTimeout(200);
+
+    // change column name back to "active"
+    await page.waitForSelector("input#column-name-text-566");
+    await page.evaluate(
+        () => (document.getElementById("column-name-text-566").value = "active")
+    );
+
+    await page.waitForTimeout(200);
+
+    // click save
+    await page.waitForSelector(homePage.customerEditSchemaButton);
+    await page.click(homePage.customerEditSchemaButton);
+
+    try {
+        // wait for error message for 400 ms
+        await page.waitForSelector(homePage.errorModalButton, {timeout: 400});
+        // it reached here hence an error message popped up
+        await page.click(homePage.errorModalButton);
+        await console.log("Test Failed: ", 14)
+    } catch (e) {
+        // timeout occured hence there was no error message
+        await passed(14);
+    }
+
 };
 
 let arr = [];


### PR DESCRIPTION
Fixes #142 

The error came up due to the columnNamesList being in a different order from what is seen in the UI. This was due to converting the keys of the name map to array which messed up the order. 

The fix was to generate the columnNamesList by iterating the UI for columnNames ensuring the order is consistent.

Also added unit tests to simulate this.