### PR TITLE
Added flag to skip foreign key creation for the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ Any data in the source database will be ignored.
 A spanner database will be created based on the schema state provided
 by a session file (`-session`) and data will be migrated.
 
+`-skip-foreign-keys` Specifies that foreign key creation will be skipped after 
+data migration is complete. It cannot be used with schema-only mode. This flag does not 
+omit Foreign Key statements in the generated DDL.
+
 `-session` Specifies a session file that contains all schema and data 
 conversion state endcoded as JSON.
 

--- a/testing/mysql/integration_test.go
+++ b/testing/mysql/integration_test.go
@@ -118,7 +118,7 @@ func TestIntegration_MYSQLDUMP_SimpleUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open the test data file: %v", err)
 	}
-	err = cmd.CommandLine(conversion.MYSQLDUMP, projectID, instanceID, dbName, false, false, 0, "", &conversion.IOStreams{In: f, Out: os.Stdout}, filePrefix, now)
+	err = cmd.CommandLine(conversion.MYSQLDUMP, projectID, instanceID, dbName, false, false, false, 0, "", &conversion.IOStreams{In: f, Out: os.Stdout}, filePrefix, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestIntegration_MYSQL_SimpleUse(t *testing.T) {
 	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 
-	err := cmd.CommandLine(conversion.MYSQL, projectID, instanceID, dbName, false, false, 0, "", &conversion.IOStreams{Out: os.Stdout}, filePrefix, now)
+	err := cmd.CommandLine(conversion.MYSQL, projectID, instanceID, dbName, false, false, false, 0, "", &conversion.IOStreams{Out: os.Stdout}, filePrefix, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testing/postgres/integration_test.go
+++ b/testing/postgres/integration_test.go
@@ -120,7 +120,7 @@ func TestIntegration_PGDUMP_SimpleUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open the test data file: %v", err)
 	}
-	err = cmd.CommandLine(conversion.PGDUMP, projectID, instanceID, dbName, false, false, 0, "", &conversion.IOStreams{In: f, Out: os.Stdout}, filePrefix, now)
+	err = cmd.CommandLine(conversion.PGDUMP, projectID, instanceID, dbName, false, false, false, 0, "", &conversion.IOStreams{In: f, Out: os.Stdout}, filePrefix, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestIntegration_POSTGRES_SimpleUse(t *testing.T) {
 	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 
-	err := cmd.CommandLine(conversion.POSTGRES, projectID, instanceID, dbName, false, false, 0, "", &conversion.IOStreams{Out: os.Stdout}, filePrefix, now)
+	err := cmd.CommandLine(conversion.POSTGRES, projectID, instanceID, dbName, false, false, false, 0, "", &conversion.IOStreams{Out: os.Stdout}, filePrefix, now)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Throw an exception when both schema-only and skip-foreign-keys are set.
This flag does not omit the Foreign Key statements in the DDL.

Fixes 145 part 3
