### PR TITLE
Boilerplate code to run a dynamodb integration test

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -23,8 +23,14 @@ jobs:
       MYSQLDATABASE: test
       MYSQLPWD: root
 
+      # set DynamoDB related environment variables
+      AWS_ACCESS_KEY_ID: dummyId
+      AWS_SECRET_ACCESS_KEY: dummyKey
+      AWS_REGION: dummyRegion
+      DYNAMODB_ENDPOINT_OVERRIDE: http://localhost:8000
+
     services:
-      emulator:
+      spanner_emulator:
         image: gcr.io/cloud-spanner-emulator/emulator:1.2.0
         ports:
           - 9010:9010
@@ -48,6 +54,11 @@ jobs:
         - 3306:3306
         # needed because the mysql container does not provide a healthcheck
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      dynamodb_emulator:
+        image: amazon/dynamodb-local
+        ports:
+        - 8000:8000
+        options: --workdir /home/dynamodblocal --health-cmd "curl --fail http://127.0.0.1:8000/shell/ || exit 1" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - uses: actions/checkout@v2

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,7 +36,7 @@ var (
 // 2. Create database (if schemaOnly is set to false)
 // 3. Run data conversion (if schemaOnly is set to false)
 // 4. Generate report
-func CommandLine(driver, projectID, instanceID, dbName string, dataOnly, schemaOnly bool, skipForeignKeys bool, schemaSampleSize int64, sessionJSON string, ioHelper *conversion.IOStreams, outputFilePrefix string, now time.Time) error {
+func CommandLine(driver, projectID, instanceID, dbName string, dataOnly, schemaOnly, skipForeignKeys bool, schemaSampleSize int64, sessionJSON string, ioHelper *conversion.IOStreams, outputFilePrefix string, now time.Time) error {
 	var conv *internal.Conv
 	var err error
 	if !dataOnly {

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -43,6 +43,7 @@ import (
 	sp "cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	dydb "github.com/aws/aws-sdk-go/service/dynamodb"
 	_ "github.com/go-sql-driver/mysql"
@@ -216,7 +217,14 @@ func dataFromSQL(driver string, config spanner.BatchWriterConfig, client *sp.Cli
 func schemaFromDynamoDB(sampleSize int64) (*internal.Conv, error) {
 	conv := internal.MakeConv()
 	mySession := session.Must(session.NewSession())
-	client := dydb.New(mySession)
+	cfg := aws.Config{}
+	endpointOverride := os.Getenv("DYNAMODB_ENDPOINT_OVERRIDE")
+	if endpointOverride != "" {
+		cfg = aws.Config{
+			Endpoint: aws.String(endpointOverride),
+		}
+	}
+	client := dydb.New(mySession, &cfg)
 	err := dynamodb.ProcessSchema(conv, client, []string{}, sampleSize)
 	if err != nil {
 		return nil, err
@@ -226,8 +234,14 @@ func schemaFromDynamoDB(sampleSize int64) (*internal.Conv, error) {
 
 func dataFromDynamoDB(config spanner.BatchWriterConfig, client *sp.Client, conv *internal.Conv) (*spanner.BatchWriter, error) {
 	mySession := session.Must(session.NewSession())
-	dyclient := dydb.New(mySession)
-
+	cfg := aws.Config{}
+	endpointOverride := os.Getenv("DYNAMODB_ENDPOINT_OVERRIDE")
+	if endpointOverride != "" {
+		cfg = aws.Config{
+			Endpoint: aws.String(endpointOverride),
+		}
+	}
+	dyclient := dydb.New(mySession, &cfg)
 	dynamodb.SetRowStats(conv, dyclient)
 	totalRows := conv.Rows()
 	p := internal.NewProgress(totalRows, "Writing data to Spanner", internal.Verbose())

--- a/testing/dynamodb/integration_test.go
+++ b/testing/dynamodb/integration_test.go
@@ -1,0 +1,244 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynamodb_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cloudspannerecosystem/harbourbridge/cmd"
+	"github.com/cloudspannerecosystem/harbourbridge/conversion"
+
+	"cloud.google.com/go/spanner"
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"google.golang.org/api/iterator"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	dydb "github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	databasepb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+)
+
+var (
+	projectID  string
+	instanceID string
+
+	databaseAdmin *database.DatabaseAdminClient
+)
+
+// Create struct to hold info about new item in dynamodb
+type Item struct {
+	Year   string
+	Title  string
+	Plot   string
+	Rating float64
+}
+
+func TestMain(m *testing.M) {
+	cleanup := initIntegrationTests()
+	res := m.Run()
+	cleanup()
+	os.Exit(res)
+}
+
+func initIntegrationTests() (cleanup func()) {
+	projectID = os.Getenv("HARBOURBRIDGE_TESTS_GCLOUD_PROJECT_ID")
+	instanceID = os.Getenv("HARBOURBRIDGE_TESTS_GCLOUD_INSTANCE_ID")
+
+	ctx := context.Background()
+	flag.Parse() // Needed for testing.Short().
+	noop := func() {}
+
+	if testing.Short() {
+		log.Println("Integration tests skipped in -short mode.")
+		return noop
+	}
+
+	if projectID == "" {
+		log.Println("Integration tests skipped: HARBOURBRIDGE_TESTS_GCLOUD_PROJECT_ID is missing")
+		return noop
+	}
+
+	if instanceID == "" {
+		log.Println("Integration tests skipped: HARBOURBRIDGE_TESTS_GCLOUD_INSTANCE_ID is missing")
+		return noop
+	}
+
+	var err error
+	databaseAdmin, err = database.NewDatabaseAdminClient(ctx)
+	if err != nil {
+		log.Fatalf("cannot create databaseAdmin client: %v", err)
+	}
+
+	return func() {
+		databaseAdmin.Close()
+	}
+}
+
+func dropDatabase(t *testing.T, dbPath string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	// Drop the testing database.
+	if err := databaseAdmin.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: dbPath}); err != nil {
+		t.Fatalf("failed to drop testing database %v: %v", dbPath, err)
+	}
+}
+
+func prepareIntegrationTest(t *testing.T) string {
+	if databaseAdmin == nil {
+		t.Skip("Integration tests skipped")
+	}
+	tmpdir, err := ioutil.TempDir(".", "int-test-")
+	if err != nil {
+		log.Fatal(err)
+	}
+	populateDynamoDB(t)
+	return tmpdir
+}
+
+func populateDynamoDB(t *testing.T) {
+	cfg := aws.Config{
+		Endpoint: aws.String("http://localhost:8000"),
+	}
+	sess := session.Must(session.NewSession())
+	dydbClient := dydb.New(sess, &cfg)
+
+	tableName := "Movies"
+	createTableInput := &dydb.CreateTableInput{
+		AttributeDefinitions: []*dydb.AttributeDefinition{
+			{
+				AttributeName: aws.String("Year"),
+				AttributeType: aws.String("S"),
+			},
+			{
+				AttributeName: aws.String("Title"),
+				AttributeType: aws.String("S"),
+			},
+		},
+		KeySchema: []*dydb.KeySchemaElement{
+			{
+				AttributeName: aws.String("Year"),
+				KeyType:       aws.String("HASH"),
+			},
+			{
+				AttributeName: aws.String("Title"),
+				KeyType:       aws.String("RANGE"),
+			},
+		},
+		ProvisionedThroughput: &dydb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(10),
+			WriteCapacityUnits: aws.Int64(10),
+		},
+		TableName: aws.String(tableName),
+	}
+	_, err := dydbClient.CreateTable(createTableInput)
+	if err != nil {
+		t.Fatalf("Got error calling CreateTable: %s", err)
+	}
+
+	item := Item{
+		Year:   "2015",
+		Title:  "The Big New Movie",
+		Plot:   "Nothing happens at all.",
+		Rating: 0.0,
+	}
+	av, err := dynamodbattribute.MarshalMap(item)
+	if err != nil {
+		t.Fatalf("Got error marshalling new movie item: %s", err)
+	}
+
+	putItemInput := &dydb.PutItemInput{
+		Item:      av,
+		TableName: aws.String(tableName),
+	}
+
+	_, err = dydbClient.PutItem(putItemInput)
+	if err != nil {
+		t.Fatalf("Got error calling PutItem: %s", err)
+	}
+	log.Println("Successfully created table and put item for dynamodb")
+}
+
+func TestIntegration_DYNAMODB_SimpleUse(t *testing.T) {
+	onlyRunForEmulatorTest(t)
+	t.Parallel()
+
+	tmpdir := prepareIntegrationTest(t)
+	defer os.RemoveAll(tmpdir)
+
+	now := time.Now()
+	dbName, _ := conversion.GetDatabaseName(conversion.DYNAMODB, now)
+	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
+	filePrefix := filepath.Join(tmpdir, dbName+".")
+
+	err := cmd.CommandLine(conversion.DYNAMODB, projectID, instanceID, dbName, false, false, false, 0, "", &conversion.IOStreams{Out: os.Stdout}, filePrefix, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drop the database later.
+	defer dropDatabase(t, dbPath)
+
+	checkResults(t, dbPath)
+}
+
+func checkResults(t *testing.T, dbPath string) {
+	// Make a query to check results.
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, dbPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	checkBigInt(ctx, t, client)
+}
+
+func checkBigInt(ctx context.Context, t *testing.T, client *spanner.Client) {
+	stmt := spanner.Statement{SQL: `SELECT Year, Title, Plot FROM Movies`}
+	iter := client.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Println("Error reading row: ", err)
+			t.Fatal(err)
+			break
+		}
+		var year, title, plot string
+		if err := row.Columns(&year, &title, &plot); err != nil {
+			log.Println("Error reading into variables: ", err)
+			t.Fatal(err)
+			break
+		}
+		log.Printf("Found the following:\nYear: %s\nTitle: %s\nPlot: %s\n", year, title, plot)
+	}
+}
+
+func onlyRunForEmulatorTest(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("Skipping tests only running against the emulator.")
+	}
+}


### PR DESCRIPTION
Boilerplate code for DynamoDB tests to run a basic flow before adding proper test cases.
Currently the flow spins up a dynamodb container -> adds one row -> migrates to cloud spanner -> reads from the spanner instance.

Introduced the env variable DYNAMODB_ENDPOINT_OVERRIDE (specific to harbourbridge) to provide a custom endpoint for the dynamodb instance. By default, aws uses the AWS_REGION env variable to derive the endpoint (No env variable support from AWS to override the endpoint).