### PR TITLE
Added support for Secondary Indexes for dynamoDB

### DIFF
--- a/dynamodb/schema.go
+++ b/dynamodb/schema.go
@@ -128,13 +128,21 @@ func analyzeMetadata(client dynamoClient, s *schema.Table) error {
 		s.PrimaryKeys = append(s.PrimaryKeys, schema.Key{Column: *i.AttributeName})
 	}
 
-	// Secondary indexes
+	// Secondary indexes from GlobalSecondaryIndexes
 	for _, i := range result.Table.GlobalSecondaryIndexes {
 		var keys []schema.Key
 		for _, j := range i.KeySchema {
 			keys = append(keys, schema.Key{Column: *j.AttributeName})
 		}
-		// s.SecIndexes = append(s.SecIndexes, index{Name: *i.IndexName, Keys: keys})
+		s.Indexes = append(s.Indexes, schema.Index{Name: *i.IndexName, Keys: keys})
+	}
+
+	// Secondary indexes from LocalSecondaryIndexes
+	for _, i := range result.Table.LocalSecondaryIndexes {
+		var keys []schema.Key
+		for _, j := range i.KeySchema {
+			keys = append(keys, schema.Key{Column: *j.AttributeName})
+		}
 		s.Indexes = append(s.Indexes, schema.Index{Name: *i.IndexName, Keys: keys})
 	}
 

--- a/dynamodb/schema_test.go
+++ b/dynamodb/schema_test.go
@@ -396,9 +396,11 @@ func TestParseIndexes(t *testing.T) {
 	attrNameA := "a"
 	attrNameB := "b"
 	attrNameC := "c"
+	attrNameD := "d"
 	hashKeyType := "HASH"
 	sortKeyType := "RANGE"
-	indexName := "secondary_index_c"
+	globalIndexName := "secondary_index_c"
+	localIndexName := "secondary_index_d"
 	describeTableOutputs := []dynamodb.DescribeTableOutput{
 		{
 			Table: &dynamodb.TableDescription{
@@ -409,9 +411,17 @@ func TestParseIndexes(t *testing.T) {
 				},
 				GlobalSecondaryIndexes: []*dynamodb.GlobalSecondaryIndexDescription{
 					{
-						IndexName: &indexName,
+						IndexName: &globalIndexName,
 						KeySchema: []*dynamodb.KeySchemaElement{
 							{AttributeName: &attrNameC, KeyType: &hashKeyType},
+						},
+					},
+				},
+				LocalSecondaryIndexes: []*dynamodb.LocalSecondaryIndexDescription{
+					{
+						IndexName: &localIndexName,
+						KeySchema: []*dynamodb.KeySchemaElement{
+							{AttributeName: &attrNameD, KeyType: &hashKeyType},
 						},
 					},
 				},
@@ -430,7 +440,10 @@ func TestParseIndexes(t *testing.T) {
 
 	pKeys := []schema.Key{{Column: "a"}, {Column: "b"}}
 	assert.Equal(t, pKeys, dySchema.PrimaryKeys)
-	secIndexes := []schema.Index{{Name: "secondary_index_c", Keys: []schema.Key{{Column: "c"}}}}
+	secIndexes := []schema.Index{
+		{Name: "secondary_index_c", Keys: []schema.Key{{Column: "c"}}},
+		{Name: "secondary_index_d", Keys: []schema.Key{{Column: "d"}}},
+	}
 	assert.Equal(t, secIndexes, dySchema.Indexes)
 }
 

--- a/dynamodb/toddl_test.go
+++ b/dynamodb/toddl_test.go
@@ -44,8 +44,10 @@ func TestToSpannerType(t *testing.T) {
 			"k": {Name: "k", Type: schema.Type{Name: typeNumberStringSet}},
 		},
 		PrimaryKeys: []schema.Key{{Column: "a"}, {Column: "b"}},
-		Indexes: []schema.Index{{Name: "index1", Keys: []schema.Key{{Column: "b"}, {Column: "c"}}},
-			{Name: "index2", Keys: []schema.Key{{Column: "d"}}}},
+		Indexes: []schema.Index{
+			{Name: "index1", Keys: []schema.Key{{Column: "b"}, {Column: "c"}}},
+			{Name: "index2", Keys: []schema.Key{{Column: "d"}}},
+		},
 	}
 	conv.SrcSchema[name] = srcSchema
 	assert.Nil(t, schemaToDDL(conv))
@@ -68,8 +70,10 @@ func TestToSpannerType(t *testing.T) {
 			"k": {Name: "k", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength, IsArray: true}},
 		},
 		Pks: []ddl.IndexKey{{Col: "a"}, {Col: "b"}},
-		Indexes: []ddl.CreateIndex{{Name: "index1", Table: name, Keys: []ddl.IndexKey{{Col: "b"}, {Col: "c"}}},
-			{Name: "index2", Table: name, Keys: []ddl.IndexKey{{Col: "d"}}}},
+		Indexes: []ddl.CreateIndex{
+			{Name: "index1", Table: name, Keys: []ddl.IndexKey{{Col: "b"}, {Col: "c"}}},
+			{Name: "index2", Table: name, Keys: []ddl.IndexKey{{Col: "d"}}},
+		},
 	}
 	assert.Equal(t, expected, actual)
 }

--- a/dynamodb/toddl_test.go
+++ b/dynamodb/toddl_test.go
@@ -43,7 +43,10 @@ func TestToSpannerType(t *testing.T) {
 			"j": {Name: "j", Type: schema.Type{Name: typeNumberSet}},
 			"k": {Name: "k", Type: schema.Type{Name: typeNumberStringSet}},
 		},
-		PrimaryKeys: []schema.Key{{Column: "a"}, {Column: "b"}}}
+		PrimaryKeys: []schema.Key{{Column: "a"}, {Column: "b"}},
+		Indexes: []schema.Index{{Name: "index1", Keys: []schema.Key{{Column: "b"}, {Column: "c"}}},
+			{Name: "index2", Keys: []schema.Key{{Column: "d"}}}},
+	}
 	conv.SrcSchema[name] = srcSchema
 	assert.Nil(t, schemaToDDL(conv))
 	actual := conv.SpSchema[name]
@@ -65,6 +68,8 @@ func TestToSpannerType(t *testing.T) {
 			"k": {Name: "k", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength, IsArray: true}},
 		},
 		Pks: []ddl.IndexKey{{Col: "a"}, {Col: "b"}},
+		Indexes: []ddl.CreateIndex{{Name: "index1", Table: name, Keys: []ddl.IndexKey{{Col: "b"}, {Col: "c"}}},
+			{Name: "index2", Table: name, Keys: []ddl.IndexKey{{Col: "d"}}}},
 	}
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
We convert both global and local secondary indexes now. Earlier these were not converted.