### PR TITLE
Refactored context and database client

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ to set up your local development environment with authentication credentials.
 Set the GCLOUD_PROJECT environment variable to your Google Cloud project ID:
 
 ```sh
-export GCLOUD_PROJECT=[MY_PROJECT_ID]
+export GCLOUD_PROJECT=my-project-id
 ```
 
 If you do not already have a Cloud Spanner instance, or you want to use a
@@ -178,7 +178,7 @@ conversion), a session file and a bad data file (if any data was dropped).
 If you don't have ready access to a PostgreSQL or MySQL database, some example
 dump files can be found [here](examples). The files
 [cart.pg_dump](examples/cart.pg_dump) and
-[cart.mysqldump](examples/cart.mysqldump] contain pg_dump and mysqldump output
+[cart.mysqldump](examples/cart.mysqldump) contain pg_dump and mysqldump output
 for a very basic shopping cart application (just two tables, one for products
 and one for user carts). The files [singers.pg_dump](examples/singers.pg_dump)
 and [singers.mysqldump](examples/singers.mysqldump) contain pg_dump and

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func main() {
 
 		instance = instanceOverride
 		if instance == "" {
-			instance, err = conversion.GetInstance(project, ioHelper.Out)
+			instance, err = conversion.GetInstance(ctx, project, ioHelper.Out)
 			if err != nil {
 				fmt.Printf("\nCan't get instance: %v\n", err)
 				panic(fmt.Errorf("can't get instance"))
@@ -160,6 +160,7 @@ func main() {
 			panic(fmt.Errorf("can't get database name"))
 		}
 	}
+	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, dbName)
 
 	// If filePrefix not explicitly set, use dbName.
 	if filePrefix == "" {
@@ -168,7 +169,7 @@ func main() {
 
 	// TODO (agasheesh@): Collect all the config state in a single struct and pass the same to CommandLine instead of
 	// passing multiple parameters. Config state would be populated by parsing the flags and environment variables.
-	err = cmd.CommandLine(driverName, targetDb, project, instance, dbName, dataOnly, schemaOnly, skipForeignKeys, schemaSampleSize, sessionJSON, &ioHelper, filePrefix, now)
+	err = cmd.CommandLine(ctx, driverName, targetDb, dbURI, dataOnly, schemaOnly, skipForeignKeys, schemaSampleSize, sessionJSON, &ioHelper, filePrefix, now)
 	if err != nil {
 		panic(err)
 	}

--- a/testing/mysql/integration_test.go
+++ b/testing/mysql/integration_test.go
@@ -41,6 +41,7 @@ var (
 	projectID  string
 	instanceID string
 
+	ctx           context.Context
 	databaseAdmin *database.DatabaseAdminClient
 )
 
@@ -55,7 +56,7 @@ func initIntegrationTests() (cleanup func()) {
 	projectID = os.Getenv("HARBOURBRIDGE_TESTS_GCLOUD_PROJECT_ID")
 	instanceID = os.Getenv("HARBOURBRIDGE_TESTS_GCLOUD_INSTANCE_ID")
 
-	ctx := context.Background()
+	ctx = context.Background()
 	flag.Parse() // Needed for testing.Short().
 	noop := func() {}
 
@@ -85,12 +86,12 @@ func initIntegrationTests() (cleanup func()) {
 	}
 }
 
-func dropDatabase(t *testing.T, dbPath string) {
+func dropDatabase(t *testing.T, dbURI string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	// Drop the testing database.
-	if err := databaseAdmin.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: dbPath}); err != nil {
-		t.Fatalf("failed to drop testing database %v: %v", dbPath, err)
+	if err := databaseAdmin.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: dbURI}); err != nil {
+		t.Fatalf("failed to drop testing database %v: %v", dbURI, err)
 	}
 }
 
@@ -111,21 +112,21 @@ func TestIntegration_MYSQLDUMP_SimpleUse(t *testing.T) {
 
 	now := time.Now()
 	dbName, _ := conversion.GetDatabaseName(conversion.MYSQLDUMP, now)
-	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
+	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
 	dataFilepath := "../../test_data/mysqldump.test.out"
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 	f, err := os.Open(dataFilepath)
 	if err != nil {
 		t.Fatalf("failed to open the test data file: %v", err)
 	}
-	err = cmd.CommandLine(conversion.MYSQLDUMP, "spanner", projectID, instanceID, dbName, false, false, false, 0, "", &conversion.IOStreams{In: f, Out: os.Stdout}, filePrefix, now)
+	err = cmd.CommandLine(ctx, conversion.MYSQLDUMP, "spanner", dbURI, false, false, false, 0, "", &conversion.IOStreams{In: f, Out: os.Stdout}, filePrefix, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Drop the database later.
-	defer dropDatabase(t, dbPath)
+	defer dropDatabase(t, dbURI)
 
-	checkResults(t, dbPath)
+	checkResults(t, dbURI)
 }
 
 func TestIntegration_MYSQL_SimpleUse(t *testing.T) {
@@ -137,17 +138,17 @@ func TestIntegration_MYSQL_SimpleUse(t *testing.T) {
 
 	now := time.Now()
 	dbName, _ := conversion.GetDatabaseName(conversion.MYSQL, now)
-	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
+	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 
-	err := cmd.CommandLine(conversion.MYSQL, "spanner", projectID, instanceID, dbName, false, false, false, 0, "", &conversion.IOStreams{Out: os.Stdout}, filePrefix, now)
+	err := cmd.CommandLine(ctx, conversion.MYSQL, "spanner", dbURI, false, false, false, 0, "", &conversion.IOStreams{Out: os.Stdout}, filePrefix, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Drop the database later.
-	defer dropDatabase(t, dbPath)
+	defer dropDatabase(t, dbURI)
 
-	checkResults(t, dbPath)
+	checkResults(t, dbURI)
 }
 
 func runSchemaOnly(t *testing.T, dbName, filePrefix, sessionFile, dumpFilePath string) {
@@ -217,10 +218,9 @@ func TestIntegration_MySQLDUMP_DataOnly(t *testing.T) {
 	checkResults(t, dbURI)
 }
 
-func checkResults(t *testing.T, dbPath string) {
+func checkResults(t *testing.T, dbURI string) {
 	// Make a query to check results.
-	ctx := context.Background()
-	client, err := spanner.NewClient(ctx, dbPath)
+	client, err := spanner.NewClient(ctx, dbURI)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Changed parameters to pass context and database client rather than generating a new one each time.

Also modified parameters to use dbURI wherever possible rather than constructing a new one using project, instance and dbname.