### PR TITLE
Revert "Initial set of changes support existing dbs"

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -39,10 +39,6 @@ var (
 func CommandLine(driver, targetDb, projectID, instanceID, dbName string, dataOnly, schemaOnly, skipForeignKeys bool, schemaSampleSize int64, sessionJSON string, ioHelper *conversion.IOStreams, outputFilePrefix string, now time.Time) error {
 	var conv *internal.Conv
 	var err error
-	dbExists, err := conversion.VerifyDb(projectID, instanceID, dbName)
-	if err != nil {
-		return err
-	}
 	if !dataOnly {
 		conv, err = conversion.SchemaConv(driver, targetDb, ioHelper, schemaSampleSize)
 		if err != nil {
@@ -66,26 +62,30 @@ func CommandLine(driver, targetDb, projectID, instanceID, dbName string, dataOnl
 		}
 	}
 
-	dbURI, err := conversion.CreateOrUpdateDatabase(projectID, instanceID, dbName, dbExists, conv, ioHelper.Out)
+	db, err := conversion.CreateDatabase(projectID, instanceID, dbName, conv, ioHelper.Out)
 	if err != nil {
-		return fmt.Errorf("can't create/update database: %v", err)
+		fmt.Printf("\nCan't create database: %v\n", err)
+		return fmt.Errorf("can't create database")
 	}
 
-	client, err := conversion.GetClient(dbURI)
+	client, err := conversion.GetClient(db)
 	if err != nil {
-		return fmt.Errorf("can't create client for db %s: %v", dbURI, err)
+		fmt.Printf("\nCan't create client for db %s: %v\n", db, err)
+		return fmt.Errorf("can't create Spanner client")
 	}
 
 	bw, err := conversion.DataConv(driver, ioHelper, client, conv, dataOnly)
 	if err != nil {
-		return fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)
+		fmt.Printf("\nCan't finish data conversion for db %s: %v\n", db, err)
+		return fmt.Errorf("can't finish data conversion")
 	}
 	if !skipForeignKeys {
 		if err = conversion.UpdateDDLForeignKeys(projectID, instanceID, dbName, conv, ioHelper.Out); err != nil {
-			return fmt.Errorf("can't perform update schema on db %s with foreign keys: %v", dbURI, err)
+			fmt.Printf("\nCan't perform update operation on db %s with foreign keys: %v\n", db, err)
+			return fmt.Errorf("can't perform update schema with foreign keys")
 		}
 	}
-	banner := conversion.GetBanner(now, dbURI)
+	banner := conversion.GetBanner(now, db)
 	conversion.Report(driver, bw.DroppedRowsByTable(), ioHelper.BytesRead, banner, conv, outputFilePrefix+reportFile, ioHelper.Out)
 	conversion.WriteBadData(bw, conv, banner, outputFilePrefix+badDataFile, ioHelper.Out)
 	return nil

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -417,81 +417,12 @@ func getSeekable(f *os.File) (*os.File, int64, error) {
 	return fcopy, n, nil
 }
 
-// VerifyDb checks whether the db exists and if it does, verifies if the schema is what we currently support.
-func VerifyDb(project, instance, dbName string) (dbExists bool, err error) {
-	ctx := context.Background()
-	adminClient, err := database.NewDatabaseAdminClient(ctx)
-	if err != nil {
-		return false, fmt.Errorf("can't create admin client: %w", analyzeError(err, project, instance))
-	}
-	defer adminClient.Close()
-	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, dbName)
-	dbExists, err = CheckExistingDb(ctx, adminClient, dbURI)
-	if err != nil {
-		return dbExists, err
-	}
-	if dbExists {
-		err = ValidateDDL(ctx, adminClient, dbURI)
-	}
-	return dbExists, err
-}
-
-// CheckExistingDb checks whether the dbURI exists or not.
-func CheckExistingDb(ctx context.Context, adminClient *database.DatabaseAdminClient, dbURI string) (bool, error) {
-	_, err := adminClient.GetDatabase(ctx, &adminpb.GetDatabaseRequest{Name: dbURI})
-	if err != nil {
-		if containsAny(strings.ToLower(err.Error()), []string{"database not found"}) {
-			return false, nil
-		}
-		return false, fmt.Errorf("can't get database info: %s", err)
-	}
-	return true, nil
-}
-
-// ValidateDDL verifies if an existing DB's ddl follows what is supported by harbourbridge. Currently,
-// we only support empty schema when db already exists.
-func ValidateDDL(ctx context.Context, adminClient *database.DatabaseAdminClient, dbURI string) error {
-	dbDdl, err := adminClient.GetDatabaseDdl(ctx, &adminpb.GetDatabaseDdlRequest{Database: dbURI})
-	if err != nil {
-		return fmt.Errorf("can't fetch database ddl: %v", err)
-	}
-	if len(dbDdl.Statements) != 0 {
-		return fmt.Errorf("HarbourBridge supports writing to existing databases only if they have an empty schema")
-	}
-	return nil
-}
-
-func CreateOrUpdateDatabase(project, instance, dbName string, dbExists bool, conv *internal.Conv, out *os.File) (dbURI string, err error) {
-	ctx := context.Background()
-	adminClient, err := database.NewDatabaseAdminClient(ctx)
-	if err != nil {
-		return "", fmt.Errorf("can't create admin client: %w", analyzeError(err, project, instance))
-	}
-	defer adminClient.Close()
-
-	if dbExists {
-		dbURI, err = UpdateDatabase(project, instance, dbName, conv, out)
-		if err != nil {
-			fmt.Printf("\nCan't update database schema: %v\n", err)
-			return "", fmt.Errorf("can't update database schema")
-		}
-		return dbURI, nil
-	} else {
-		dbURI, err = CreateDatabase(project, instance, dbName, conv, out)
-		if err != nil {
-			fmt.Printf("\nCan't create database: %v\n", err)
-			return "", fmt.Errorf("can't create database")
-		}
-		return dbURI, nil
-	}
-}
-
 // CreateDatabase returns a newly create Spanner DB.
 // It automatically determines an appropriate project, selects a
 // Spanner instance to use, generates a new Spanner DB name,
 // and call into the Spanner admin interface to create the new DB.
 func CreateDatabase(project, instance, dbName string, conv *internal.Conv, out *os.File) (string, error) {
-	fmt.Fprintf(out, "Creating new database %s in instance %s with default permissions ... \n", dbName, instance)
+	fmt.Fprintf(out, "Creating new database %s in instance %s with default permissions ... ", dbName, instance)
 	ctx := context.Background()
 	adminClient, err := database.NewDatabaseAdminClient(ctx)
 	if err != nil {
@@ -513,33 +444,8 @@ func CreateDatabase(project, instance, dbName string, conv *internal.Conv, out *
 	if _, err := op.Wait(ctx); err != nil {
 		return "", fmt.Errorf("createDatabase call failed: %w", analyzeError(err, project, instance))
 	}
-	fmt.Fprintf(out, "Created database successfully.\n")
+	fmt.Fprintf(out, "done.\n")
 	return fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, dbName), nil
-}
-
-// UpdateDatabase updates the DDL of the spanner DB and return the path.
-func UpdateDatabase(project, instance, dbName string, conv *internal.Conv, out *os.File) (string, error) {
-	fmt.Fprintf(out, "Updating schema for database %s in instance %s ... \n", dbName, instance)
-	ctx := context.Background()
-	adminClient, err := database.NewDatabaseAdminClient(ctx)
-	if err != nil {
-		return "", fmt.Errorf("can't create admin client: %w", analyzeError(err, project, instance))
-	}
-	defer adminClient.Close()
-
-	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, dbName)
-	op, err := adminClient.UpdateDatabaseDdl(ctx, &adminpb.UpdateDatabaseDdlRequest{
-		Database:   dbURI,
-		Statements: conv.SpSchema.GetDDL(ddl.Config{Comments: false, ProtectIds: true, Tables: true, ForeignKeys: false}),
-	})
-	if err != nil {
-		return "", fmt.Errorf("can't submit update schema request: %s", err)
-	}
-	if err := op.Wait(ctx); err != nil {
-		return "", fmt.Errorf("can't update schema statement: %s", err)
-	}
-	fmt.Fprintf(out, "Updated schema successfully.\n")
-	return dbURI, nil
 }
 
 // UpdateDDLForeignKeys updates the Spanner database with foreign key
@@ -548,7 +454,7 @@ func UpdateDDLForeignKeys(project, instance, dbName string, conv *internal.Conv,
 	ctx := context.Background()
 	adminClient, err := database.NewDatabaseAdminClient(ctx)
 	if err != nil {
-		return fmt.Errorf("can't create admin client: %w", analyzeError(err, project, instance))
+		return fmt.Errorf("can't create admin client: %w\n", analyzeError(err, project, instance))
 	}
 	defer adminClient.Close()
 

--- a/testing/conversion/conversion_test.go
+++ b/testing/conversion/conversion_test.go
@@ -41,7 +41,6 @@ var (
 	projectID  string
 	instanceID string
 
-	ctx           context.Context
 	databaseAdmin *database.DatabaseAdminClient
 )
 
@@ -56,7 +55,7 @@ func initTests() (cleanup func()) {
 	projectID = os.Getenv("HARBOURBRIDGE_TESTS_GCLOUD_PROJECT_ID")
 	instanceID = os.Getenv("HARBOURBRIDGE_TESTS_GCLOUD_INSTANCE_ID")
 
-	ctx = context.Background()
+	ctx := context.Background()
 	flag.Parse() // Needed for testing.Short().
 	noop := func() {}
 
@@ -95,11 +94,8 @@ func dropDatabase(t *testing.T, dbPath string) {
 	}
 }
 
-func BuildConv(t *testing.T, numCols, numFks int, makeEmpty bool) *internal.Conv {
+func BuildConv(t *testing.T, numCols, numFks int) *internal.Conv {
 	conv := internal.MakeConv()
-	if makeEmpty {
-		return conv
-	}
 	colNames := []string{}
 	colDefs := map[string]ddl.ColumnDef{}
 	for i := 1; i <= numCols; i++ {
@@ -135,6 +131,7 @@ func BuildConv(t *testing.T, numCols, numFks int, makeEmpty bool) *internal.Conv
 }
 
 func checkResults(t *testing.T, dbpath string, numFks int) {
+	ctx := context.Background()
 	resp, err := databaseAdmin.GetDatabaseDdl(ctx, &databasepb.GetDatabaseDdlRequest{Database: dbpath})
 	if err != nil {
 		t.Fatalf("Could not read DDL from database %s: %v", dbpath, err)
@@ -173,7 +170,7 @@ func checkResults(t *testing.T, dbpath string, numFks int) {
 func TestUpdateDDLForeignKeys(t *testing.T) {
 	onlyRunForEmulatorTest(t)
 	t.Parallel()
-	testCases := []struct {
+	foreignKeyTests := []struct {
 		dbName     string
 		numCols    int // Number of columns in the table.
 		numFks     int // Number of foreign keys we want to add (ensure it is not greater than numCols).
@@ -183,8 +180,8 @@ func TestUpdateDDLForeignKeys(t *testing.T) {
 		{"test-workers-ten-fks", 10, 10, 1},
 	}
 
-	for _, tc := range testCases {
-		conv := BuildConv(t, tc.numCols, tc.numFks, false)
+	for _, tc := range foreignKeyTests {
+		conv := BuildConv(t, tc.numCols, tc.numFks)
 		dbpath, err := conversion.CreateDatabase(projectID, instanceID, tc.dbName, conv, os.Stdout)
 		if err != nil {
 			t.Fatal(err)
@@ -197,91 +194,6 @@ func TestUpdateDDLForeignKeys(t *testing.T) {
 		checkResults(t, dbpath, tc.numFks)
 		// Drop the database later.
 		defer dropDatabase(t, dbpath)
-	}
-}
-
-func TestVerifyDb(t *testing.T) {
-	onlyRunForEmulatorTest(t)
-
-	testCases := []struct {
-		dbName      string
-		dbExists    bool
-		emptySchema bool
-	}{
-		{"verifydb-exists-schema", true, false},
-		{"verifydb-exists-noschema", true, true},
-		{"verifydb-does-not-exist", false, true},
-	}
-
-	for _, tc := range testCases {
-		if tc.dbExists {
-			dbURI, err := conversion.CreateDatabase(projectID, instanceID, tc.dbName, BuildConv(t, 2, 0, tc.emptySchema), os.Stdout)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer dropDatabase(t, dbURI)
-			dbExists, err := conversion.VerifyDb(projectID, instanceID, tc.dbName)
-			assert.True(t, dbExists)
-			if tc.emptySchema {
-				assert.Nil(t, err)
-			} else {
-				assert.NotNil(t, err)
-			}
-		} else {
-			dbExists, err := conversion.VerifyDb(projectID, instanceID, tc.dbName)
-			assert.Nil(t, err)
-			assert.False(t, dbExists)
-		}
-
-	}
-}
-
-func TestCheckExistingDb(t *testing.T) {
-	onlyRunForEmulatorTest(t)
-
-	dbURI, err := conversion.CreateDatabase(projectID, instanceID, "check-db-exists", internal.MakeConv(), os.Stdout)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer dropDatabase(t, dbURI)
-	testCases := []struct {
-		dbName   string
-		dbExists bool
-	}{
-		{"check-db-exists", true},
-		{"check-db-does-not-exist", false},
-	}
-
-	for _, tc := range testCases {
-		dbExists, err := conversion.CheckExistingDb(ctx, databaseAdmin, fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, tc.dbName))
-		assert.Nil(t, err)
-		assert.Equal(t, tc.dbExists, dbExists)
-	}
-}
-
-func TestValidateDDL(t *testing.T) {
-	onlyRunForEmulatorTest(t)
-
-	testCases := []struct {
-		dbName      string
-		emptySchema bool
-	}{
-		{"validate-ddl-empty-schema", true},
-		{"validate-ddl-non-empty-schema", false},
-	}
-
-	for _, tc := range testCases {
-		dbURI, err := conversion.CreateDatabase(projectID, instanceID, tc.dbName, BuildConv(t, 2, 0, tc.emptySchema), os.Stdout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer dropDatabase(t, dbURI)
-		err = conversion.ValidateDDL(ctx, databaseAdmin, dbURI)
-		if tc.emptySchema {
-			assert.Nil(t, err)
-		} else {
-			assert.NotNil(t, err)
-		}
 	}
 }
 


### PR DESCRIPTION
Reverts cloudspannerecosystem/harbourbridge#163.

Fails the smoke test when running a simple HarbourBridge command from command line.

$ go build main.go
$ ./main -schema_only < "any schema"

```
panic: can't get database info: rpc error: code = InvalidArgument desc = Invalid GetDatabase request.

goroutine 1 [running]:
main.main()
	/usr/local/google/home/<>/harbourbridge/main.go:157 +0x75a
exit status 2
```