### PR TITLE
Fix integration test failing intermittently 

### DIFF
--- a/test_data/mysqldump.test.out
+++ b/test_data/mysqldump.test.out
@@ -44,13 +44,13 @@ INSERT INTO `cart` VALUES ('901e-a6cfc2b502dc','abc-123',1,'2020-07-20 05:10:26'
 UNLOCK TABLES;
 
 --
--- Table name `CART` differs only case from the table `cart`.
+-- Table name `PRODUCTS` differs only case from the table `cart`.
 -- This was added to cover more cases in our integration tests.
 --
-DROP TABLE IF EXISTS `CART`;
+DROP TABLE IF EXISTS `PRODUCTS`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `CART` (
+CREATE TABLE `PRODUCTS` (
   `usr_id` varchar(20) NOT NULL,
   `prod_id` varchar(20) NOT NULL,
   PRIMARY KEY (`usr_id`,`prod_id`)

--- a/testing/mysql/integration_test.go
+++ b/testing/mysql/integration_test.go
@@ -156,8 +156,8 @@ func runSchemaOnly(t *testing.T, dbName, filePrefix, sessionFile, dumpFilePath s
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Printf("stdout: %q\n", out.String())
-		fmt.Printf("stderr: %q\n", stderr.String())
+		log.Printf("stdout: %q\n", out.String())
+		log.Printf("stderr: %q\n", stderr.String())
 		t.Fatal(err)
 	}
 }
@@ -171,8 +171,8 @@ func runDataOnly(t *testing.T, dbName, dbURI, filePrefix, sessionFile, dumpFileP
 		fmt.Sprintf("GCLOUD_PROJECT=%s", projectID),
 	)
 	if err := cmd.Run(); err != nil {
-		fmt.Printf("stdout: %q\n", out.String())
-		fmt.Printf("stderr: %q\n", stderr.String())
+		log.Printf("stdout: %q\n", out.String())
+		log.Printf("stderr: %q\n", stderr.String())
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Due to a previous change, where another table `CART` was added to the integration test dump file, the integration tests fail intermittently.  As part of our conversion, we append a number to the table names to make them unique. This behaviour is non-deterministic i.e sometime the number is appended to `cart` and sometimes `CART`. We do a hardcoded check for the column `cart`(quantity) during our validations in our tests so during the runs when for ex, cart becomes cart_1, it checks for the column quantity in CART since for spanner, the names differing only in case are same. Due to this, we sometimes get the error quantity col does not exist in CART.