### PR TITLE
added -verbose flag to meet gcloud criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ the driver is _'pg_dump'_.
 written by the tool. If no file prefix is specified, the name of the Spanner
 database (plus a '.') is used.
 
-`-v` Specifies verbose mode. This will cause HarbourBridge to output detailed
+`-v` or `-verbose` Specifies verbose mode. This will cause HarbourBridge to output detailed
 messages about the conversion.
 
 `-schema-only` Specifies that only schema processing will be performed.

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func setupGlobalFlags() {
 	flag.StringVar(&driverName, "driver", "pg_dump", "driver name: flag for accessing source DB or dump files (accepted values are \"pg_dump\", \"postgres\", \"mysqldump\", and \"mysql\")")
 	flag.Int64Var(&schemaSampleSize, "schema-sample-size", int64(100000), "schema-sample-size: the number of rows to use for inferring schema (only for DynamoDB)")
 	flag.BoolVar(&verbose, "v", false, "verbose: print additional output")
+	flag.BoolVar(&verbose, "verbose", false, "verbose: print additional output")
 	flag.BoolVar(&schemaOnly, "schema-only", false, "schema-only: in this mode we do schema conversion, but skip data conversion")
 	flag.BoolVar(&dataOnly, "data-only", false, "data-only: in this mode we skip schema conversion and just do data conversion (use the session flag to specify the session file for schema and data mapping)")
 	flag.BoolVar(&skipForeignKeys, "skip-foreign-keys", false, "skip-foreign-keys: if true, skip creating foreign keys after data migration is complete (ddl statements for foreign keys can still be found in the downloaded schema.ddl.txt file and the same can be applied separately)")


### PR DESCRIPTION
Current verbose flag `-v` does not meet gCloud guidelines (one letter flags aren't allowed), thus I added support for a `-verbose` flag.

HarbourBridge will support both flags, however gCloud will only support `-verbose`.

- [ x] Tests pass
- [ x] Appropriate changes to README are included in PR