### PR TITLE
Updated spanner emulator version

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -31,7 +31,7 @@ jobs:
 
     services:
       spanner_emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.2.0
+        image: gcr.io/cloud-spanner-emulator/emulator:1.3.0
         ports:
           - 9010:9010
           - 9020:9020

--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -31,7 +31,7 @@ jobs:
 
     services:
       spanner_emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.3.0
+        image: gcr.io/cloud-spanner-emulator/emulator:1.4.0
         ports:
           - 9010:9010
           - 9020:9020

--- a/test_data/mysqldump.test.out
+++ b/test_data/mysqldump.test.out
@@ -88,6 +88,32 @@ LOCK TABLES `products` WRITE;
 INSERT INTO `products` VALUES ('abc-123','Blue suede shoes',141.99,'2020-06-06'),('axd-673','Antique typewriter',99.99,'2020-06-07'),('zxi-631','Glass vase',55.50,'2020-06-10');
 /*!40000 ALTER TABLE `products` ENABLE KEYS */;
 UNLOCK TABLES;
+
+--
+-- Table structure for table `customers`
+--
+
+DROP TABLE IF EXISTS `customers`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `customers` (
+  `c_id` varchar(20) NOT NULL,
+  `customer_profile` JSON DEFAULT NULL,
+  PRIMARY KEY (`c_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `customers`
+--
+
+LOCK TABLES `customers` WRITE;
+/*!40000 ALTER TABLE `customers` DISABLE KEYS */;
+INSERT INTO `customers` VALUES 
+('svd-124','{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'),
+('tel-595','{"first_name": "Ernie", "status": "Looking for treats", "location" : "Brooklyn"}');
+/*!40000 ALTER TABLE `customers` ENABLE KEYS */;
+UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/test_data/mysqldump.test.out
+++ b/test_data/mysqldump.test.out
@@ -98,7 +98,7 @@ DROP TABLE IF EXISTS `customers`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `customers` (
   `c_id` varchar(20) NOT NULL,
-  `customer_profile` JSON DEFAULT NULL,
+  `customer_profile` json DEFAULT NULL,
   PRIMARY KEY (`c_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/testing/mysql/integration_test.go
+++ b/testing/mysql/integration_test.go
@@ -22,12 +22,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/cloudspannerecosystem/harbourbridge/common/utils"
 	"github.com/cloudspannerecosystem/harbourbridge/testing/common"
+	"github.com/stretchr/testify/assert"
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -341,6 +343,7 @@ func checkResults(t *testing.T, dbURI string) {
 	defer client.Close()
 
 	checkBigInt(ctx, t, client)
+	checkJson(ctx, t, client, dbURI)
 }
 
 func checkBigInt(ctx context.Context, t *testing.T, client *spanner.Client) {
@@ -362,6 +365,27 @@ func checkBigInt(ctx context.Context, t *testing.T, client *spanner.Client) {
 	if got, want := quantity, int64(1); got != want {
 		t.Fatalf("quantities are not correct: got %v, want %v", got, want)
 	}
+}
+
+func checkJson(ctx context.Context, t *testing.T, client *spanner.Client, dbURI string) {
+	resp, err := databaseAdmin.GetDatabaseDdl(ctx, &databasepb.GetDatabaseDdlRequest{Database: dbURI})
+	if err != nil {
+		t.Fatalf("Could not read DDL from database %s: %v", dbURI, err)
+	}
+	for _, stmt := range resp.Statements {
+		if strings.Contains(stmt, "CREATE TABLE customers") {
+			assert.True(t, strings.Contains(stmt, "customer_profile JSON"))
+		}
+	}
+	stmt := spanner.Statement{
+		SQL: `SELECT COUNT(*) FROM customers`,
+	}
+	iter := client.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	row, _ := iter.Next()
+	var rowCount int64 = 0
+	row.Columns(&rowCount)
+	assert.Equal(t, 2, rowCount)
 }
 
 func onlyRunForEmulatorTest(t *testing.T) {


### PR DESCRIPTION
We skip JSON checks for interleaved tables (becuase taht uses a different dump) and for direct connect tests (because we use mariadb:10.3 which does not support JSON type, it instead converts it to longtext).