### PR TITLE
Use source profile connection params for direct connect in subcommand…

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,8 @@ func CommandLine(ctx context.Context, driver, targetDb, dbURI string, dataOnly, 
 	var conv *internal.Conv
 	var err error
 	if !dataOnly {
+		// We pass an empty string to the sqlConnectionStr parameter as this is the legacy codepath,
+		// which reads the environment variables and constructs the string later on.
 		conv, err = conversion.SchemaConv(driver, "", targetDb, ioHelper, schemaSampleSize)
 		if err != nil {
 			return err
@@ -77,6 +79,8 @@ func CommandLine(ctx context.Context, driver, targetDb, dbURI string, dataOnly, 
 		return fmt.Errorf("can't create client for db %s: %v", dbURI, err)
 	}
 
+	// We pass an empty string to the sqlConnectionStr parameter as this is the legacy codepath,
+	// which reads the environment variables and constructs the string later on.
 	bw, err := conversion.DataConv(driver, "", ioHelper, client, conv, dataOnly)
 	if err != nil {
 		return fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -77,7 +77,7 @@ func CommandLine(ctx context.Context, driver, targetDb, dbURI string, dataOnly, 
 		return fmt.Errorf("can't create client for db %s: %v", dbURI, err)
 	}
 
-	bw, err := conversion.DataConv(driver, ioHelper, client, conv, dataOnly)
+	bw, err := conversion.DataConv(driver, "", ioHelper, client, conv, dataOnly)
 	if err != nil {
 		return fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,7 +41,7 @@ func CommandLine(ctx context.Context, driver, targetDb, dbURI string, dataOnly, 
 	var conv *internal.Conv
 	var err error
 	if !dataOnly {
-		conv, err = conversion.SchemaConv(driver, targetDb, ioHelper, schemaSampleSize)
+		conv, err = conversion.SchemaConv(driver, "", targetDb, ioHelper, schemaSampleSize)
 		if err != nil {
 			return err
 		}

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -128,21 +128,8 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 		err = fmt.Errorf("can't create/update database: %v", err)
 		return subcommands.ExitFailure
 	}
-	sqlConnectionStr := ""
-	if sourceProfile.ty == SourceProfileTypeConnection {
-		// For DynamoDB, the SDK only reads credentials from env variables.
-		// There is no way to pass them through the code hence, don't need to override
-		// sqlConnectionStr for DynamoDB.
-		if sourceProfile.conn.ty == SourceProfileConnectionTypeMySQL {
-			connParams := sourceProfile.conn.mysql
-			sqlConnectionStr = conversion.GetMYSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
-		} else if sourceProfile.conn.ty == SourceProfileConnectionTypePostgreSQL {
-			connParams := sourceProfile.conn.pg
-			sqlConnectionStr = conversion.GetPGSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
-		}
-	}
 
-	bw, err := conversion.DataConv(driverName, sqlConnectionStr, &ioHelper, client, conv, true)
+	bw, err := conversion.DataConv(driverName, getSQLConnectionStr(sourceProfile), &ioHelper, client, conv, true)
 	if err != nil {
 		err = fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)
 		return subcommands.ExitFailure

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -128,8 +128,21 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 		err = fmt.Errorf("can't create/update database: %v", err)
 		return subcommands.ExitFailure
 	}
+	sqlConnectionStr := ""
+	if sourceProfile.ty == SourceProfileTypeConnection {
+		// For DynamoDB, the SDK only reads credentials from env variables.
+		// There is no way to pass them through the code hence, don't need to override
+		// sqlConnectionStr for DynamoDB.
+		if sourceProfile.conn.ty == SourceProfileConnectionTypeMySQL {
+			connParams := sourceProfile.conn.mysql
+			sqlConnectionStr = conversion.GetMYSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
+		} else if sourceProfile.conn.ty == SourceProfileConnectionTypePostgreSQL {
+			connParams := sourceProfile.conn.pg
+			sqlConnectionStr = conversion.GetPGSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
+		}
+	}
 
-	bw, err := conversion.DataConv(driverName, &ioHelper, client, conv, true)
+	bw, err := conversion.DataConv(driverName, sqlConnectionStr, &ioHelper, client, conv, true)
 	if err != nil {
 		err = fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)
 		return subcommands.ExitFailure

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -95,15 +95,23 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	}
 
 	schemaSampleSize := int64(100000)
+	driverConfig := ""
 	if sourceProfile.ty == SourceProfileTypeConnection {
 		if sourceProfile.conn.ty == SourceProfileConnectionTypeDynamoDB {
 			if sourceProfile.conn.dydb.schemaSampleSize != 0 {
 				schemaSampleSize = sourceProfile.conn.dydb.schemaSampleSize
 			}
+		} else if sourceProfile.conn.ty == SourceProfileConnectionTypeMySQL {
+			connParams := sourceProfile.conn.mysql
+			driverConfig = conversion.MySQLDriverConfigStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
+		} else {
+			connParams := sourceProfile.conn.pg
+			driverConfig = conversion.PGDriverConfigStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
 		}
 	}
+
 	var conv *internal.Conv
-	conv, err = conversion.SchemaConv(driverName, targetDb, &ioHelper, schemaSampleSize)
+	conv, err = conversion.SchemaConv(driverName, driverConfig, targetDb, &ioHelper, schemaSampleSize)
 	if err != nil {
 		return subcommands.ExitFailure
 	}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -94,27 +94,8 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 		cmd.filePrefix = dbName + "."
 	}
 
-	schemaSampleSize := int64(100000)
-	sqlConnectionStr := ""
-	if sourceProfile.ty == SourceProfileTypeConnection {
-		if sourceProfile.conn.ty == SourceProfileConnectionTypeDynamoDB {
-			if sourceProfile.conn.dydb.schemaSampleSize != 0 {
-				schemaSampleSize = sourceProfile.conn.dydb.schemaSampleSize
-			}
-			// For DynamoDB, the SDK only reads credentials from env variables.
-			// There is no way to pass them through the code hence, don't need to override
-			// sqlConnectionStr for DynamoDB.
-		} else if sourceProfile.conn.ty == SourceProfileConnectionTypeMySQL {
-			connParams := sourceProfile.conn.mysql
-			sqlConnectionStr = conversion.GetMYSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
-		} else {
-			connParams := sourceProfile.conn.pg
-			sqlConnectionStr = conversion.GetPGSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
-		}
-	}
-
 	var conv *internal.Conv
-	conv, err = conversion.SchemaConv(driverName, sqlConnectionStr, targetDb, &ioHelper, schemaSampleSize)
+	conv, err = conversion.SchemaConv(driverName, getSQLConnectionStr(sourceProfile), targetDb, &ioHelper, getSchemaSampleSize(sourceProfile))
 	if err != nil {
 		return subcommands.ExitFailure
 	}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -101,6 +101,9 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 			if sourceProfile.conn.dydb.schemaSampleSize != 0 {
 				schemaSampleSize = sourceProfile.conn.dydb.schemaSampleSize
 			}
+			// For DynamoDB, the SDK only reads credentials from env variables.
+			// There is no way to pass them through the code hence, don't need to override
+			// driver config for DynamoDB.
 		} else if sourceProfile.conn.ty == SourceProfileConnectionTypeMySQL {
 			connParams := sourceProfile.conn.mysql
 			driverConfig = conversion.MySQLDriverConfigStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -95,7 +95,7 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	}
 
 	schemaSampleSize := int64(100000)
-	driverConfig := ""
+	sqlConnectionStr := ""
 	if sourceProfile.ty == SourceProfileTypeConnection {
 		if sourceProfile.conn.ty == SourceProfileConnectionTypeDynamoDB {
 			if sourceProfile.conn.dydb.schemaSampleSize != 0 {
@@ -103,18 +103,18 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 			}
 			// For DynamoDB, the SDK only reads credentials from env variables.
 			// There is no way to pass them through the code hence, don't need to override
-			// driver config for DynamoDB.
+			// sqlConnectionStr for DynamoDB.
 		} else if sourceProfile.conn.ty == SourceProfileConnectionTypeMySQL {
 			connParams := sourceProfile.conn.mysql
-			driverConfig = conversion.MySQLDriverConfigStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
+			sqlConnectionStr = conversion.GetMYSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
 		} else {
 			connParams := sourceProfile.conn.pg
-			driverConfig = conversion.PGDriverConfigStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
+			sqlConnectionStr = conversion.GetPGSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
 		}
 	}
 
 	var conv *internal.Conv
-	conv, err = conversion.SchemaConv(driverName, driverConfig, targetDb, &ioHelper, schemaSampleSize)
+	conv, err = conversion.SchemaConv(driverName, sqlConnectionStr, targetDb, &ioHelper, schemaSampleSize)
 	if err != nil {
 		return subcommands.ExitFailure
 	}

--- a/cmd/source_profile.go
+++ b/cmd/source_profile.go
@@ -168,7 +168,7 @@ func NewSourceProfileConnectionDynamoDB(params map[string]string) (SourceProfile
 		// No connection params provided through source-profile. Fetching from env variables.
 		fmt.Printf("Connection parameters not specified in source-profile. Reading from " +
 			"environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, DYNAMODB_ENDPOINT_OVERRIDE(optional)...\n")
-		//Don't need to do anything as they are handled later.
+		// Don't need to do anything as they are handled later.
 	} else if idOk && keyOk && regionOk {
 		// Override env variables for these params as source-profile takes precedence.
 		os.Setenv("AWS_ACCESS_KEY_ID", awsAccessKeyID)

--- a/cmd/source_profile.go
+++ b/cmd/source_profile.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
+	"github.com/cloudspannerecosystem/harbourbridge/conversion"
 )
 
 type SourceProfileType int
@@ -56,24 +57,47 @@ type SourceProfileConnectionMySQL struct {
 }
 
 func NewSourceProfileConnectionMySQL(params map[string]string) SourceProfileConnectionMySQL {
-	// TODO: Move parsing of environment variables in this function.
 	mysql := SourceProfileConnectionMySQL{}
 	if host, ok := params["host"]; ok {
 		mysql.host = host
+	} else {
+		mysql.host = os.Getenv("MYSQLHOST")
 	}
+
 	if port, ok := params["port"]; ok {
 		mysql.port = port
-	} else { // Set default port for mysql, which rarely changes.
-		mysql.port = "3306"
+	} else {
+		mysql.port = os.Getenv("MYSQLPORT")
+		if mysql.port == "" {
+			// Set default port for mysql, which rarely changes.
+			mysql.port = "3306"
+		}
 	}
+
 	if user, ok := params["user"]; ok {
 		mysql.user = user
+	} else {
+		mysql.user = os.Getenv("MYSQLUSER")
 	}
+
 	if db, ok := params["db_name"]; ok {
 		mysql.db = db
+	} else {
+		mysql.db = os.Getenv("MYSQLDATABASE")
 	}
+
+	if mysql.host == "" || mysql.port == "" || mysql.user == "" || mysql.db == "" {
+		fmt.Printf("Please specify host, port, user and database either in the source profile or using MYSQLHOST, MYSQLPORT, MYSQLUSER and MYSQLDATABASE environment variables.\n")
+		// TODO: Throw error earlier here.
+	}
+
 	if pwd, ok := params["password"]; ok {
 		mysql.pwd = pwd
+	} else {
+		mysql.pwd = os.Getenv("MYSQLPWD")
+		if mysql.pwd == "" {
+			mysql.pwd = conversion.GetPassword()
+		}
 	}
 	return mysql
 }
@@ -90,20 +114,44 @@ func NewSourceProfileConnectionPostgreSQL(params map[string]string) SourceProfil
 	pg := SourceProfileConnectionPostgreSQL{}
 	if host, ok := params["host"]; ok {
 		pg.host = host
+	} else {
+		pg.host = os.Getenv("PGHOST")
 	}
+
 	if port, ok := params["port"]; ok {
 		pg.port = port
-	} else { // Set default port for postgresql, which rarely changes.
-		pg.port = "5432"
+	} else {
+		pg.port = os.Getenv("PGPORT")
+		if pg.port == "" {
+			// Set default port for postgresql, which rarely changes.
+			pg.port = "5432"
+		}
 	}
+
 	if user, ok := params["user"]; ok {
 		pg.user = user
+	} else {
+		pg.user = os.Getenv("PGUSER")
 	}
+
 	if db, ok := params["db_name"]; ok {
 		pg.db = db
+	} else {
+		pg.db = os.Getenv("PGDATABASE")
 	}
+
+	if pg.host == "" || pg.port == "" || pg.user == "" || pg.db == "" {
+		fmt.Printf("Please specify host, port, user and database either in the source profile or using PGHOST, PGPORT, PGUSER and PGDATABASE environment variables.\n")
+		// TODO: Throw error earlier here.
+	}
+
 	if pwd, ok := params["password"]; ok {
 		pg.pwd = pwd
+	} else {
+		pg.pwd = os.Getenv("PGPASSWORD")
+		if pg.pwd == "" {
+			pg.pwd = conversion.GetPassword()
+		}
 	}
 	return pg
 }

--- a/cmd/source_profile.go
+++ b/cmd/source_profile.go
@@ -175,9 +175,12 @@ func NewSourceProfileConnectionDynamoDB(params map[string]string) (SourceProfile
 		os.Setenv("AWS_SECRET_ACCESS_KEY", awsSecretAccessKey)
 		os.Setenv("AWS_REGION", awsRegion)
 		// Endpoint is optional. If not provided, the SDK infers endpoint from AWS_REGION.
-		if endpointOk {
-			os.Setenv("DYNAMODB_ENDPOINT_OVERRIDE", dydbEndpoint)
+		// We should explicitly set it to "" if not provided to handle the case
+		// when the user already has an env variable DYNAMODB_ENDPOINT_OVERRIDE.
+		if !endpointOk {
+			dydbEndpoint = ""
 		}
+		os.Setenv("DYNAMODB_ENDPOINT_OVERRIDE", dydbEndpoint)
 	} else {
 		return dydb, fmt.Errorf("please specify awsAccessKeyID, awsSecretAccessKey, awsRegion in the source-profile")
 

--- a/cmd/source_profile_test.go
+++ b/cmd/source_profile_test.go
@@ -128,21 +128,6 @@ func TestNewSourceProfileConnectionDynamoDB(t *testing.T) {
 			params:        map[string]string{"schemaSampleSize": "a"},
 			errorExpected: true,
 		},
-		{
-			name:          "no mandatory params but optional provided",
-			params:        map[string]string{"dydbEndpoint": "b"},
-			errorExpected: true,
-		},
-		{
-			name:          "partial mandatory params",
-			params:        map[string]string{"awsRegion": "a"},
-			errorExpected: true,
-		},
-		{
-			name:          "partial mandatory params and optional provided",
-			params:        map[string]string{"awsAccessKeyID": "a", "dydbEndpoint": "b"},
-			errorExpected: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/source_profile_test.go
+++ b/cmd/source_profile_test.go
@@ -53,3 +53,100 @@ func TestNewSourceProfileFile(t *testing.T) {
 		assert.Equal(t, profile, tc.want, tc.name)
 	}
 }
+
+func TestNewSourceProfileConnectionSQL(t *testing.T) {
+	// Avoid getting/settinng env variables in the unit tests.
+	testCases := []struct {
+		name          string
+		params        map[string]string
+		errorExpected bool
+	}{
+		{
+			name:          "mandatory params provided",
+			params:        map[string]string{"host": "a", "user": "b", "db_name": "c", "password": "e"},
+			errorExpected: false,
+		},
+		{
+			name:          "partial mandatory params provided",
+			params:        map[string]string{"user": "b", "db_name": "c"},
+			errorExpected: true,
+		},
+		{
+			name:          "no mandatory params but optional provided",
+			params:        map[string]string{"port": "b"},
+			errorExpected: true,
+		},
+		{
+			name:          "partial mandatory params and optional provided",
+			params:        map[string]string{"host": "a", "port": "b"},
+			errorExpected: true,
+		},
+		{
+			name:          "all params provided",
+			params:        map[string]string{"host": "a", "user": "b", "db_name": "c", "port": "d", "password": "e"},
+			errorExpected: false,
+		},
+		{
+			name:          "empty mandatory param",
+			params:        map[string]string{"host": "", "user": "b", "db_name": "c"},
+			errorExpected: true,
+		},
+		{
+			name:          "empty port",
+			params:        map[string]string{"host": "a", "user": "b", "db_name": "c", "password": "e"},
+			errorExpected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, pgErr := NewSourceProfileConnectionPostgreSQL(tc.params)
+		_, mysqlErr := NewSourceProfileConnectionMySQL(tc.params)
+		assert.Equal(t, tc.errorExpected, pgErr != nil)
+		assert.Equal(t, tc.errorExpected, mysqlErr != nil)
+	}
+}
+
+func TestNewSourceProfileConnectionDynamoDB(t *testing.T) {
+	// Avoid getting/settinng env variables in the unit tests.
+	testCases := []struct {
+		name          string
+		params        map[string]string
+		errorExpected bool
+	}{
+		{
+			name:          "no params",
+			params:        map[string]string{},
+			errorExpected: false,
+		},
+		{
+			name:          "valid schema sample size",
+			params:        map[string]string{"schemaSampleSize": "15"},
+			errorExpected: false,
+		},
+		{
+			name:          "invalid schema sample size",
+			params:        map[string]string{"schemaSampleSize": "a"},
+			errorExpected: true,
+		},
+		{
+			name:          "no mandatory params but optional provided",
+			params:        map[string]string{"dydbEndpoint": "b"},
+			errorExpected: true,
+		},
+		{
+			name:          "partial mandatory params",
+			params:        map[string]string{"awsRegion": "a"},
+			errorExpected: true,
+		},
+		{
+			name:          "partial mandatory params and optional provided",
+			params:        map[string]string{"awsAccessKeyID": "a", "dydbEndpoint": "b"},
+			errorExpected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := NewSourceProfileConnectionDynamoDB(tc.params)
+		assert.Equal(t, tc.errorExpected, err != nil)
+	}
+}

--- a/cmd/target_profile.go
+++ b/cmd/target_profile.go
@@ -39,7 +39,7 @@ type TargetProfile struct {
 	conn TargetProfileConnection
 }
 
-// ToLegacyTargetDb converts source profile to equivalent legacy global flag
+// ToLegacyTargetDb converts source-profile to equivalent legacy global flag
 // -target-db etc since the rest of the codebase still uses the same.
 // TODO: Deprecate this function and pass around TargetProfile across the
 // codebase wherever information about target connection is required.

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -130,7 +130,7 @@ func pgDriverConfig() (string, error) {
 	}
 	password := os.Getenv("PGPASSWORD")
 	if password == "" {
-		password = getPassword()
+		password = GetPassword()
 	}
 	return PGDriverConfigStr(server, port, user, password, dbname), nil
 }
@@ -150,7 +150,7 @@ func mysqlDriverConfig() (string, error) {
 	}
 	password := os.Getenv("MYSQLPWD")
 	if password == "" {
-		password = getPassword()
+		password = GetPassword()
 	}
 	return MySQLDriverConfigStr(server, port, user, password, dbname), nil
 }
@@ -887,7 +887,7 @@ func GetDatabaseName(driver string, now time.Time) (string, error) {
 	return generateName(fmt.Sprintf("%s_%s", driver, now.Format("2006-01-02")))
 }
 
-func getPassword() string {
+func GetPassword() string {
 	fmt.Print("Enter Password: ")
 	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -171,8 +171,8 @@ func getDbNameFromSQLConnectionStr(driver, sqlConnectionStr string) string {
 }
 
 // TODO: Pass around cmd.SourceProfile instead of sqlConnectionStr.
-// Doing that requires refactoring since that woul dintroduce a circular dependency between
-// conversion.go and cmd/source_profile.go
+// Doing that requires refactoring since that would introduce a circular dependency between
+// conversion.go and cmd/source_profile.go.
 func schemaFromSQL(driver, sqlConnectionStr, targetDb string) (*internal.Conv, error) {
 	if sqlConnectionStr == "" {
 		// If empty, this is called as part of the old command line workflow.

--- a/internal/convert.go
+++ b/internal/convert.go
@@ -28,6 +28,7 @@ type Conv struct {
 	SpSchema       ddl.Schema                          // Maps Spanner table name to Spanner schema.
 	SyntheticPKeys map[string]SyntheticPKey            // Maps Spanner table name to synthetic primary key (if needed).
 	SrcSchema      map[string]schema.Table             // Maps source-DB table name to schema information.
+	SrcDbName      string                              // Name of the source database. Currently only used for mysql infoschema.
 	Issues         map[string]map[string][]SchemaIssue // Maps source-DB table/col to list of schema conversion issues.
 	ToSpanner      map[string]NameAndCols              // Maps from source-DB table name to Spanner name and column mapping.
 	ToSource       map[string]NameAndCols              // Maps from Spanner table name to source-DB table name and column mapping.

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func main() {
 	}
 	fmt.Printf("\nWarning: Found usage of deprecated flags. Support for these " +
 		"flags will be discontinued soon. It is recommended to use Harbourbridge " +
-		"in subcommand mode with connection profiles.\n\n")
+		"using connection profiles. Checkout usage here: https://github.com/cloudspannerecosystem/harbourbridge/tree/master/cmd#command-line-flags\n\n")
 	// Running HB CLI in global command line mode.
 	setupGlobalFlags()
 	flag.Usage = usage

--- a/main.go
+++ b/main.go
@@ -111,6 +111,9 @@ func main() {
 		flag.Parse()
 		os.Exit(int(subcommands.Execute(ctx)))
 	}
+	fmt.Printf("\nWarning: Found usage of deprecated flags. Support for these " +
+		"flags will be discontinued soon. It is recommended to use Harbourbridge " +
+		"in subcommand mode.\n\n")
 	// Running HB CLI in global command line mode.
 	setupGlobalFlags()
 	flag.Usage = usage

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func main() {
 	}
 	fmt.Printf("\nWarning: Found usage of deprecated flags. Support for these " +
 		"flags will be discontinued soon. It is recommended to use Harbourbridge " +
-		"in subcommand mode.\n\n")
+		"in subcommand mode with connection profiles.\n\n")
 	// Running HB CLI in global command line mode.
 	setupGlobalFlags()
 	flag.Usage = usage

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func main() {
 		os.Exit(int(subcommands.Execute(ctx)))
 	}
 	fmt.Printf("\nWarning: Found usage of deprecated flags. Support for these " +
-		"flags will be discontinued soon. It is recommended to use Harbourbridge " +
+		"flags will be discontinued soon.\nIt is recommended to use Harbourbridge " +
 		"using connection profiles. Checkout usage here: https://github.com/cloudspannerecosystem/harbourbridge/tree/master/cmd#command-line-flags\n\n")
 	// Running HB CLI in global command line mode.
 	setupGlobalFlags()

--- a/sources/dynamodb/README.md
+++ b/sources/dynamodb/README.md
@@ -42,7 +42,7 @@ harbourbridge -driver=dynamodb -schema-sample-size=500000
 
 The HarbourBridge tool maps DynamoDB types to Spanner types as follows:
 
-| PostgreSQL Type    | Spanner Type               | Notes                                     |
+| DynamoDB Type    | Spanner Type               | Notes                                     |
 | ------------------ | -------------------------- | ----------------------------------------- |
 | `Number`           | `NUMERIC` or `STRING`      | defaults to NUMERIC, otherwise, STRING    |
 | `String`           | `STRING`                   |                                           |

--- a/testing/common/testutil.go
+++ b/testing/common/testutil.go
@@ -27,3 +27,20 @@ func RunCommand(args string, projectID string) error {
 	}
 	return nil
 }
+
+// Clears the env variables specified in the input list and stashes the values
+// in a map.
+func ClearEnvVariables(vars []string) map[string]string {
+	envVars := make(map[string]string)
+	for _, v := range vars {
+		envVars[v] = os.Getenv(v)
+		os.Setenv(v, "")
+	}
+	return envVars
+}
+
+func RestoreEnvVariables(params map[string]string) {
+	for k, v := range params {
+		os.Setenv(k, v)
+	}
+}

--- a/testing/mysql/integration_test.go
+++ b/testing/mysql/integration_test.go
@@ -126,21 +126,6 @@ func TestIntegration_MYSQLDUMP_Command(t *testing.T) {
 	checkResults(t, dbURI)
 }
 
-func clearEnvVariables(vars []string) map[string]string {
-	envVars := make(map[string]string)
-	for _, v := range vars {
-		envVars[v] = os.Getenv(v)
-		os.Setenv(v, "")
-	}
-	return envVars
-}
-
-func restoreEnvVariables(params map[string]string) {
-	for k, v := range params {
-		os.Setenv(k, v)
-	}
-}
-
 func TestIntegration_MySQL_EvalSubcommand(t *testing.T) {
 	onlyRunForEmulatorTest(t)
 	t.Parallel()
@@ -153,10 +138,10 @@ func TestIntegration_MySQL_EvalSubcommand(t *testing.T) {
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 
 	host, user, db_name, password := os.Getenv("MYSQLHOST"), os.Getenv("MYSQLUSER"), os.Getenv("MYSQLDATABASE"), os.Getenv("MYSQLPWD")
-	envVars := clearEnvVariables([]string{"MYSQLHOST", "MYSQLUSER", "MYSQLDATABASE", "MYSQLPWD"})
+	envVars := common.ClearEnvVariables([]string{"MYSQLHOST", "MYSQLUSER", "MYSQLDATABASE", "MYSQLPWD"})
 	args := fmt.Sprintf("eval -source=%s -prefix=%s -source-profile='host=%s,user=%s,db_name=%s,password=%s' -target-profile='instance=%s,dbname=%s'", constants.MYSQL, filePrefix, host, user, db_name, password, instanceID, dbName)
 	err := common.RunCommand(args, projectID)
-	restoreEnvVariables(envVars)
+	common.RestoreEnvVariables(envVars)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testing/mysql/integration_test.go
+++ b/testing/mysql/integration_test.go
@@ -126,6 +126,21 @@ func TestIntegration_MYSQLDUMP_Command(t *testing.T) {
 	checkResults(t, dbURI)
 }
 
+func clearEnvVariables(vars []string) map[string]string {
+	envVars := make(map[string]string)
+	for _, v := range vars {
+		envVars[v] = os.Getenv(v)
+		os.Setenv(v, "")
+	}
+	return envVars
+}
+
+func restoreEnvVariables(params map[string]string) {
+	for k, v := range params {
+		os.Setenv(k, v)
+	}
+}
+
 func TestIntegration_MySQL_EvalSubcommand(t *testing.T) {
 	onlyRunForEmulatorTest(t)
 	t.Parallel()
@@ -138,8 +153,10 @@ func TestIntegration_MySQL_EvalSubcommand(t *testing.T) {
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 
 	host, user, db_name, password := os.Getenv("MYSQLHOST"), os.Getenv("MYSQLUSER"), os.Getenv("MYSQLDATABASE"), os.Getenv("MYSQLPWD")
+	envVars := clearEnvVariables([]string{"MYSQLHOST", "MYSQLUSER", "MYSQLDATABASE", "MYSQLPWD"})
 	args := fmt.Sprintf("eval -source=%s -prefix=%s -source-profile='host=%s,user=%s,db_name=%s,password=%s' -target-profile='instance=%s,dbname=%s'", constants.MYSQL, filePrefix, host, user, db_name, password, instanceID, dbName)
 	err := common.RunCommand(args, projectID)
+	restoreEnvVariables(envVars)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testing/mysql/integration_test.go
+++ b/testing/mysql/integration_test.go
@@ -126,6 +126,29 @@ func TestIntegration_MYSQLDUMP_Command(t *testing.T) {
 	checkResults(t, dbURI)
 }
 
+func TestIntegration_MySQL_EvalSubcommand(t *testing.T) {
+	onlyRunForEmulatorTest(t)
+	t.Parallel()
+
+	tmpdir := prepareIntegrationTest(t)
+	defer os.RemoveAll(tmpdir)
+
+	dbName := "mysql-dc-eval-src-params"
+	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
+	filePrefix := filepath.Join(tmpdir, dbName+".")
+
+	host, user, db_name, password := os.Getenv("MYSQLHOST"), os.Getenv("MYSQLUSER"), os.Getenv("MYSQLDATABASE"), os.Getenv("MYSQLPWD")
+	args := fmt.Sprintf("eval -source=%s -prefix=%s -source-profile='host=%s,user=%s,db_name=%s,password=%s' -target-profile='instance=%s,dbname=%s'", constants.MYSQL, filePrefix, host, user, db_name, password, instanceID, dbName)
+	err := common.RunCommand(args, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drop the database later.
+	defer dropDatabase(t, dbURI)
+
+	checkResults(t, dbURI)
+}
+
 func TestIntegration_MYSQL_Command(t *testing.T) {
 	onlyRunForEmulatorTest(t)
 	t.Parallel()

--- a/web/web.go
+++ b/web/web.go
@@ -168,7 +168,7 @@ func convertSchemaDump(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("failed to open dump file %v : %v", dc.FilePath, err), http.StatusNotFound)
 		return
 	}
-	conv, err := conversion.SchemaConv(dc.Driver, constants.TARGET_SPANNER, &conversion.IOStreams{In: f, Out: os.Stdout}, 0)
+	conv, err := conversion.SchemaConv(dc.Driver, "", constants.TARGET_SPANNER, &conversion.IOStreams{In: f, Out: os.Stdout}, 0)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Schema Conversion Error : %v", err), http.StatusNotFound)
 		return


### PR DESCRIPTION
Refactor the **driverConfig** variable to **sqlConnectionStr** which is a more suitable name and avoids clashes.

For schema, data and eval in subcommand mode, we can pass the sqlConnectionStr throughout as a parameter. 

If `sqlConnectionStr == ""`,  it means user is running HB in legacy mode. We follow the original flow then where the params are fetched from env variables.

In subcommand mode i.e. `sqlConnectionStr != ""`, the expectation is user will provide all connection params in the source-profile. If host/user/dbname are missing, we throw an error asking to specify those. If the user does not provide any flag (to support backward compatibility), we read the params from env variables. This is only temporary and will be removed once we fully switch to subcommand mode.

For DynamoDB, the code path is kept same as before because the SDK itself only supports reading from the env variables. We cannot specify credentials in the go client.