### PR TITLE
Replace instructions to run HarbourBridge with git clone and go run

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,34 +123,39 @@ variable if it is not already configured using
 
 ### Installing HarbourBridge
 
-Download the tool to your machine and install it.
+You can make a copy of the HarbourBridge codebase from the github repository
+and use "go run":
 
 ```sh
-GO111MODULE=on go get github.com/cloudspannerecosystem/harbourbridge
+git clone https://github.com/cloudspannerecosystem/harbourbridge
+cd harbourbridge
+pg_dump mydb | go run github.com/cloudspannerecosystem/harbourbridge -driver=pg_dump
 ```
 
-The tool should now be installed as `$GOPATH/bin/harbourbridge`.
-See the [Troubleshooting Guide](#troubleshooting-guide) if you run
-into any issues.
+```
+alias harbourbridge="go run github.com/cloudspannerecosystem/harbourbridge"
+```
+
+This workflow also allows you to modify or customize the HarbourBridge codebase.
 
 ### Running HarbourBridge
 
 To use the tool on a PostgreSQL database called mydb, run
 
 ```sh
-pg_dump mydb | $GOPATH/bin/harbourbridge -driver=pg_dump
+pg_dump mydb | harbourbridge -driver=pg_dump
 ```
 
 To use the tool on a MySQL database called mydb, run
 
 ```sh
-mysqldump mydb | $GOPATH/bin/harbourbridge -driver=mysqldump
+mysqldump mydb | harbourbridge -driver=mysqldump
 ```
 
 To use the tool on a DynamoDB database, run
 
 ```sh
-$GOPATH/bin/harbourbridge -driver=dynamodb
+harbourbridge -driver=dynamodb
 ```
 More details on running harbourbridge can be found in [Example usage](#example-usage) section.
 
@@ -189,7 +194,7 @@ example. To use HarbourBridge on cart.pg_dump, download the file locally and
 run
 
 ```
-$GOPATH/bin/harbourbridge -driver=pg_dump < cart.pg_dump
+harbourbridge -driver=pg_dump < cart.pg_dump
 ```
 
 ### Verifying Results
@@ -337,27 +342,6 @@ data conversion can be found here:
 - [DynamoDB data conversion](sources/dynamodb/README.md#data-conversion)
 
 ## Troubleshooting Guide
-
-HarbourBridge is written using the Go module system, and so it must be
-installed in [module-aware mode](https://golang.org/cmd/go/#hdr-Module_support).
-This can be achived by setting the environment variable `GO111MODULE` to `on`
-before calling "go get" e.g.
-
-```sh
-GO111MODULE=on go get github.com/cloudspannerecosystem/harbourbridge
-```
-
-As an alternative to "go get", you can make a copy of the HarbourBridge
-codebase from the github repository and use "go run":
-
-```sh
-git clone https://github.com/cloudspannerecosystem/harbourbridge
-cd harbourbridge
-pg_dump mydb | go run github.com/cloudspannerecosystem/harbourbridge -driver=pg_dump
-
-```
-
-This workflow also allows you to modify or customize the HarbourBridge codebase.
 
 The following steps can help diagnose common issues encountered while running
 HarbourBridge.

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ and use "go run":
 ```sh
 git clone https://github.com/cloudspannerecosystem/harbourbridge
 cd harbourbridge
-pg_dump mydb | go run github.com/cloudspannerecosystem/harbourbridge -driver=pg_dump
+go run github.com/cloudspannerecosystem/harbourbridge -driver=pg_dump < my_pg_dump_file
 ```
 
-```
+```sh
 alias harbourbridge="go run github.com/cloudspannerecosystem/harbourbridge"
 ```
 

--- a/sources/dynamodb/README.md
+++ b/sources/dynamodb/README.md
@@ -7,8 +7,14 @@ HarbourBridge information see this [README](https://github.com/cloudspannerecosy
 
 ## Example DynamoDB Usage
 
-The following examples assume `harbourbridge` has been added to your PATH
-environment variable.
+The following examples assume `harbourbridge` alias has been setup as
+following.
+
+```sh
+git clone https://github.com/cloudspannerecosystem/harbourbridge
+cd harbourbridge
+alias harbourbridge="go run github.com/cloudspannerecosystem/harbourbridge"
+```
 
 Before running HarbourBridge, make sure that you have
 [set up your AWS credentials/region](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)

--- a/sources/mysql/README.md
+++ b/sources/mysql/README.md
@@ -7,8 +7,14 @@ see this [README](https://github.com/cloudspannerecosystem/harbourbridge#harbour
 
 ## Example MySQL Usage
 
-The following examples assume `harbourbridge` has been added to your PATH
-environment variable.
+The following examples assume `harbourbridge` alias has been setup as
+following.
+
+```sh
+git clone https://github.com/cloudspannerecosystem/harbourbridge
+cd harbourbridge
+alias harbourbridge="go run github.com/cloudspannerecosystem/harbourbridge"
+```
 
 HarbourBridge can either be used with mysqldump or it can be run directly
 on a MySQL database (via go's database/sql package).

--- a/sources/postgres/README.md
+++ b/sources/postgres/README.md
@@ -7,8 +7,14 @@ see this [README](https://github.com/cloudspannerecosystem/harbourbridge#harbour
 
 ## Example PostgreSQL Usage
 
-The following examples assume `harbourbridge` has been added to your PATH
-environment variable.
+The following examples assume `harbourbridge` alias has been setup as
+following.
+
+```sh
+git clone https://github.com/cloudspannerecosystem/harbourbridge
+cd harbourbridge
+alias harbourbridge="go run github.com/cloudspannerecosystem/harbourbridge"
+```
 
 HarbourBridge can either be used with pg_dump or it can be run directly
 on a PostgreSQL database (via go's database/sql package).

--- a/web/README.md
+++ b/web/README.md
@@ -8,8 +8,14 @@ schema assistant is currently in alpha release.
 
 ### Starting web server for HarbourBridge
 
-The following example assume `harbourbridge` has been added to your PATH
-environment variable.
+The following examples assume `harbourbridge` alias has been setup as
+following.
+
+```sh
+git clone https://github.com/cloudspannerecosystem/harbourbridge
+cd harbourbridge
+alias harbourbridge="go run github.com/cloudspannerecosystem/harbourbridge"
+```
 
 HarbourBridge's Web API feature can be used with all the driver modes available,
 using mysql or postgres dump or direct connection.


### PR DESCRIPTION
`go install` or `go get` commands require that go.mod doesn't have replace directives and thus the current instructions don't work anymore. Thus, we are now switching to recommend that customers only use git clone mechanism to setup and install HarbourBridge.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR