### PR TITLE
Add double quotes around the database name for PG Spanner

### DIFF
--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -567,7 +567,7 @@ func CreateDatabase(ctx context.Context, adminClient *database.DatabaseAdminClie
 		// a) backticks around the database name, and
 		// b) DDL statements as part of a CreateDatabase operation (so schema
 		// must be set using a separate UpdateDatabase operation).
-		req.CreateStatement = "CREATE DATABASE " + dbName
+		req.CreateStatement = "CREATE DATABASE \"" + dbName + "\""
 		req.DatabaseDialect = adminpb.DatabaseDialect_POSTGRESQL
 	} else {
 		req.CreateStatement = "CREATE DATABASE `" + dbName + "`"


### PR DESCRIPTION
Spanner with GoogleSQL dialect requires database names with hypens in CreateDatabase statement to be quoted with backtick characters e.g., \`my-db-name\`, whereas Spanner with PostgreSQL dialect (PGSpanner) doesn't allows recognize backtick characters. Thus, to create database with a name that contains hyphens, the dbname needs to be quoted with double quotes e.g., \"my-pg-db-name\".