### PR TITLE
Support for CSV: First Cut

### DIFF
--- a/cmd/data.go
+++ b/cmd/data.go
@@ -112,6 +112,10 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 
 	// If using CSV mode, follow different code path from here.
 	if driverName == constants.CSV {
+		if targetProfile.conn.sp.dbname == "" {
+			err = fmt.Errorf("dbname is mandatory in target-profile for csv source")
+			return subcommands.ExitFailure
+		}
 		// TODO: refactor this to go through DataConv(). Fix it when refactoring passing of source-profile throughout the code
 		// to avoid excess parameters in the DataConv and SchemaConv functions.
 		bw, err := conversion.DataFromCSV(conv, sourceProfile.csv.manifest, client, targetDb)

--- a/cmd/source_profile.go
+++ b/cmd/source_profile.go
@@ -250,11 +250,23 @@ func NewSourceProfileConfig(path string) SourceProfileConfig {
 }
 
 type SourceProfileCsv struct {
-	manifest string
+	manifest  string
+	delimiter string
+	nullStr   string
 }
 
-func NewSourceProfileCsv(manifest string) SourceProfileCsv {
-	return SourceProfileCsv{manifest: manifest}
+func NewSourceProfileCsv(params map[string]string) SourceProfileCsv {
+	csvProfile := SourceProfileCsv{}
+	csvProfile.manifest = params["manifest"]
+	csvProfile.delimiter = ","
+	csvProfile.nullStr = ""
+	if delimiter, ok := params["delimiter"]; ok {
+		csvProfile.delimiter = delimiter
+	}
+	if nullStr, ok := params["nullStr"]; ok {
+		csvProfile.nullStr = nullStr
+	}
+	return csvProfile
 }
 
 type SourceProfile struct {
@@ -338,8 +350,8 @@ func NewSourceProfile(s string, source string) (SourceProfile, error) {
 		return SourceProfile{}, fmt.Errorf("could not parse source-profile, error = %v", err)
 	}
 
-	if manifest, ok := params["manifest"]; ok {
-		profile := NewSourceProfileCsv(manifest)
+	if _, ok := params["manifest"]; ok {
+		profile := NewSourceProfileCsv(params)
 		return SourceProfile{ty: SourceProfileTypeCsv, csv: profile}, nil
 	}
 

--- a/cmd/source_profile.go
+++ b/cmd/source_profile.go
@@ -349,10 +349,13 @@ func NewSourceProfile(s string, source string) (SourceProfile, error) {
 	if err != nil {
 		return SourceProfile{}, fmt.Errorf("could not parse source-profile, error = %v", err)
 	}
-
-	if _, ok := params["manifest"]; ok {
-		profile := NewSourceProfileCsv(params)
-		return SourceProfile{ty: SourceProfileTypeCsv, csv: profile}, nil
+	if source == constants.CSV {
+		if _, ok := params["manifest"]; ok {
+			profile := NewSourceProfileCsv(params)
+			return SourceProfile{ty: SourceProfileTypeCsv, csv: profile}, nil
+		} else {
+			return SourceProfile{}, fmt.Errorf("csv source requires a manifest file, please specify manifest file in the source profile e.g., -source-profile=\"manifest=file_path\"")
+		}
 	}
 
 	if _, ok := params["file"]; ok || filePipedToStdin() {

--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -20,6 +20,9 @@ const (
 	// This is an experimental driver; implementation in progress.
 	DYNAMODB string = "dynamodb"
 
+	// CSV is the driver name when loading data using csv.
+	CSV string = "csv"
+
 	// Target db for which schema is being generated.
 	TargetSpanner              string = "spanner"
 	TargetExperimentalPostgres string = "experimental_postgres"

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -408,14 +408,14 @@ func dataFromDump(driver string, config spanner.BatchWriterConfig, ioHelper *IOS
 	return writer, nil
 }
 
-func DataFromCSV(conv *internal.Conv, manifestFile string, client *sp.Client, targetDb string) (*spanner.BatchWriter, error) {
-	tables, err := csv.LoadManifest(manifestFile)
+func DataFromCSV(conv *internal.Conv, manifestFile string, client *sp.Client, targetDb, nullStr string, delimiter rune) (*spanner.BatchWriter, error) {
+	tables, err := csv.LoadManifest(conv, manifestFile)
 	if err != nil {
 		return nil, err
 	}
 
 	// Find the number of rows in each csv file for generating stats.
-	csv.SetRowStats(conv, tables)
+	csv.SetRowStats(conv, tables, delimiter)
 	totalRows := conv.Rows()
 	p := internal.NewProgress(totalRows, "Writing data to Spanner", internal.Verbose(), false)
 	rows := int64(0)
@@ -440,7 +440,7 @@ func DataFromCSV(conv *internal.Conv, manifestFile string, client *sp.Client, ta
 		func(table string, cols []string, vals []interface{}) {
 			writer.AddRow(table, cols, vals)
 		})
-	err = csv.ProcessCSV(conv, tables)
+	err = csv.ProcessCSV(conv, tables, nullStr, delimiter)
 	if err != nil {
 		return nil, fmt.Errorf("can't process csv: %v", err)
 	}

--- a/sources/csv/data.go
+++ b/sources/csv/data.go
@@ -1,0 +1,284 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csv
+
+import (
+	csvReader "encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"strconv"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/schema"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+)
+
+type Column struct {
+	Column_name string `json:"column_name"`
+	Type_name   string `json:"type_name"`
+}
+
+// Harbourbridge accepts a manifest file in the form of a json which unmarshalls into the Table struct.
+type Table struct {
+	Table_name    string   `json:"table_name"`
+	File_patterns []string `json:"file_patterns"`
+	Columns       []Column `json:"columns"`
+}
+
+// LoadManifest reads the manifest file and unmarshalls it into a list of Table struct.
+// It also performs certain checks on the manifest.
+func LoadManifest(manifestFile string) ([]Table, error) {
+	manifest, err := ioutil.ReadFile(manifestFile)
+	if err != nil {
+		return nil, fmt.Errorf("can't read manifest file due to: %v", err)
+	}
+	tables := []Table{}
+	err = json.Unmarshal(manifest, &tables)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshall json due to: %v", err)
+	}
+	err = verifyManifest(tables)
+	if err != nil {
+		return nil, fmt.Errorf("manifest is incomplete: %v", err)
+	}
+	return tables, nil
+}
+
+// verifyManifest performs certain prechecks on the structure of the manifest.
+// Checks on valid file paths and empty CSVs are handled as conv.Unexpected errors later during processing.
+func verifyManifest(tables []Table) error {
+	if len(tables) == 0 {
+		return fmt.Errorf("no tables found")
+	}
+	for i, table := range tables {
+		name := table.Table_name
+		if name == "" {
+			return fmt.Errorf("table number %d (0-indexed) does not have a name", i)
+		}
+		if len(table.File_patterns) == 0 {
+			return fmt.Errorf("no file path provided for table %s", name)
+		}
+		cols := table.Columns
+		if len(cols) == 0 {
+			return fmt.Errorf("`columns` field for table %s is empty", name)
+		}
+		for j, col := range cols {
+			if col.Column_name == "" || col.Type_name == "" {
+				return fmt.Errorf("please provide column_name and type_name in `columns` field at position %d (0-indexed)", j)
+			}
+		}
+	}
+	return nil
+}
+
+// SetRowStats calculates the number of rows per table.
+func SetRowStats(conv *internal.Conv, tables []Table) {
+	for _, table := range tables {
+		for _, filePath := range table.File_patterns {
+			count, err := getCSVRowCount(filePath)
+			if err != nil {
+				conv.Unexpected(fmt.Sprintf("Couldn't get number of rows for table %s", table.Table_name))
+				continue
+			}
+			conv.Stats.Rows[table.Table_name] += count
+		}
+	}
+}
+
+// getCSVRowCount returns the number of data rows in the CSV file.
+func getCSVRowCount(filePath string) (int64, error) {
+	count := int64(0)
+	csvFile, err := os.Open(filePath)
+	if err != nil {
+		fmt.Printf("can't read csv file: %s due to: %v\n", filePath, err)
+	}
+	r := csvReader.NewReader(csvFile)
+	for {
+		_, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, fmt.Errorf("can't read row from file: %s", filePath)
+		}
+		count++
+	}
+	// Exclude the first row, that is, column headers.
+	return count - 1, nil
+}
+
+// ProcessCSV writes data across the tables provided in the manifest file. Each table's data can be provided
+// across multiple CSV files hence, the manifest accepts a list of file paths in the input.
+func ProcessCSV(conv *internal.Conv, tables []Table) error {
+	for _, table := range tables {
+		// Populating just the table names in the conv for SrcSchema and SpSchema
+		// so the report for row stats is generated.
+		conv.SrcSchema[table.Table_name] = schema.Table{Name: table.Table_name}
+
+		// The map colDefs stores the mapping from column names to their final types.
+		colDefs := make(map[string]ddl.ColumnDef)
+		for _, col := range table.Columns {
+			ty, err := ToSpannerType(col.Type_name)
+			if err != nil {
+				return fmt.Errorf("can't map to spanner type: %v. Please use the data types as in your spanner database", err)
+			}
+			colDefs[col.Column_name] = ddl.ColumnDef{Name: col.Column_name, T: ty}
+		}
+		conv.SpSchema[table.Table_name] = ddl.CreateTable{Name: table.Table_name, ColDefs: colDefs}
+
+		for _, filePath := range table.File_patterns {
+			csvFile, err := os.Open(filePath)
+			if err != nil {
+				return fmt.Errorf(fmt.Sprintf("can't read csv file: %s due to: %v\n", filePath, err))
+			}
+			r := csvReader.NewReader(csvFile)
+
+			// First row is expected to be the column headers.
+			srcCols, err := r.Read()
+			if err == io.EOF {
+				conv.Unexpected(fmt.Sprintf("File %s is empty.", filePath))
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("can't read csv headers for col names due to: %v", err)
+			}
+			for {
+				values, err := r.Read()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return fmt.Errorf(fmt.Sprintf("can't read row  names due to: %v", err))
+				}
+				processDataRow(conv, table.Table_name, srcCols, values)
+			}
+		}
+	}
+	return nil
+}
+
+// processDataRow converts a row into go data types as per the client libs.
+func processDataRow(conv *internal.Conv, tableName string, srcCols []string, values []string) {
+	cvtVals, err := convertData(conv, tableName, srcCols, values)
+	if err != nil {
+		conv.Unexpected(fmt.Sprintf("Error while converting data: %s\n", err))
+		conv.StatsAddBadRow(tableName, conv.DataMode())
+		conv.CollectBadRow(tableName, srcCols, values)
+	} else {
+		conv.WriteRow(tableName, tableName, srcCols, cvtVals)
+	}
+}
+
+// convertData currently only supports scalar data types.
+func convertData(conv *internal.Conv, tableName string, srcCols []string, values []string) ([]interface{}, error) {
+	var v []interface{}
+	colDefs := conv.SpSchema[tableName].ColDefs
+	for i, val := range values {
+		colName := srcCols[i]
+		x, err := convScalar(colDefs[colName].T, val)
+		if err != nil {
+			return nil, err
+		}
+		v = append(v, x)
+	}
+	return v, nil
+}
+
+func convScalar(spannerType ddl.Type, val string) (interface{}, error) {
+	switch spannerType.Name {
+	case ddl.Bool:
+		return convBool(val)
+	case ddl.Bytes:
+		return convBytes(val)
+	case ddl.Date:
+		return convDate(val)
+	case ddl.Float64:
+		return convFloat64(val)
+	case ddl.Int64:
+		return convInt64(val)
+	case ddl.Numeric:
+		return convNumeric(val)
+	case ddl.String:
+		return val, nil
+	case ddl.Timestamp:
+		return convTimestamp(val)
+	case ddl.JSON:
+		return val, nil
+	default:
+		return val, fmt.Errorf("data conversion not implemented for type %v", spannerType)
+	}
+}
+
+func convBool(val string) (bool, error) {
+	b, err := strconv.ParseBool(val)
+	if err != nil {
+		return b, fmt.Errorf("can't convert to bool: %w", err)
+	}
+	return b, err
+}
+
+func convBytes(val string) ([]byte, error) {
+	// convert a string to a byte slice.
+	b := []byte(val)
+	return b, nil
+}
+
+func convDate(val string) (civil.Date, error) {
+	d, err := civil.ParseDate(val)
+	if err != nil {
+		return d, fmt.Errorf("can't convert to date: %w", err)
+	}
+	return d, err
+}
+
+func convFloat64(val string) (float64, error) {
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return f, fmt.Errorf("can't convert to float64: %w", err)
+	}
+	return f, err
+}
+
+func convInt64(val string) (int64, error) {
+	i, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return i, fmt.Errorf("can't convert to int64: %w", err)
+	}
+	return i, err
+}
+
+// convNumeric maps a source database string value (representing a numeric)
+// into a string representing a valid Spanner numeric.
+func convNumeric(val string) (interface{}, error) {
+	r := new(big.Rat)
+	if _, ok := r.SetString(val); !ok {
+		return "", fmt.Errorf("can't convert %q to big.Rat", val)
+	}
+	return r, nil
+}
+
+func convTimestamp(val string) (t time.Time, err error) {
+	t, err = time.Parse("2006-01-02 15:04:05", val)
+	if err != nil {
+		return t, fmt.Errorf("can't convert to timestamp: %s", val)
+	}
+	return t, err
+}

--- a/sources/csv/data_test.go
+++ b/sources/csv/data_test.go
@@ -1,0 +1,216 @@
+package csv
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+	"github.com/stretchr/testify/assert"
+)
+
+type spannerData struct {
+	table string
+	cols  []string
+	vals  []interface{}
+}
+
+const (
+	ALL_TYPES_TABLE string = "all_data_types"
+	SINGERS_TABLE   string = "singers"
+
+	ALL_TYPES_CSV string = ALL_TYPES_TABLE + ".csv"
+	SINGERS_1_CSV string = SINGERS_TABLE + "_1.csv"
+	SINGERS_2_CSV string = SINGERS_TABLE + "_2.csv"
+)
+
+func getManifestTables() []Table {
+	return []Table{
+		{
+			Table_name:    ALL_TYPES_TABLE,
+			File_patterns: []string{ALL_TYPES_CSV},
+			Columns: []Column{
+				{Column_name: "bool_col", Type_name: "BOOL"},
+				{Column_name: "byte_col", Type_name: "BYTES"},
+				{Column_name: "date_col", Type_name: "DATE"},
+				{Column_name: "float_col", Type_name: "FLOAT64"},
+				{Column_name: "int_col", Type_name: "INT64"},
+				{Column_name: "numeric_col", Type_name: "NUMERIC"},
+				{Column_name: "string_col", Type_name: "STRING"},
+				{Column_name: "timestamp_col", Type_name: "TIMESTAMP"},
+				{Column_name: "json_col", Type_name: "JSON"},
+			},
+		},
+		{
+			Table_name:    SINGERS_TABLE,
+			File_patterns: []string{SINGERS_1_CSV, SINGERS_2_CSV},
+			Columns: []Column{
+				{Column_name: "SingerId", Type_name: "INT64"},
+				{Column_name: "FirstName", Type_name: "STRING"},
+				{Column_name: "LastName", Type_name: "STRING"},
+			},
+		},
+	}
+}
+
+func writeCSVs(t *testing.T) {
+	csvInput := []struct {
+		fileName string
+		data     []string
+	}{
+		{
+			ALL_TYPES_CSV,
+			[]string{
+				"bool_col,byte_col,date_col,float_col,int_col,numeric_col,string_col,timestamp_col,json_col\n",
+				"true,test,2019-10-29,15.13,100,39.94,Helloworld,2019-10-29 05:30:00,\"{\"\"key1\"\": \"\"value1\"\", \"\"key2\"\": \"\"value2\"\"}\"",
+			},
+		},
+		{
+			SINGERS_1_CSV,
+			[]string{
+				"SingerId,FirstName,LastName\n",
+				"1,\"fn1\",ln1",
+			},
+		},
+		{
+			SINGERS_2_CSV,
+			[]string{
+				"SingerId,FirstName,LastName\n",
+				"2,fn2,\"ln2\"",
+			},
+		},
+	}
+	for _, in := range csvInput {
+		f, err := os.Create(in.fileName)
+		if err != nil {
+			t.Fatalf("Could not create %s: %v", in.fileName, err)
+		}
+		if _, err := f.WriteString(strings.Join(in.data, "")); err != nil {
+			t.Fatalf("Could not write to %s: %v", in.fileName, err)
+		}
+	}
+}
+
+func cleanupCSVs() {
+	for _, fn := range []string{ALL_TYPES_CSV, SINGERS_1_CSV, SINGERS_2_CSV} {
+		os.Remove(fn)
+	}
+}
+
+func TestSetRowStats(t *testing.T) {
+	conv := internal.MakeConv()
+	writeCSVs(t)
+	defer cleanupCSVs()
+	SetRowStats(conv, getManifestTables())
+	assert.Equal(t, map[string]int64{ALL_TYPES_TABLE: 1, SINGERS_TABLE: 2}, conv.Stats.Rows)
+}
+
+func TestProcessDataRow(t *testing.T) {
+	conv := internal.MakeConv()
+	var rows []spannerData
+	conv.SetDataMode()
+	conv.SetDataSink(
+		func(table string, cols []string, vals []interface{}) {
+			rows = append(rows, spannerData{table: table, cols: cols, vals: vals})
+		})
+
+	writeCSVs(t)
+	defer cleanupCSVs()
+
+	err := ProcessCSV(conv, getManifestTables())
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.Equal(t, []spannerData{
+		{
+			table: ALL_TYPES_TABLE,
+			cols:  []string{"bool_col", "byte_col", "date_col", "float_col", "int_col", "numeric_col", "string_col", "timestamp_col", "json_col"},
+			vals:  []interface{}{true, []uint8{0x74, 0x65, 0x73, 0x74}, getDate("2019-10-29"), 15.13, int64(100), big.NewRat(3994, 100), "Helloworld", getTime(t, "2019-10-29T05:30:00Z"), "{\"key1\": \"value1\", \"key2\": \"value2\"}"},
+		},
+		{table: SINGERS_TABLE, cols: []string{"SingerId", "FirstName", "LastName"}, vals: []interface{}{int64(1), "fn1", "ln1"}},
+		{table: SINGERS_TABLE, cols: []string{"SingerId", "FirstName", "LastName"}, vals: []interface{}{int64(2), "fn2", "ln2"}},
+	}, rows)
+}
+
+func TestConvertData(t *testing.T) {
+	singleColTests := []struct {
+		name string
+		ty   ddl.Type
+		in   string      // Input value for conversion.
+		ev   interface{} // Expected values.
+	}{
+		{"bool", ddl.Type{Name: ddl.Bool}, "true", true},
+		{"bytes", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, string([]byte{137, 80}), []byte{0x89, 0x50}},
+		{"date", ddl.Type{Name: ddl.Date}, "2019-10-29", getDate("2019-10-29")},
+		{"float64", ddl.Type{Name: ddl.Float64}, "42.6", float64(42.6)},
+		{"int64", ddl.Type{Name: ddl.Int64}, "42", int64(42)},
+		{"numeric", ddl.Type{Name: ddl.Numeric}, "42.6", big.NewRat(426, 10)},
+		{"string", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, "eh", "eh"},
+		{"timestamp", ddl.Type{Name: ddl.Timestamp}, "2019-10-29 05:30:00", getTime(t, "2019-10-29T05:30:00Z")},
+		{"json", ddl.Type{Name: ddl.JSON}, "{\"key1\": \"value1\"}", "{\"key1\": \"value1\"}"},
+	}
+	tableName := "testtable"
+	for _, tc := range singleColTests {
+		col := "a"
+		conv := buildConv(
+			ddl.CreateTable{
+				Name:    tableName,
+				ColDefs: map[string]ddl.ColumnDef{col: ddl.ColumnDef{Name: col, T: tc.ty}}})
+		av, err := convertData(conv, tableName, []string{col}, []string{tc.in})
+		assert.Nil(t, err, tc.name)
+		assert.Equal(t, []interface{}{tc.ev}, av, tc.name+": value mismatch")
+	}
+
+	cols := []string{"a", "b", "c"}
+	spTable := ddl.CreateTable{
+		Name: tableName,
+		ColDefs: map[string]ddl.ColumnDef{
+			"a": ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+			"b": ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.Float64}},
+			"c": ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.Bool}},
+		}}
+	errorTests := []struct {
+		name string
+		cols []string // Input columns.
+		vals []string // Input values.
+	}{
+		{
+			name: "Error in int64",
+			vals: []string{" 6", "6.6", "true"},
+		},
+		{
+			name: "Error in float64",
+			vals: []string{"6", "6.6e", "true"},
+		},
+		{
+			name: "Error in bool",
+			vals: []string{"6", "6.6", "truee"},
+		},
+	}
+	for _, tc := range errorTests {
+		conv := buildConv(spTable)
+		_, err := convertData(conv, tableName, cols, tc.vals)
+		assert.NotNil(t, err, tc.name)
+	}
+}
+
+func buildConv(spTable ddl.CreateTable) *internal.Conv {
+	conv := internal.MakeConv()
+	conv.SpSchema[spTable.Name] = spTable
+	return conv
+}
+
+func getTime(t *testing.T, s string) time.Time {
+	x, err := time.Parse(time.RFC3339, s)
+	assert.Nil(t, err, fmt.Sprintf("getTime can't parse %s:", s))
+	return x
+}
+
+func getDate(s string) civil.Date {
+	d, _ := civil.ParseDate(s)
+	return d
+}

--- a/sources/csv/toddl.go
+++ b/sources/csv/toddl.go
@@ -1,0 +1,36 @@
+package csv
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+)
+
+func ToSpannerType(columnType string) (ddl.Type, error) {
+	ty := strings.ToUpper(columnType)
+	switch {
+	case ty == "BOOL":
+		return ddl.Type{Name: ddl.Bool}, nil
+	// In case user enters the length as well, ex: BYTES(40).
+	case strings.HasPrefix(ty, "BYTES"):
+		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
+	case ty == "DATE":
+		return ddl.Type{Name: ddl.Date}, nil
+	case ty == "FLOAT64" || ty == "FLOAT":
+		return ddl.Type{Name: ddl.Float64}, nil
+	case ty == "INT64" || ty == "INT":
+		return ddl.Type{Name: ddl.Int64}, nil
+	case ty == "NUMERIC":
+		return ddl.Type{Name: ddl.Numeric}, nil
+	// In case user enters the length as well, ex: STRING(40).
+	case strings.HasPrefix(ty, "STRING"):
+		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
+	case ty == "TIMESTAMP":
+		return ddl.Type{Name: ddl.Timestamp}, nil
+	case ty == "JSON":
+		return ddl.Type{Name: ddl.JSON}, nil
+	default:
+		return ddl.Type{}, fmt.Errorf("%v is not a valid Spanner column type", columnType)
+	}
+}

--- a/sources/csv/toddl.go
+++ b/sources/csv/toddl.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
@@ -12,20 +13,28 @@ func ToSpannerType(columnType string) (ddl.Type, error) {
 	switch {
 	case ty == "BOOL":
 		return ddl.Type{Name: ddl.Bool}, nil
-	// In case user enters the length as well, ex: BYTES(40).
+	// We accept variations including BYTES, BYTES(), BYTES(0) since the length doesn't matter.
 	case strings.HasPrefix(ty, "BYTES"):
-		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
+		match, _ := regexp.MatchString(`^BYTES\([0-9]*\)$`, ty)
+		if match || ty == "BYTES" {
+			return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
+		}
+		return ddl.Type{}, fmt.Errorf("%v is not a valid Spanner column type", columnType)
 	case ty == "DATE":
 		return ddl.Type{Name: ddl.Date}, nil
-	case ty == "FLOAT64" || ty == "FLOAT":
+	case ty == "FLOAT64":
 		return ddl.Type{Name: ddl.Float64}, nil
-	case ty == "INT64" || ty == "INT":
+	case ty == "INT64":
 		return ddl.Type{Name: ddl.Int64}, nil
 	case ty == "NUMERIC":
 		return ddl.Type{Name: ddl.Numeric}, nil
-	// In case user enters the length as well, ex: STRING(40).
+	// We accept variations including STRING, STRING(), STRING(0) since the length doesn't matter.
 	case strings.HasPrefix(ty, "STRING"):
-		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
+		match, _ := regexp.MatchString(`^STRING\([0-9]*\)$`, ty)
+		if match || ty == "STRING" {
+			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
+		}
+		return ddl.Type{}, fmt.Errorf("%v is not a valid Spanner column type", columnType)
 	case ty == "TIMESTAMP":
 		return ddl.Type{Name: ddl.Timestamp}, nil
 	case ty == "JSON":

--- a/sources/csv/toddl_test.go
+++ b/sources/csv/toddl_test.go
@@ -1,0 +1,59 @@
+package csv
+
+import (
+	"testing"
+
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToSpannerType(t *testing.T) {
+	conv := internal.MakeConv()
+	conv.SetSchemaMode()
+	toDDLTests := []struct {
+		name       string
+		columnType string
+		expDDLType ddl.Type
+	}{
+		// Exact inputs.
+		{"bool", "BOOL", ddl.Type{Name: ddl.Bool}},
+		{"bytes", "BYTES", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},
+		{"date", "DATE", ddl.Type{Name: ddl.Date}},
+		{"float", "FLOAT64", ddl.Type{Name: ddl.Float64}},
+		{"int", "INT64", ddl.Type{Name: ddl.Int64}},
+		{"numeric", "NUMERIC", ddl.Type{Name: ddl.Numeric}},
+		{"string", "STRING", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+		{"timestamp", "TIMESTAMP", ddl.Type{Name: ddl.Timestamp}},
+		{"json", "JSON", ddl.Type{Name: ddl.JSON}},
+		// Variations in case and field length.
+		{"bool mixed case", "BoOl", ddl.Type{Name: ddl.Bool}},
+		{"NUMERIC mixed case", "numErIC", ddl.Type{Name: ddl.Numeric}},
+		{"timestamp mixed case", "tImEsTamP", ddl.Type{Name: ddl.Timestamp}},
+		{"string with length", "STRING(100)", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+		{"mixed case byte with length", "BytES(100)", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},
+		{"mixed case byte with no length", "BytES()", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},
+	}
+	for _, tc := range toDDLTests {
+		ty, err := ToSpannerType(tc.columnType)
+		assert.Nil(t, err, tc.name)
+		assert.Equal(t, tc.expDDLType, ty, tc.name)
+	}
+
+	errorTests := []struct {
+		columnType string
+	}{
+		// These columns should error out.
+		{"BYTE"},
+		{"STRINGS"},
+		{"INTEGER"},
+		{"INT32"},
+		{"INT"},
+		{"FLOAT"},
+		{"BOOLEAN"},
+	}
+	for _, tc := range errorTests {
+		_, err := ToSpannerType(tc.columnType)
+		assert.NotNil(t, err)
+	}
+}


### PR DESCRIPTION
First cut of changes to support CSV in harbourbridge. The functionality is limited in the first cut to just unblock UHG.

Subcommand changes:
Added CSV as a source for data mode. The source profile accepts the path to the manifest file. No changes to target profile.
Sample command:
`data -source=csv -source-profile="manifest=manifest.json" -target-profile="project=my-project,instance=spanner-instance,dbname=spanner-db" `

The manifest structure is largely similar to dataflow's manifest with slight changes:
```
[
    {
      "table_name": "Albums",
      "file_patterns": [
        "/Users/deepchowdhury/Desktop/harbourbridge/Albums.csv"
      ],
      "columns": [
        {"column_name": "a", "type_name": "BOOL"},
        {"column_name": "b", "type_name": "BYTES(124)"},   // Length is optional
        {"column_name": "c", "type_name": "DATE"},
        {"column_name": "d", "type_name": "FLOAT64"},
        {"column_name": "e", "type_name": "INT64"},
        {"column_name": "f", "type_name": "NUMERIC"},
        {"column_name": "g", "type_name": "STRING"},
        {"column_name": "h", "type_name": "TIMESTAMP"},
        {"column_name": "i", "type_name": "JSON"}
      ]
    },
    {
      "table_name": "Singers",
      "file_patterns": [
        "/Users/deepchowdhury/Desktop/harbourbridge/Singers.csv"
      ],
      "columns": [
        {"column_name": "SingerId", "type_name": "INT64"},
        {"column_name": "FirstName", "type_name": "STRING(100)"},  // Length is optional
        {"column_name": "LastName", "type_name": "STRING"}
      ]
    }
]
```
**Note regarding the manifest:**
- The table_name field should be identical to the table name in Spanner schema.
- File patterns do not accept regex expressions. Provide the path inside double quotes.
- The type_name should be identical to the types in spanner schema. Only for `STRING` and `BYTES`, the length can be optionally omitted.

**CSV file format:**
```
bool_col,byte_col,date_col,float_col,int_col,numeric_col,string_col,timestamp_col,json_col // column headers
true,bytevalue,2020-12-09,15.13,100,39.94,Helloworld,2019-10-29 05:30:00,"{""key1"": ""value1"", ""key2"": ""value2""}" // data
```
**Note regarding the CSV file:**
- Each column in a row should be separated by commas.
- The first row needs to have the column name headers. The column names should be identical to the column names in Spanner schema.
- Remove trailing spaces, tabs in the column name headers.

**CSV Data types:**
- We only support scalar data types right now. Sample data format for each provided in the snippet above.
- The only supported data format right now is **RFC3339 full-date format**
- The only supported timestamp format right now is **ISO 8601**
- The format to escape the quotes in json is adding an additional `"` in front of the double quote. `\` does not work. Also enclose the whole data inside "". Some modification might be required since most databases do not export CSVs with escaping quotes like mentioned.

Pending tasks:
1) Interleaved table support
2) PG Spanner support

Stretch Goal:
Implement as a full fledged feature where manifest file is not required. 