### PR TITLE
Fix for failing tests

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -74,10 +74,6 @@ jobs:
       - run: psql -f test_data/pg_dump.test.out
 
       # init a MySQL database from the test_data
-      - name: Install MySQL client required for loading .sql files
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mysql-client
       - run: mysql --version
       - run: mysql -v -P 3306 --protocol=tcp -u root -proot test < test_data/mysqldump.test.out
 


### PR DESCRIPTION
Current tests are suddenly failing during setup when running
`sudo apt-get install -y mysql-client`
with
```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 mysql-client : Depends: mysql-client-8.0 but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

I tried specifying the older version used in older successful runs of the tests which was 8.0.26-0ubuntu0.20.04.3 via
`sudo apt-get install -y mysql-client=8.0.26-0` but that also fails with version not found.

Currently, removing that line as the mysql CLI still seems to work and the tests pass without that.