### PR TITLE
Pg spanner misc fixes

### DIFF
--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -578,7 +578,7 @@ func UpdateDatabase(ctx context.Context, adminClient *database.DatabaseAdminClie
 	// Spanner DDL doesn't accept them), and protects table and col names
 	// using backticks (to avoid any issues with Spanner reserved words).
 	// Foreign Keys are set to false since we create them post data migration.
-	schema := conv.SpSchema.GetDDL(ddl.Config{Comments: false, ProtectIds: false, Tables: true, ForeignKeys: false, TargetDb: conv.TargetDb})
+	schema := conv.SpSchema.GetDDL(ddl.Config{Comments: false, ProtectIds: true, Tables: true, ForeignKeys: false, TargetDb: conv.TargetDb})
 	req := &adminpb.UpdateDatabaseDdlRequest{
 		Database:   dbURI,
 		Statements: schema,
@@ -633,7 +633,7 @@ func UpdateDDLForeignKeys(ctx context.Context, adminClient *database.DatabaseAdm
 	// The schema we send to Spanner excludes comments (since Cloud
 	// Spanner DDL doesn't accept them), and protects table and col names
 	// using backticks (to avoid any issues with Spanner reserved words).
-	fkStmts := conv.SpSchema.GetDDL(ddl.Config{Comments: false, ProtectIds: true, Tables: false, ForeignKeys: true})
+	fkStmts := conv.SpSchema.GetDDL(ddl.Config{Comments: false, ProtectIds: true, Tables: false, ForeignKeys: true, TargetDb: conv.TargetDb})
 	if len(fkStmts) == 0 {
 		return nil
 	}
@@ -778,7 +778,7 @@ func WriteSchemaFile(conv *internal.Conv, now time.Time, name string, out *os.Fi
 	// and doesn't add backticks around table and column names. This file is
 	// intended for explanatory and documentation purposes, and is not strictly
 	// legal Cloud Spanner DDL (Cloud Spanner doesn't currently support comments).
-	spDDL := conv.SpSchema.GetDDL(ddl.Config{Comments: true, ProtectIds: false, Tables: true, ForeignKeys: true})
+	spDDL := conv.SpSchema.GetDDL(ddl.Config{Comments: true, ProtectIds: false, Tables: true, ForeignKeys: true, TargetDb: conv.TargetDb})
 	if len(spDDL) == 0 {
 		spDDL = []string{"\n-- Schema is empty -- no tables found\n"}
 	}
@@ -805,7 +805,7 @@ func WriteSchemaFile(conv *internal.Conv, now time.Time, name string, out *os.Fi
 
 	// We change 'Comments' to false and 'ProtectIds' to true below to write out a
 	// schema file that is a legal Cloud Spanner DDL.
-	spDDL = conv.SpSchema.GetDDL(ddl.Config{Comments: false, ProtectIds: true, Tables: true, ForeignKeys: true})
+	spDDL = conv.SpSchema.GetDDL(ddl.Config{Comments: false, ProtectIds: true, Tables: true, ForeignKeys: true, TargetDb: conv.TargetDb})
 	if len(spDDL) == 0 {
 		spDDL = []string{"\n-- Schema is empty -- no tables found\n"}
 	}

--- a/sources/postgres/data.go
+++ b/sources/postgres/data.go
@@ -76,7 +76,10 @@ func ConvertData(conv *internal.Conv, srcTable string, srcCols []string, vals []
 	}
 	for i, spCol := range spCols {
 		srcCol := srcCols[i]
-		if vals[i] == "\\N" { // PostgreSQL representation of empty column in COPY-FROM blocks.
+		// "\\N" is for PostgreSQL representation of empty column in COPY-FROM blocks.
+		// TODO: Consider using NullString to differentiate between an actual column having "NULL" as a string
+		// and NULL values.
+		if vals[i] == "\\N" || vals[i] == "NULL" {
 			continue
 		}
 		spColDef, ok1 := spSchema.ColDefs[spCol]

--- a/sources/postgres/pgdump.go
+++ b/sources/postgres/pgdump.go
@@ -732,6 +732,12 @@ func getRows(conv *internal.Conv, vll []*pg_query.Node, n *pg_query.InsertStmt) 
 						// high priority (it isn't right now), then consider preserving int64
 						// here to avoid the int64 -> string -> int64 conversions.
 						values = append(values, strconv.FormatInt(int64(c.Integer.Ival), 10))
+					case *pg_query.Node_Float:
+						values = append(values, c.Float.Str)
+					case *pg_query.Node_Null:
+						values = append(values, "NULL")
+					// TODO: There are other Node types like Node_IntList, Node_List, Node_BitString etc that
+					// need to be explored.
 					default:
 						conv.Unexpected(fmt.Sprintf("Processing %v statement: found %s node for A_Const Val", printNodeType(n), printNodeType(c)))
 					}

--- a/sources/postgres/pgdump.go
+++ b/sources/postgres/pgdump.go
@@ -724,6 +724,9 @@ func getRows(conv *internal.Conv, vll []*pg_query.Node, n *pg_query.InsertStmt) 
 				switch val := v.GetNode().(type) {
 				case *pg_query.Node_AConst:
 					switch c := val.AConst.Val.GetNode().(type) {
+					// Most data is dumped enclosed in quotes ('') lke 'abc', '12:30:45' etc which is classified
+					// as type Node_String_ by the parser. Some data might not be quoted like (NULL, 14.67) and
+					// the type assigned to them is Node_Null and Node_Float respectively.
 					case *pg_query.Node_String_:
 						values = append(values, trimString(c.String_))
 					case *pg_query.Node_Integer:
@@ -736,8 +739,8 @@ func getRows(conv *internal.Conv, vll []*pg_query.Node, n *pg_query.InsertStmt) 
 						values = append(values, c.Float.Str)
 					case *pg_query.Node_Null:
 						values = append(values, "NULL")
-					// TODO: There are other Node types like Node_IntList, Node_List, Node_BitString etc that
-					// need to be explored.
+					// TODO: There might be other Node types like Node_IntList, Node_List, Node_BitString etc that
+					// need to be checked if they are handled or not.
 					default:
 						conv.Unexpected(fmt.Sprintf("Processing %v statement: found %s node for A_Const Val", printNodeType(n), printNodeType(c)))
 					}

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -158,7 +158,11 @@ type Config struct {
 
 func (c Config) quote(s string) string {
 	if c.ProtectIds {
-		return "`" + s + "`"
+		if c.TargetDb == constants.TargetExperimentalPostgres {
+			return "\"" + s + "\""
+		} else {
+			return "`" + s + "`"
+		}
 	}
 	return s
 }


### PR DESCRIPTION
Fixes #241, #244 and #245 

- Added handling for float and null values
- For pg dump, null values were not getting skipped earlier.
- Quoting was incorrect for pg dialect, causing foreign key statements to fail
- The schema files were of spanner dialect since targetdb was not passed as a param.