### PR TITLE
Refactoring 2: Pass profiles across conversion methods instead of flags.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -52,7 +52,7 @@ func CommandLine(ctx context.Context, driver, targetDb, dbURI string, dataOnly, 
 	if !dataOnly {
 		// We pass an empty string to the sqlConnectionStr parameter as this is the legacy codepath,
 		// which reads the environment variables and constructs the string later on.
-		conv, err = conversion.SchemaConv(&sourceProfile, &targetProfile, ioHelper)
+		conv, err = conversion.SchemaConv(sourceProfile, targetProfile, ioHelper)
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func CommandLine(ctx context.Context, driver, targetDb, dbURI string, dataOnly, 
 
 	// We pass an empty string to the sqlConnectionStr parameter as this is the legacy codepath,
 	// which reads the environment variables and constructs the string later on.
-	bw, err := conversion.DataConv(&sourceProfile, &targetProfile, ioHelper, client, conv, dataOnly)
+	bw, err := conversion.DataConv(sourceProfile, targetProfile, ioHelper, client, conv, dataOnly)
 	if err != nil {
 		return fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)
 	}

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -131,7 +131,7 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 		return subcommands.ExitFailure
 	}
 
-	bw, err := conversion.DataConv(&sourceProfile, &targetProfile, &ioHelper, client, conv, true)
+	bw, err := conversion.DataConv(sourceProfile, targetProfile, &ioHelper, client, conv, true)
 	if err != nil {
 		err = fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)
 		return subcommands.ExitFailure

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -97,7 +97,7 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	}
 
 	var conv *internal.Conv
-	conv, err = conversion.SchemaConv(&sourceProfile, &targetProfile, &ioHelper)
+	conv, err = conversion.SchemaConv(sourceProfile, targetProfile, &ioHelper)
 	if err != nil {
 		return subcommands.ExitFailure
 	}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -66,7 +66,7 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
-	driverName, err := sourceProfile.ToLegacyDriver(cmd.source)
+	sourceProfile.Driver, err = sourceProfile.ToLegacyDriver(cmd.source)
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
@@ -75,20 +75,20 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
-	targetDb := targetProfile.ToLegacyTargetDb()
+	targetProfile.TargetDb = targetProfile.ToLegacyTargetDb()
 
 	dumpFilePath := ""
 	if sourceProfile.Ty == profiles.SourceProfileTypeFile && (sourceProfile.File.Format == "" || sourceProfile.File.Format == "dump") {
 		dumpFilePath = sourceProfile.File.Path
 	}
-	ioHelper := utils.NewIOStreams(driverName, dumpFilePath)
+	ioHelper := utils.NewIOStreams(sourceProfile.Driver, dumpFilePath)
 	if ioHelper.SeekableIn != nil {
 		defer ioHelper.In.Close()
 	}
 
 	// If filePrefix not explicitly set, use generated dbName.
 	if cmd.filePrefix == "" {
-		dbName, err := utils.GetDatabaseName(driverName, time.Now())
+		dbName, err := utils.GetDatabaseName(sourceProfile.Driver, time.Now())
 		if err != nil {
 			err = fmt.Errorf("can't generate database name for prefix: %v", err)
 			return subcommands.ExitFailure
@@ -97,7 +97,7 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	}
 
 	var conv *internal.Conv
-	conv, err = conversion.SchemaConv(driverName, profiles.GetSQLConnectionStr(sourceProfile), targetDb, &ioHelper, profiles.GetSchemaSampleSize(sourceProfile))
+	conv, err = conversion.SchemaConv(&sourceProfile, &targetProfile, &ioHelper)
 	if err != nil {
 		return subcommands.ExitFailure
 	}
@@ -105,6 +105,6 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	now := time.Now()
 	conversion.WriteSchemaFile(conv, now, cmd.filePrefix+schemaFile, ioHelper.Out)
 	conversion.WriteSessionFile(conv, cmd.filePrefix+sessionFile, ioHelper.Out)
-	conversion.Report(driverName, nil, ioHelper.BytesRead, "", conv, cmd.filePrefix+reportFile, ioHelper.Out)
+	conversion.Report(sourceProfile.Driver, nil, ioHelper.BytesRead, "", conv, cmd.filePrefix+reportFile, ioHelper.Out)
 	return subcommands.ExitSuccess
 }

--- a/cmd/schema_and_data.go
+++ b/cmd/schema_and_data.go
@@ -68,7 +68,7 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
-	driverName, err := sourceProfile.ToLegacyDriver(cmd.source)
+	sourceProfile.Driver, err = sourceProfile.ToLegacyDriver(cmd.source)
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
@@ -77,13 +77,13 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
-	targetDb := targetProfile.ToLegacyTargetDb()
+	targetProfile.TargetDb = targetProfile.ToLegacyTargetDb()
 
 	dumpFilePath := ""
 	if sourceProfile.Ty == profiles.SourceProfileTypeFile && (sourceProfile.File.Format == "" || sourceProfile.File.Format == "dump") {
 		dumpFilePath = sourceProfile.File.Path
 	}
-	ioHelper := utils.NewIOStreams(driverName, dumpFilePath)
+	ioHelper := utils.NewIOStreams(sourceProfile.Driver, dumpFilePath)
 	if ioHelper.SeekableIn != nil {
 		defer ioHelper.In.Close()
 	}
@@ -92,26 +92,24 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 
 	// If filePrefix not explicitly set, use dbName as prefix.
 	if cmd.filePrefix == "" {
-		dbName, err := utils.GetDatabaseName(driverName, now)
+		dbName, err := utils.GetDatabaseName(sourceProfile.Driver, now)
 		if err != nil {
 			panic(fmt.Errorf("can't generate database name for prefix: %v", err))
 		}
 		cmd.filePrefix = dbName + "."
 	}
 
-	sqlConnectionStr := profiles.GetSQLConnectionStr(sourceProfile)
-	schemaSampleSize := profiles.GetSchemaSampleSize(sourceProfile)
 	var conv *internal.Conv
-	conv, err = conversion.SchemaConv(driverName, sqlConnectionStr, targetDb, &ioHelper, schemaSampleSize)
+	conv, err = conversion.SchemaConv(&sourceProfile, &targetProfile, &ioHelper)
 	if err != nil {
 		panic(err)
 	}
 
 	conversion.WriteSchemaFile(conv, now, cmd.filePrefix+schemaFile, ioHelper.Out)
 	conversion.WriteSessionFile(conv, cmd.filePrefix+sessionFile, ioHelper.Out)
-	conversion.Report(driverName, nil, ioHelper.BytesRead, "", conv, cmd.filePrefix+reportFile, ioHelper.Out)
+	conversion.Report(sourceProfile.Driver, nil, ioHelper.BytesRead, "", conv, cmd.filePrefix+reportFile, ioHelper.Out)
 
-	project, instance, dbName, err := profiles.GetResourceIds(ctx, targetProfile, now, driverName, ioHelper.Out)
+	project, instance, dbName, err := profiles.GetResourceIds(ctx, targetProfile, now, sourceProfile.Driver, ioHelper.Out)
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
@@ -136,7 +134,7 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 		return subcommands.ExitFailure
 	}
 
-	bw, err := conversion.DataConv(driverName, sqlConnectionStr, &ioHelper, client, conv, true, schemaSampleSize)
+	bw, err := conversion.DataConv(&sourceProfile, &targetProfile, &ioHelper, client, conv, true)
 	if err != nil {
 		err = fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)
 		return subcommands.ExitFailure
@@ -148,7 +146,7 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 		}
 	}
 	banner := utils.GetBanner(now, dbURI)
-	conversion.Report(driverName, bw.DroppedRowsByTable(), ioHelper.BytesRead, banner, conv, cmd.filePrefix+reportFile, ioHelper.Out)
+	conversion.Report(sourceProfile.Driver, bw.DroppedRowsByTable(), ioHelper.BytesRead, banner, conv, cmd.filePrefix+reportFile, ioHelper.Out)
 	conversion.WriteBadData(bw, conv, banner, cmd.filePrefix+badDataFile, ioHelper.Out)
 	return subcommands.ExitSuccess
 }

--- a/cmd/schema_and_data.go
+++ b/cmd/schema_and_data.go
@@ -100,7 +100,7 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 	}
 
 	var conv *internal.Conv
-	conv, err = conversion.SchemaConv(&sourceProfile, &targetProfile, &ioHelper)
+	conv, err = conversion.SchemaConv(sourceProfile, targetProfile, &ioHelper)
 	if err != nil {
 		panic(err)
 	}
@@ -134,7 +134,7 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 		return subcommands.ExitFailure
 	}
 
-	bw, err := conversion.DataConv(&sourceProfile, &targetProfile, &ioHelper, client, conv, true)
+	bw, err := conversion.DataConv(sourceProfile, targetProfile, &ioHelper, client, conv, true)
 	if err != nil {
 		err = fmt.Errorf("can't finish data conversion for db %s: %v", dbURI, err)
 		return subcommands.ExitFailure

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -73,7 +73,7 @@ var (
 //  - Driver is DynamoDB or a dump file mode.
 //  - This function is called as part of the legacy global CLI flag mode. (This string is constructed from env variables later on)
 // When using source-profile, the sqlConnectionStr is constructed from the input params.
-func SchemaConv(sourceProfile *profiles.SourceProfile, targetProfile *profiles.TargetProfile, ioHelper *utils.IOStreams) (*internal.Conv, error) {
+func SchemaConv(sourceProfile profiles.SourceProfile, targetProfile profiles.TargetProfile, ioHelper *utils.IOStreams) (*internal.Conv, error) {
 	switch sourceProfile.Driver {
 	case constants.POSTGRES, constants.MYSQL, constants.DYNAMODB:
 		return schemaFromDatabase(sourceProfile, targetProfile)
@@ -90,7 +90,7 @@ func SchemaConv(sourceProfile *profiles.SourceProfile, targetProfile *profiles.T
 //  - Driver is DynamoDB or a dump file mode.
 //  - This function is called as part of the legacy global CLI flag mode. (This string is constructed from env variables later on)
 // When using source-profile, the sqlConnectionStr and schemaSampleSize are constructed from the input params.
-func DataConv(sourceProfile *profiles.SourceProfile, targetProfile *profiles.TargetProfile, ioHelper *utils.IOStreams, client *sp.Client, conv *internal.Conv, dataOnly bool) (*spanner.BatchWriter, error) {
+func DataConv(sourceProfile profiles.SourceProfile, targetProfile profiles.TargetProfile, ioHelper *utils.IOStreams, client *sp.Client, conv *internal.Conv, dataOnly bool) (*spanner.BatchWriter, error) {
 	config := spanner.BatchWriterConfig{
 		BytesLimit: 100 * 1000 * 1000,
 		WriteLimit: 40,
@@ -110,7 +110,7 @@ func DataConv(sourceProfile *profiles.SourceProfile, targetProfile *profiles.Tar
 	}
 }
 
-func connectionConfig(sourceProfile *profiles.SourceProfile) (interface{}, error) {
+func connectionConfig(sourceProfile profiles.SourceProfile) (interface{}, error) {
 	switch sourceProfile.Driver {
 	// For PG and MYSQL, When called as part of the subcommand flow, host/user/db etc will
 	// never be empty as we error out right during source profile creation. If any of them
@@ -151,7 +151,7 @@ func getDbNameFromSQLConnectionStr(driver, sqlConnectionStr string) string {
 	return ""
 }
 
-func schemaFromDatabase(sourceProfile *profiles.SourceProfile, targetProfile *profiles.TargetProfile) (*internal.Conv, error) {
+func schemaFromDatabase(sourceProfile profiles.SourceProfile, targetProfile profiles.TargetProfile) (*internal.Conv, error) {
 	conv := internal.MakeConv()
 	conv.TargetDb = targetProfile.TargetDb
 	infoSchema, err := GetInfoSchema(sourceProfile)
@@ -161,7 +161,7 @@ func schemaFromDatabase(sourceProfile *profiles.SourceProfile, targetProfile *pr
 	return conv, common.ProcessSchema(conv, infoSchema)
 }
 
-func dataFromDatabase(sourceProfile *profiles.SourceProfile, config spanner.BatchWriterConfig, client *sp.Client, conv *internal.Conv) (*spanner.BatchWriter, error) {
+func dataFromDatabase(sourceProfile profiles.SourceProfile, config spanner.BatchWriterConfig, client *sp.Client, conv *internal.Conv) (*spanner.BatchWriter, error) {
 	infoSchema, err := GetInfoSchema(sourceProfile)
 	if err != nil {
 		return nil, err
@@ -704,7 +704,7 @@ func ProcessDump(driver string, conv *internal.Conv, r *internal.Reader) error {
 	}
 }
 
-func GetInfoSchema(sourceProfile *profiles.SourceProfile) (common.InfoSchema, error) {
+func GetInfoSchema(sourceProfile profiles.SourceProfile) (common.InfoSchema, error) {
 	connectionConfig, err := connectionConfig(sourceProfile)
 	if err != nil {
 		return nil, err

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -73,14 +73,14 @@ var (
 //  - Driver is DynamoDB or a dump file mode.
 //  - This function is called as part of the legacy global CLI flag mode. (This string is constructed from env variables later on)
 // When using source-profile, the sqlConnectionStr is constructed from the input params.
-func SchemaConv(driver, sqlConnectionStr, targetDb string, ioHelper *utils.IOStreams, schemaSampleSize int64) (*internal.Conv, error) {
-	switch driver {
+func SchemaConv(sourceProfile *profiles.SourceProfile, targetProfile *profiles.TargetProfile, ioHelper *utils.IOStreams) (*internal.Conv, error) {
+	switch sourceProfile.Driver {
 	case constants.POSTGRES, constants.MYSQL, constants.DYNAMODB:
-		return schemaFromDatabase(driver, sqlConnectionStr, targetDb, schemaSampleSize)
+		return schemaFromDatabase(sourceProfile, targetProfile)
 	case constants.PGDUMP, constants.MYSQLDUMP:
-		return schemaFromDump(driver, targetDb, ioHelper)
+		return schemaFromDump(sourceProfile.Driver, targetProfile.TargetDb, ioHelper)
 	default:
-		return nil, fmt.Errorf("schema conversion for driver %s not supported", driver)
+		return nil, fmt.Errorf("schema conversion for driver %s not supported", sourceProfile.Driver)
 	}
 }
 
@@ -90,46 +90,53 @@ func SchemaConv(driver, sqlConnectionStr, targetDb string, ioHelper *utils.IOStr
 //  - Driver is DynamoDB or a dump file mode.
 //  - This function is called as part of the legacy global CLI flag mode. (This string is constructed from env variables later on)
 // When using source-profile, the sqlConnectionStr and schemaSampleSize are constructed from the input params.
-func DataConv(driver, sqlConnectionStr string, ioHelper *utils.IOStreams, client *sp.Client, conv *internal.Conv, dataOnly bool, schemaSampleSize int64) (*spanner.BatchWriter, error) {
+func DataConv(sourceProfile *profiles.SourceProfile, targetProfile *profiles.TargetProfile, ioHelper *utils.IOStreams, client *sp.Client, conv *internal.Conv, dataOnly bool) (*spanner.BatchWriter, error) {
 	config := spanner.BatchWriterConfig{
 		BytesLimit: 100 * 1000 * 1000,
 		WriteLimit: 40,
 		RetryLimit: 1000,
 		Verbose:    internal.Verbose(),
 	}
-	switch driver {
+	switch sourceProfile.Driver {
 	case constants.POSTGRES, constants.MYSQL, constants.DYNAMODB:
-		return dataFromDatabase(driver, sqlConnectionStr, config, client, conv, schemaSampleSize)
+		return dataFromDatabase(sourceProfile, config, client, conv)
 	case constants.PGDUMP, constants.MYSQLDUMP:
 		if conv.SpSchema.CheckInterleaved() {
 			return nil, fmt.Errorf("harbourBridge does not currently support data conversion from dump files\nif the schema contains interleaved tables. Suggest using direct access to source database\ni.e. using drivers postgres and mysql")
 		}
-		return dataFromDump(driver, config, ioHelper, client, conv, dataOnly)
+		return dataFromDump(sourceProfile.Driver, config, ioHelper, client, conv, dataOnly)
 	default:
-		return nil, fmt.Errorf("data conversion for driver %s not supported", driver)
+		return nil, fmt.Errorf("data conversion for driver %s not supported", sourceProfile.Driver)
 	}
 }
 
-func connectionConfig(driver string, sqlConnectionStr string) (interface{}, error) {
-	switch driver {
+func connectionConfig(sourceProfile *profiles.SourceProfile) (interface{}, error) {
+	switch sourceProfile.Driver {
+	// For PG and MYSQL, When called as part of the subcommand flow, host/user/db etc will
+	// never be empty as we error out right during source profile creation. If any of them
+	// are empty, that means this was called through the legacy cmd flow and we create the
+	// string using env vars.
 	case constants.POSTGRES:
-		// If empty, this is called as part of the legacy mode witih global CLI flags.
-		// When using source-profile mode is used, the sqlConnectionStr is already populated.
-		if sqlConnectionStr == "" {
+		pgConn := sourceProfile.Conn.Pg
+		if !(pgConn.Host != "" && pgConn.User != "" && pgConn.Db != "") {
 			return profiles.GeneratePGSQLConnectionStr()
+		} else {
+			return profiles.GetSQLConnectionStr(sourceProfile), nil
 		}
-		return sqlConnectionStr, nil
 	case constants.MYSQL:
 		// If empty, this is called as part of the legacy mode witih global CLI flags.
 		// When using source-profile mode is used, the sqlConnectionStr is already populated.
-		if sqlConnectionStr == "" {
+		mysqlConn := sourceProfile.Conn.Mysql
+		if !(mysqlConn.Host != "" && mysqlConn.User != "" && mysqlConn.Db != "") {
 			return profiles.GenerateMYSQLConnectionStr()
+		} else {
+			return profiles.GetSQLConnectionStr(sourceProfile), nil
 		}
-		return sqlConnectionStr, nil
+	// For Dynamodb, both legacy and new flows use env vars.
 	case constants.DYNAMODB:
 		return getDynamoDBClientConfig()
 	default:
-		return "", fmt.Errorf("driver %s not supported", driver)
+		return "", fmt.Errorf("driver %s not supported", sourceProfile.Driver)
 	}
 }
 
@@ -144,18 +151,18 @@ func getDbNameFromSQLConnectionStr(driver, sqlConnectionStr string) string {
 	return ""
 }
 
-func schemaFromDatabase(driver, sqlConnectionStr, targetDb string, schemaSampleSize int64) (*internal.Conv, error) {
+func schemaFromDatabase(sourceProfile *profiles.SourceProfile, targetProfile *profiles.TargetProfile) (*internal.Conv, error) {
 	conv := internal.MakeConv()
-	conv.TargetDb = targetDb
-	infoSchema, err := GetInfoSchema(driver, sqlConnectionStr, schemaSampleSize)
+	conv.TargetDb = targetProfile.TargetDb
+	infoSchema, err := GetInfoSchema(sourceProfile)
 	if err != nil {
 		return conv, err
 	}
 	return conv, common.ProcessSchema(conv, infoSchema)
 }
 
-func dataFromDatabase(driver, sqlConnectionStr string, config spanner.BatchWriterConfig, client *sp.Client, conv *internal.Conv, schemaSampleSize int64) (*spanner.BatchWriter, error) {
-	infoSchema, err := GetInfoSchema(driver, sqlConnectionStr, schemaSampleSize)
+func dataFromDatabase(sourceProfile *profiles.SourceProfile, config spanner.BatchWriterConfig, client *sp.Client, conv *internal.Conv) (*spanner.BatchWriter, error) {
+	infoSchema, err := GetInfoSchema(sourceProfile)
 	if err != nil {
 		return nil, err
 	}
@@ -697,11 +704,12 @@ func ProcessDump(driver string, conv *internal.Conv, r *internal.Reader) error {
 	}
 }
 
-func GetInfoSchema(driver, sqlConnectionStr string, schemaSampleSize int64) (common.InfoSchema, error) {
-	connectionConfig, err := connectionConfig(driver, sqlConnectionStr)
+func GetInfoSchema(sourceProfile *profiles.SourceProfile) (common.InfoSchema, error) {
+	connectionConfig, err := connectionConfig(sourceProfile)
 	if err != nil {
 		return nil, err
 	}
+	driver := sourceProfile.Driver
 	switch driver {
 	case constants.MYSQL:
 		db, err := sql.Open(driver, connectionConfig.(string))
@@ -719,7 +727,7 @@ func GetInfoSchema(driver, sqlConnectionStr string, schemaSampleSize int64) (com
 	case constants.DYNAMODB:
 		mySession := session.Must(session.NewSession())
 		dydbClient := dydb.New(mySession, connectionConfig.(*aws.Config))
-		return dynamodb.InfoSchemaImpl{DynamoClient: dydbClient, SampleSize: schemaSampleSize}, nil
+		return dynamodb.InfoSchemaImpl{DynamoClient: dydbClient, SampleSize: profiles.GetSchemaSampleSize(sourceProfile)}, nil
 	default:
 		return nil, fmt.Errorf("driver %s not supported", driver)
 	}

--- a/profiles/common.go
+++ b/profiles/common.go
@@ -78,7 +78,7 @@ func GetResourceIds(ctx context.Context, targetProfile TargetProfile, now time.T
 	return project, instance, dbName, err
 }
 
-func GetSQLConnectionStr(sourceProfile *SourceProfile) string {
+func GetSQLConnectionStr(sourceProfile SourceProfile) string {
 	sqlConnectionStr := ""
 	if sourceProfile.Ty == SourceProfileTypeConnection {
 		switch sourceProfile.Conn.Ty {
@@ -138,7 +138,7 @@ func getMYSQLConnectionStr(server, port, user, password, dbname string) string {
 	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, server, port, dbname)
 }
 
-func GetSchemaSampleSize(sourceProfile *SourceProfile) int64 {
+func GetSchemaSampleSize(sourceProfile SourceProfile) int64 {
 	schemaSampleSize := int64(100000)
 	if sourceProfile.Ty == SourceProfileTypeConnection {
 		if sourceProfile.Conn.Ty == SourceProfileConnectionTypeDynamoDB {

--- a/profiles/common.go
+++ b/profiles/common.go
@@ -78,16 +78,16 @@ func GetResourceIds(ctx context.Context, targetProfile TargetProfile, now time.T
 	return project, instance, dbName, err
 }
 
-func GetSQLConnectionStr(sourceProfile SourceProfile) string {
+func GetSQLConnectionStr(sourceProfile *SourceProfile) string {
 	sqlConnectionStr := ""
 	if sourceProfile.Ty == SourceProfileTypeConnection {
 		switch sourceProfile.Conn.Ty {
 		case SourceProfileConnectionTypeMySQL:
 			connParams := sourceProfile.Conn.Mysql
-			return getMYSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
+			return getMYSQLConnectionStr(connParams.Host, connParams.Port, connParams.User, connParams.Pwd, connParams.Db)
 		case SourceProfileConnectionTypePostgreSQL:
 			connParams := sourceProfile.Conn.Pg
-			return getPGSQLConnectionStr(connParams.host, connParams.port, connParams.user, connParams.pwd, connParams.db)
+			return getPGSQLConnectionStr(connParams.Host, connParams.Port, connParams.User, connParams.Pwd, connParams.Db)
 		case SourceProfileConnectionTypeDynamoDB:
 			// For DynamoDB, client provided by aws-sdk reads connection credentials from env variables only.
 			// Thus, there is no need to create sqlConnectionStr for the same. We instead set the env variables
@@ -138,12 +138,12 @@ func getMYSQLConnectionStr(server, port, user, password, dbname string) string {
 	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, server, port, dbname)
 }
 
-func GetSchemaSampleSize(sourceProfile SourceProfile) int64 {
+func GetSchemaSampleSize(sourceProfile *SourceProfile) int64 {
 	schemaSampleSize := int64(100000)
 	if sourceProfile.Ty == SourceProfileTypeConnection {
 		if sourceProfile.Conn.Ty == SourceProfileConnectionTypeDynamoDB {
-			if sourceProfile.Conn.Dydb.schemaSampleSize != 0 {
-				schemaSampleSize = sourceProfile.Conn.Dydb.schemaSampleSize
+			if sourceProfile.Conn.Dydb.SchemaSampleSize != 0 {
+				schemaSampleSize = sourceProfile.Conn.Dydb.SchemaSampleSize
 			}
 		}
 	}

--- a/profiles/source_profile.go
+++ b/profiles/source_profile.go
@@ -49,11 +49,11 @@ const (
 )
 
 type SourceProfileConnectionMySQL struct {
-	host string // Same as MYSQLHOST environment variable
-	port string // Same as MYSQLPORT environment variable
-	user string // Same as MYSQLUSER environment variable
-	db   string // Same as MYSQLDATABASE environment variable
-	pwd  string // Same as MYSQLPWD environment variable
+	Host string // Same as MYSQLHOST environment variable
+	Port string // Same as MYSQLPORT environment variable
+	User string // Same as MYSQLUSER environment variable
+	Db   string // Same as MYSQLDATABASE environment variable
+	Pwd  string // Same as MYSQLPWD environment variable
 }
 
 func NewSourceProfileConnectionMySQL(params map[string]string) (SourceProfileConnectionMySQL, error) {
@@ -69,21 +69,21 @@ func NewSourceProfileConnectionMySQL(params map[string]string) (SourceProfileCon
 		// No connection params provided through source-profile. Fetching from env variables.
 		fmt.Printf("Connection parameters not specified in source-profile. Reading from " +
 			"environment variables MYSQLHOST, MYSQLUSER, MYSQLDATABASE, MYSQLPORT, MYSQLPWD...\n")
-		mysql.host = os.Getenv("MYSQLHOST")
-		mysql.user = os.Getenv("MYSQLUSER")
-		mysql.db = os.Getenv("MYSQLDATABASE")
-		mysql.port = os.Getenv("MYSQLPORT")
-		mysql.pwd = os.Getenv("MYSQLPWD")
+		mysql.Host = os.Getenv("MYSQLHOST")
+		mysql.User = os.Getenv("MYSQLUSER")
+		mysql.Db = os.Getenv("MYSQLDATABASE")
+		mysql.Port = os.Getenv("MYSQLPORT")
+		mysql.Pwd = os.Getenv("MYSQLPWD")
 		// Throw error if the input entered is empty.
-		if mysql.host == "" || mysql.user == "" || mysql.db == "" {
+		if mysql.Host == "" || mysql.User == "" || mysql.Db == "" {
 			return mysql, fmt.Errorf("found empty string for MYSQLHOST/MYSQLUSER/MYSQLDATABASE. Please specify these environment variables with correct values")
 		}
 	} else if hostOk && userOk && dbOk {
 		// If atleast host, username and dbname are provided through source-profile,
 		// go ahead and use source-profile. Port and password handled later even if they are empty.
-		mysql.host, mysql.user, mysql.db, mysql.port, mysql.pwd = host, user, db, port, pwd
+		mysql.Host, mysql.User, mysql.Db, mysql.Port, mysql.Pwd = host, user, db, port, pwd
 		// Throw error if the input entered is empty.
-		if mysql.host == "" || mysql.user == "" || mysql.db == "" {
+		if mysql.Host == "" || mysql.User == "" || mysql.Db == "" {
 			return mysql, fmt.Errorf("found empty string for host/user/db_name. Please specify host, port, user and db_name in the source-profile")
 		}
 	} else {
@@ -92,27 +92,27 @@ func NewSourceProfileConnectionMySQL(params map[string]string) (SourceProfileCon
 	}
 
 	// Throw same error if the input entered is empty.
-	if mysql.host == "" || mysql.user == "" || mysql.db == "" {
+	if mysql.Host == "" || mysql.User == "" || mysql.Db == "" {
 		return mysql, fmt.Errorf("found empty string for host/user/db. please specify host, port, user and db_name in the source-profile")
 	}
 
-	if mysql.port == "" {
+	if mysql.Port == "" {
 		// Set default port for mysql, which rarely changes.
-		mysql.port = "3306"
+		mysql.Port = "3306"
 	}
-	if mysql.pwd == "" {
-		mysql.pwd = utils.GetPassword()
+	if mysql.Pwd == "" {
+		mysql.Pwd = utils.GetPassword()
 	}
 
 	return mysql, nil
 }
 
 type SourceProfileConnectionPostgreSQL struct {
-	host string // Same as PGHOST environment variable
-	port string // Same as PGPORT environment variable
-	user string // Same as PGUSER environment variable
-	db   string // Same as PGDATABASE environment variable
-	pwd  string // Same as PGPASSWORD environment variable
+	Host string // Same as PGHOST environment variable
+	Port string // Same as PGPORT environment variable
+	User string // Same as PGUSER environment variable
+	Db   string // Same as PGDATABASE environment variable
+	Pwd  string // Same as PGPASSWORD environment variable
 }
 
 func NewSourceProfileConnectionPostgreSQL(params map[string]string) (SourceProfileConnectionPostgreSQL, error) {
@@ -128,20 +128,20 @@ func NewSourceProfileConnectionPostgreSQL(params map[string]string) (SourceProfi
 		// No connection params provided through source-profile. Fetching from env variables.
 		fmt.Printf("Connection parameters not specified in source-profile. Reading from " +
 			"environment variables PGHOST, PGUSER, PGDATABASE, PGPORT, PGPASSWORD...\n")
-		pg.host = os.Getenv("PGHOST")
-		pg.user = os.Getenv("PGUSER")
-		pg.db = os.Getenv("PGDATABASE")
-		pg.port = os.Getenv("PGPORT")
-		pg.pwd = os.Getenv("PGPASSWORD")
+		pg.Host = os.Getenv("PGHOST")
+		pg.User = os.Getenv("PGUSER")
+		pg.Db = os.Getenv("PGDATABASE")
+		pg.Port = os.Getenv("PGPORT")
+		pg.Pwd = os.Getenv("PGPASSWORD")
 		// Throw error if the input entered is empty.
-		if pg.host == "" || pg.user == "" || pg.db == "" {
+		if pg.Host == "" || pg.User == "" || pg.Db == "" {
 			return pg, fmt.Errorf("found empty string for PGHOST/PGUSER/PGDATABASE. Please specify these environment variables with correct values")
 		}
 	} else if hostOk && userOk && dbOk {
 		// All connection params provided through source-profile. Port and password handled later.
-		pg.host, pg.user, pg.db, pg.port, pg.pwd = host, user, db, port, pwd
+		pg.Host, pg.User, pg.Db, pg.Port, pg.Pwd = host, user, db, port, pwd
 		// Throw error if the input entered is empty.
-		if pg.host == "" || pg.user == "" || pg.db == "" {
+		if pg.Host == "" || pg.User == "" || pg.Db == "" {
 			return pg, fmt.Errorf("found empty string for host/user/db_name. Please specify host, port, user and db_name in the source-profile")
 		}
 	} else {
@@ -149,12 +149,12 @@ func NewSourceProfileConnectionPostgreSQL(params map[string]string) (SourceProfi
 		return pg, fmt.Errorf("please specify host, port, user and db_name in the source-profile")
 	}
 
-	if pg.port == "" {
+	if pg.Port == "" {
 		// Set default port for postgresql, which rarely changes.
-		pg.port = "5432"
+		pg.Port = "5432"
 	}
-	if pg.pwd == "" {
-		pg.pwd = utils.GetPassword()
+	if pg.Pwd == "" {
+		pg.Pwd = utils.GetPassword()
 	}
 
 	return pg, nil
@@ -164,11 +164,11 @@ type SourceProfileConnectionDynamoDB struct {
 	// These connection params are not used currently because the SDK reads directly from the env variables.
 	// These are still kept around as reference when we refactor passing
 	// SourceProfile instead of sqlConnectionStr around.
-	awsAccessKeyID     string // Same as AWS_ACCESS_KEY_ID environment variable
-	awsSecretAccessKey string // Same as AWS_SECRET_ACCESS_KEY environment variable
-	awsRegion          string // Same as AWS_REGION environment variable
-	dydbEndpoint       string // Same as DYNAMODB_ENDPOINT_OVERRIDE environment variable
-	schemaSampleSize   int64  // Number of rows to use for inferring schema (default 100,000)
+	AwsAccessKeyID     string // Same as AWS_ACCESS_KEY_ID environment variable
+	AwsSecretAccessKey string // Same as AWS_SECRET_ACCESS_KEY environment variable
+	AwsRegion          string // Same as AWS_REGION environment variable
+	DydbEndpoint       string // Same as DYNAMODB_ENDPOINT_OVERRIDE environment variable
+	SchemaSampleSize   int64  // Number of rows to use for inferring schema (default 100,000)
 }
 
 func NewSourceProfileConnectionDynamoDB(params map[string]string) (SourceProfileConnectionDynamoDB, error) {
@@ -178,23 +178,23 @@ func NewSourceProfileConnectionDynamoDB(params map[string]string) (SourceProfile
 		if err != nil {
 			return dydb, fmt.Errorf("could not parse schema-sample-size = %v as a valid int64", schemaSampleSize)
 		}
-		dydb.schemaSampleSize = int64(schemaSampleSizeInt)
+		dydb.SchemaSampleSize = int64(schemaSampleSizeInt)
 	}
 	// For DynamoDB, the preferred way to provide connection params is through env variables.
 	// Unlike postgres and mysql, there may not be deprecation of env variables, hence it
 	// is better to override env variables optionally via source profile params.
 	var ok bool
-	if dydb.awsAccessKeyID, ok = params["aws-access-key-id"]; ok {
-		os.Setenv("AWS_ACCESS_KEY_ID", dydb.awsAccessKeyID)
+	if dydb.AwsAccessKeyID, ok = params["aws-access-key-id"]; ok {
+		os.Setenv("AWS_ACCESS_KEY_ID", dydb.AwsAccessKeyID)
 	}
-	if dydb.awsSecretAccessKey, ok = params["aws-secret-access-key"]; ok {
-		os.Setenv("AWS_SECRET_ACCESS_KEY", dydb.awsAccessKeyID)
+	if dydb.AwsSecretAccessKey, ok = params["aws-secret-access-key"]; ok {
+		os.Setenv("AWS_SECRET_ACCESS_KEY", dydb.AwsSecretAccessKey)
 	}
-	if dydb.awsRegion, ok = params["aws-region"]; ok {
-		os.Setenv("AWS_REGION", dydb.awsAccessKeyID)
+	if dydb.AwsRegion, ok = params["aws-region"]; ok {
+		os.Setenv("AWS_REGION", dydb.AwsRegion)
 	}
-	if dydb.dydbEndpoint, ok = params["dydb-endpoint"]; ok {
-		os.Setenv("DYNAMODB_ENDPOINT_OVERRIDE", dydb.awsAccessKeyID)
+	if dydb.DydbEndpoint, ok = params["dydb-endpoint"]; ok {
+		os.Setenv("DYNAMODB_ENDPOINT_OVERRIDE", dydb.DydbEndpoint)
 	}
 	return dydb, nil
 }
@@ -249,6 +249,7 @@ func NewSourceProfileConfig(path string) SourceProfileConfig {
 }
 
 type SourceProfile struct {
+	Driver string
 	Ty     SourceProfileType
 	File   SourceProfileFile
 	Conn   SourceProfileConnection

--- a/profiles/target_profile.go
+++ b/profiles/target_profile.go
@@ -35,8 +35,9 @@ type TargetProfileConnection struct {
 }
 
 type TargetProfile struct {
-	ty   TargetProfileType
-	conn TargetProfileConnection
+	TargetDb string
+	ty       TargetProfileType
+	conn     TargetProfileConnection
 }
 
 // ToLegacyTargetDb converts source-profile to equivalent legacy global flag

--- a/web/web.go
+++ b/web/web.go
@@ -174,7 +174,7 @@ func convertSchemaDump(w http.ResponseWriter, r *http.Request) {
 	sourceProfile.Driver = dc.Driver
 	targetProfile, _ := profiles.NewTargetProfile("")
 	targetProfile.TargetDb = constants.TargetSpanner
-	conv, err := conversion.SchemaConv(&sourceProfile, &targetProfile, &utils.IOStreams{In: f, Out: os.Stdout})
+	conv, err := conversion.SchemaConv(sourceProfile, targetProfile, &utils.IOStreams{In: f, Out: os.Stdout})
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Schema Conversion Error : %v", err), http.StatusNotFound)
 		return

--- a/web/web.go
+++ b/web/web.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cloudspannerecosystem/harbourbridge/common/utils"
 	"github.com/cloudspannerecosystem/harbourbridge/conversion"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/profiles"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/common"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/mysql"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/postgres"
@@ -168,7 +169,12 @@ func convertSchemaDump(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("failed to open dump file %v : %v", dc.FilePath, err), http.StatusNotFound)
 		return
 	}
-	conv, err := conversion.SchemaConv(dc.Driver, "", constants.TargetSpanner, &utils.IOStreams{In: f, Out: os.Stdout}, 0)
+	// We don't support Dynamodb in web hence no need to pass schema sample size here.
+	sourceProfile, _ := profiles.NewSourceProfile("", dc.Driver)
+	sourceProfile.Driver = dc.Driver
+	targetProfile, _ := profiles.NewTargetProfile("")
+	targetProfile.TargetDb = constants.TargetSpanner
+	conv, err := conversion.SchemaConv(&sourceProfile, &targetProfile, &utils.IOStreams{In: f, Out: os.Stdout})
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Schema Conversion Error : %v", err), http.StatusNotFound)
 		return


### PR DESCRIPTION
This change ensures we pass Source Profile and Target Profile across the SchemaConv and Data conv functions.
We also store driver and targetdb in source and target profiles respectively.
