### PR TITLE
Support for CSV: First Cut

### DIFF
--- a/cmd/data.go
+++ b/cmd/data.go
@@ -114,6 +114,10 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 
 	// If using CSV mode, follow different code path from here.
 	if sourceProfile.Driver == constants.CSV {
+		if targetProfile.Conn.Sp.Dbname == "" {
+			err = fmt.Errorf("dbname is mandatory in target-profile for csv source")
+			return subcommands.ExitFailure
+		}
 		// TODO: refactor this to go through DataConv(). Fix it when refactoring passing of source-profile throughout the code
 		// to avoid excess parameters in the DataConv and SchemaConv functions.
 		bw, err := conversion.DataFromCSV(conv, sourceProfile.Csv.Manifest, client, targetProfile.TargetDb)

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/cloudspannerecosystem/harbourbridge/common/utils"
 	"github.com/cloudspannerecosystem/harbourbridge/conversion"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
@@ -103,6 +104,29 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 	}
 
 	conv := internal.MakeConv()
+
+	client, err := utils.GetClient(ctx, dbURI)
+	if err != nil {
+		err = fmt.Errorf("can't create client for db %s: %v", dbURI, err)
+		return subcommands.ExitFailure
+	}
+	defer client.Close()
+
+	// If using CSV mode, follow different code path from here.
+	if sourceProfile.Driver == constants.CSV {
+		// TODO: refactor this to go through DataConv(). Fix it when refactoring passing of source-profile throughout the code
+		// to avoid excess parameters in the DataConv and SchemaConv functions.
+		bw, err := conversion.DataFromCSV(conv, sourceProfile.Csv.Manifest, client, targetProfile.TargetDb)
+		if err != nil {
+			fmt.Printf("can't finish data conversion for db %s: %v", dbURI, err)
+			return subcommands.ExitFailure
+		}
+		banner := utils.GetBanner(now, dbURI)
+		conversion.Report(sourceProfile.Driver, bw.DroppedRowsByTable(), ioHelper.BytesRead, banner, conv, cmd.filePrefix+reportFile, ioHelper.Out)
+		conversion.WriteBadData(bw, conv, banner, cmd.filePrefix+badDataFile, ioHelper.Out)
+
+		return subcommands.ExitSuccess
+	}
 	err = conversion.ReadSessionFile(conv, cmd.sessionJSON)
 	if err != nil {
 		return subcommands.ExitUsageError
@@ -118,12 +142,6 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 		return subcommands.ExitFailure
 	}
 	defer adminClient.Close()
-	client, err := utils.GetClient(ctx, dbURI)
-	if err != nil {
-		err = fmt.Errorf("can't create client for db %s: %v", dbURI, err)
-		return subcommands.ExitFailure
-	}
-	defer client.Close()
 
 	err = conversion.CreateOrUpdateDatabase(ctx, adminClient, dbURI, conv, ioHelper.Out)
 	if err != nil {

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/cloudspannerecosystem/harbourbridge/common/utils"
 	"github.com/cloudspannerecosystem/harbourbridge/conversion"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
@@ -111,8 +110,7 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 	}
 	defer client.Close()
 
-	// For csv mode, skip loading a session file.
-	if sourceProfile.Driver != constants.CSV {
+	if !sourceProfile.UseTargetSchema() {
 		err = conversion.ReadSessionFile(conv, cmd.sessionJSON)
 		if err != nil {
 			return subcommands.ExitUsageError

--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -23,6 +23,9 @@ const (
 	// This is an experimental driver; implementation in progress.
 	DYNAMODB string = "dynamodb"
 
+	// CSV is the driver name when loading data using csv.
+	CSV string = "csv"
+
 	// Target db for which schema is being generated.
 	TargetSpanner              string = "spanner"
 	TargetExperimentalPostgres string = "experimental_postgres"

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
 	"github.com/cloudspannerecosystem/harbourbridge/profiles"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/common"
+	"github.com/cloudspannerecosystem/harbourbridge/sources/csv"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/dynamodb"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/mysql"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/postgres"
@@ -278,6 +279,47 @@ func dataFromDump(driver string, config spanner.BatchWriterConfig, ioHelper *uti
 	writer.Flush()
 	p.Done()
 
+	return writer, nil
+}
+
+func DataFromCSV(conv *internal.Conv, manifestFile string, client *sp.Client, targetDb string) (*spanner.BatchWriter, error) {
+	tables, err := csv.LoadManifest(manifestFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the number of rows in each csv file for generating stats.
+	csv.SetRowStats(conv, tables)
+	totalRows := conv.Rows()
+	p := internal.NewProgress(totalRows, "Writing data to Spanner", internal.Verbose(), false)
+	rows := int64(0)
+	config := spanner.BatchWriterConfig{
+		BytesLimit: 100 * 1000 * 1000,
+		WriteLimit: 40,
+		RetryLimit: 1000,
+		Verbose:    internal.Verbose(),
+	}
+	config.Write = func(m []*sp.Mutation) error {
+		_, err := client.Apply(context.Background(), m)
+		if err != nil {
+			return err
+		}
+		atomic.AddInt64(&rows, int64(len(m)))
+		p.MaybeReport(atomic.LoadInt64(&rows))
+		return nil
+	}
+	writer := spanner.NewBatchWriter(config)
+	conv.SetDataMode()
+	conv.SetDataSink(
+		func(table string, cols []string, vals []interface{}) {
+			writer.AddRow(table, cols, vals)
+		})
+	err = csv.ProcessCSV(conv, tables)
+	if err != nil {
+		return nil, fmt.Errorf("can't process csv: %v", err)
+	}
+	writer.Flush()
+	p.Done()
 	return writer, nil
 }
 

--- a/profiles/common.go
+++ b/profiles/common.go
@@ -49,7 +49,7 @@ func parseProfile(s string) (map[string]string, error) {
 
 func GetResourceIds(ctx context.Context, targetProfile TargetProfile, now time.Time, driverName string, out *os.File) (string, string, string, error) {
 	var err error
-	project := targetProfile.conn.sp.project
+	project := targetProfile.Conn.Sp.Project
 	if project == "" {
 		project, err = utils.GetProject()
 		if err != nil {
@@ -58,7 +58,7 @@ func GetResourceIds(ctx context.Context, targetProfile TargetProfile, now time.T
 	}
 	fmt.Println("Using Google Cloud project:", project)
 
-	instance := targetProfile.conn.sp.instance
+	instance := targetProfile.Conn.Sp.Instance
 	if instance == "" {
 		instance, err = utils.GetInstance(ctx, project, out)
 		if err != nil {
@@ -68,7 +68,7 @@ func GetResourceIds(ctx context.Context, targetProfile TargetProfile, now time.T
 	fmt.Println("Using Cloud Spanner instance:", instance)
 	utils.PrintPermissionsWarning(driverName, out)
 
-	dbName := targetProfile.conn.sp.dbname
+	dbName := targetProfile.Conn.Sp.Dbname
 	if dbName == "" {
 		dbName, err = utils.GetDatabaseName(driverName, now)
 		if err != nil {

--- a/profiles/source_profile.go
+++ b/profiles/source_profile.go
@@ -430,10 +430,13 @@ func NewSourceProfile(s string, source string) (SourceProfile, error) {
 	if err != nil {
 		return SourceProfile{}, fmt.Errorf("could not parse source-profile, error = %v", err)
 	}
-
-	if _, ok := params["manifest"]; ok {
-		profile := NewSourceProfileCsv(params)
-		return SourceProfile{Ty: SourceProfileTypeCsv, Csv: profile}, nil
+	if source == constants.CSV {
+		if _, ok := params["manifest"]; ok {
+			profile := NewSourceProfileCsv(params)
+			return SourceProfile{Ty: SourceProfileTypeCsv, Csv: profile}, nil
+		} else {
+			return SourceProfile{}, fmt.Errorf("csv source requires a manifest file, please specify manifest file in the source profile e.g., -source-profile=\"manifest=file_path\"")
+		}
 	}
 
 	if _, ok := params["file"]; ok || filePipedToStdin() {

--- a/profiles/source_profile.go
+++ b/profiles/source_profile.go
@@ -399,13 +399,7 @@ func (src SourceProfile) ToLegacyDriver(source string) (string, error) {
 	case SourceProfileTypeConfig:
 		return "", fmt.Errorf("specifying source-profile using config not implemented")
 	case SourceProfileTypeCsv:
-		{
-			if strings.ToLower(source) == constants.CSV {
-				return constants.CSV, nil
-			} else {
-				return "", fmt.Errorf("found manifest in the source profile but invalid -source flag received = %v, (did you mean csv?)", source)
-			}
-		}
+		return constants.CSV, nil
 	default:
 		return "", fmt.Errorf("invalid source-profile, could not infer type")
 	}

--- a/profiles/source_profile.go
+++ b/profiles/source_profile.go
@@ -356,6 +356,12 @@ type SourceProfile struct {
 	Csv    SourceProfileCsv
 }
 
+// UseTargetSchema returns true if the driver expects an existing schema
+// to use in the target database.
+func (src SourceProfile) UseTargetSchema() bool {
+	return (src.Driver == constants.CSV)
+}
+
 // ToLegacyDriver converts source-profile to equivalent legacy global flags
 // e.g., -driver, -dump-file etc since the rest of the codebase still uses the
 // same. TODO: Deprecate this function and pass around SourceProfile across the
@@ -430,7 +436,7 @@ func NewSourceProfile(s string, source string) (SourceProfile, error) {
 	if err != nil {
 		return SourceProfile{}, fmt.Errorf("could not parse source-profile, error = %v", err)
 	}
-	if source == constants.CSV {
+	if strings.ToLower(source) == constants.CSV {
 		if _, ok := params["manifest"]; ok {
 			profile := NewSourceProfileCsv(params)
 			return SourceProfile{Ty: SourceProfileTypeCsv, Csv: profile}, nil

--- a/profiles/source_profile.go
+++ b/profiles/source_profile.go
@@ -328,11 +328,23 @@ func NewSourceProfileConfig(path string) SourceProfileConfig {
 }
 
 type SourceProfileCsv struct {
-	Manifest string
+	Manifest  string
+	Delimiter string
+	NullStr   string
 }
 
-func NewSourceProfileCsv(manifest string) SourceProfileCsv {
-	return SourceProfileCsv{Manifest: manifest}
+func NewSourceProfileCsv(params map[string]string) SourceProfileCsv {
+	csvProfile := SourceProfileCsv{}
+	csvProfile.Manifest = params["manifest"]
+	csvProfile.Delimiter = ","
+	csvProfile.NullStr = ""
+	if delimiter, ok := params["delimiter"]; ok {
+		csvProfile.Delimiter = delimiter
+	}
+	if nullStr, ok := params["nullStr"]; ok {
+		csvProfile.NullStr = nullStr
+	}
+	return csvProfile
 }
 
 type SourceProfile struct {
@@ -419,8 +431,8 @@ func NewSourceProfile(s string, source string) (SourceProfile, error) {
 		return SourceProfile{}, fmt.Errorf("could not parse source-profile, error = %v", err)
 	}
 
-	if manifest, ok := params["manifest"]; ok {
-		profile := NewSourceProfileCsv(manifest)
+	if _, ok := params["manifest"]; ok {
+		profile := NewSourceProfileCsv(params)
 		return SourceProfile{Ty: SourceProfileTypeCsv, Csv: profile}, nil
 	}
 

--- a/profiles/target_profile.go
+++ b/profiles/target_profile.go
@@ -22,22 +22,22 @@ const (
 )
 
 type TargetProfileConnectionSpanner struct {
-	endpoint string // Same as SPANNER_API_ENDPOINT environment variable
-	project  string // Same as GCLOUD_PROJECT environment variable
-	instance string
-	dbname   string
-	dialect  string
+	Endpoint string // Same as SPANNER_API_ENDPOINT environment variable
+	Project  string // Same as GCLOUD_PROJECT environment variable
+	Instance string
+	Dbname   string
+	Dialect  string
 }
 
 type TargetProfileConnection struct {
-	ty TargetProfileConnectionType
-	sp TargetProfileConnectionSpanner
+	Ty TargetProfileConnectionType
+	Sp TargetProfileConnectionSpanner
 }
 
 type TargetProfile struct {
 	TargetDb string
-	ty       TargetProfileType
-	conn     TargetProfileConnection
+	Ty       TargetProfileType
+	Conn     TargetProfileConnection
 }
 
 // ToLegacyTargetDb converts source-profile to equivalent legacy global flag
@@ -45,15 +45,15 @@ type TargetProfile struct {
 // TODO: Deprecate this function and pass around TargetProfile across the
 // codebase wherever information about target connection is required.
 func (trg TargetProfile) ToLegacyTargetDb() string {
-	switch trg.ty {
+	switch trg.Ty {
 	case TargetProfileTypeConnection:
 		{
-			conn := trg.conn
-			switch conn.ty {
+			conn := trg.Conn
+			switch conn.Ty {
 			case TargetProfileConnectionTypeSpanner:
 				{
-					sp := conn.sp
-					if len(sp.dialect) > 0 && strings.ToLower(sp.dialect) == constants.DIALECT_POSTGRESQL {
+					sp := conn.Sp
+					if len(sp.Dialect) > 0 && strings.ToLower(sp.Dialect) == constants.DIALECT_POSTGRESQL {
 						return constants.TargetExperimentalPostgres
 					}
 					return constants.TargetSpanner
@@ -94,21 +94,21 @@ func NewTargetProfile(s string) (TargetProfile, error) {
 
 	sp := TargetProfileConnectionSpanner{}
 	if endpoint, ok := params["endpoint"]; ok {
-		sp.endpoint = endpoint
+		sp.Endpoint = endpoint
 	}
 	if project, ok := params["project"]; ok {
-		sp.project = project
+		sp.Project = project
 	}
 	if instance, ok := params["instance"]; ok {
-		sp.instance = instance
+		sp.Instance = instance
 	}
 	if dbname, ok := params["dbname"]; ok {
-		sp.dbname = dbname
+		sp.Dbname = dbname
 	}
 	if dialect, ok := params["dialect"]; ok {
-		sp.dialect = dialect
+		sp.Dialect = dialect
 	}
 
-	conn := TargetProfileConnection{ty: TargetProfileConnectionTypeSpanner, sp: sp}
-	return TargetProfile{ty: TargetProfileTypeConnection, conn: conn}, nil
+	conn := TargetProfileConnection{Ty: TargetProfileConnectionTypeSpanner, Sp: sp}
+	return TargetProfile{Ty: TargetProfileTypeConnection, Conn: conn}, nil
 }

--- a/sources/csv/data.go
+++ b/sources/csv/data.go
@@ -1,0 +1,284 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csv
+
+import (
+	csvReader "encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"strconv"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/schema"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+)
+
+type Column struct {
+	Column_name string `json:"column_name"`
+	Type_name   string `json:"type_name"`
+}
+
+// Harbourbridge accepts a manifest file in the form of a json which unmarshalls into the Table struct.
+type Table struct {
+	Table_name    string   `json:"table_name"`
+	File_patterns []string `json:"file_patterns"`
+	Columns       []Column `json:"columns"`
+}
+
+// LoadManifest reads the manifest file and unmarshalls it into a list of Table struct.
+// It also performs certain checks on the manifest.
+func LoadManifest(manifestFile string) ([]Table, error) {
+	manifest, err := ioutil.ReadFile(manifestFile)
+	if err != nil {
+		return nil, fmt.Errorf("can't read manifest file due to: %v", err)
+	}
+	tables := []Table{}
+	err = json.Unmarshal(manifest, &tables)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshall json due to: %v", err)
+	}
+	err = verifyManifest(tables)
+	if err != nil {
+		return nil, fmt.Errorf("manifest is incomplete: %v", err)
+	}
+	return tables, nil
+}
+
+// verifyManifest performs certain prechecks on the structure of the manifest.
+// Checks on valid file paths and empty CSVs are handled as conv.Unexpected errors later during processing.
+func verifyManifest(tables []Table) error {
+	if len(tables) == 0 {
+		return fmt.Errorf("no tables found")
+	}
+	for i, table := range tables {
+		name := table.Table_name
+		if name == "" {
+			return fmt.Errorf("table number %d (0-indexed) does not have a name", i)
+		}
+		if len(table.File_patterns) == 0 {
+			return fmt.Errorf("no file path provided for table %s", name)
+		}
+		cols := table.Columns
+		if len(cols) == 0 {
+			return fmt.Errorf("`columns` field for table %s is empty", name)
+		}
+		for j, col := range cols {
+			if col.Column_name == "" || col.Type_name == "" {
+				return fmt.Errorf("please provide column_name and type_name in `columns` field at position %d (0-indexed)", j)
+			}
+		}
+	}
+	return nil
+}
+
+// SetRowStats calculates the number of rows per table.
+func SetRowStats(conv *internal.Conv, tables []Table) {
+	for _, table := range tables {
+		for _, filePath := range table.File_patterns {
+			count, err := getCSVRowCount(filePath)
+			if err != nil {
+				conv.Unexpected(fmt.Sprintf("Couldn't get number of rows for table %s", table.Table_name))
+				continue
+			}
+			conv.Stats.Rows[table.Table_name] += count
+		}
+	}
+}
+
+// getCSVRowCount returns the number of data rows in the CSV file.
+func getCSVRowCount(filePath string) (int64, error) {
+	count := int64(0)
+	csvFile, err := os.Open(filePath)
+	if err != nil {
+		fmt.Printf("can't read csv file: %s due to: %v\n", filePath, err)
+	}
+	r := csvReader.NewReader(csvFile)
+	for {
+		_, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, fmt.Errorf("can't read row from file: %s", filePath)
+		}
+		count++
+	}
+	// Exclude the first row, that is, column headers.
+	return count - 1, nil
+}
+
+// ProcessCSV writes data across the tables provided in the manifest file. Each table's data can be provided
+// across multiple CSV files hence, the manifest accepts a list of file paths in the input.
+func ProcessCSV(conv *internal.Conv, tables []Table) error {
+	for _, table := range tables {
+		// Populating just the table names in the conv for SrcSchema and SpSchema
+		// so the report for row stats is generated.
+		conv.SrcSchema[table.Table_name] = schema.Table{Name: table.Table_name}
+
+		// The map colDefs stores the mapping from column names to their final types.
+		colDefs := make(map[string]ddl.ColumnDef)
+		for _, col := range table.Columns {
+			ty, err := ToSpannerType(col.Type_name)
+			if err != nil {
+				return fmt.Errorf("can't map to spanner type: %v. Please use the data types as in your spanner database", err)
+			}
+			colDefs[col.Column_name] = ddl.ColumnDef{Name: col.Column_name, T: ty}
+		}
+		conv.SpSchema[table.Table_name] = ddl.CreateTable{Name: table.Table_name, ColDefs: colDefs}
+
+		for _, filePath := range table.File_patterns {
+			csvFile, err := os.Open(filePath)
+			if err != nil {
+				return fmt.Errorf(fmt.Sprintf("can't read csv file: %s due to: %v\n", filePath, err))
+			}
+			r := csvReader.NewReader(csvFile)
+
+			// First row is expected to be the column headers.
+			srcCols, err := r.Read()
+			if err == io.EOF {
+				conv.Unexpected(fmt.Sprintf("File %s is empty.", filePath))
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("can't read csv headers for col names due to: %v", err)
+			}
+			for {
+				values, err := r.Read()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return fmt.Errorf(fmt.Sprintf("can't read row  names due to: %v", err))
+				}
+				processDataRow(conv, table.Table_name, srcCols, values)
+			}
+		}
+	}
+	return nil
+}
+
+// processDataRow converts a row into go data types as per the client libs.
+func processDataRow(conv *internal.Conv, tableName string, srcCols []string, values []string) {
+	cvtVals, err := convertData(conv, tableName, srcCols, values)
+	if err != nil {
+		conv.Unexpected(fmt.Sprintf("Error while converting data: %s\n", err))
+		conv.StatsAddBadRow(tableName, conv.DataMode())
+		conv.CollectBadRow(tableName, srcCols, values)
+	} else {
+		conv.WriteRow(tableName, tableName, srcCols, cvtVals)
+	}
+}
+
+// convertData currently only supports scalar data types.
+func convertData(conv *internal.Conv, tableName string, srcCols []string, values []string) ([]interface{}, error) {
+	var v []interface{}
+	colDefs := conv.SpSchema[tableName].ColDefs
+	for i, val := range values {
+		colName := srcCols[i]
+		x, err := convScalar(colDefs[colName].T, val)
+		if err != nil {
+			return nil, err
+		}
+		v = append(v, x)
+	}
+	return v, nil
+}
+
+func convScalar(spannerType ddl.Type, val string) (interface{}, error) {
+	switch spannerType.Name {
+	case ddl.Bool:
+		return convBool(val)
+	case ddl.Bytes:
+		return convBytes(val)
+	case ddl.Date:
+		return convDate(val)
+	case ddl.Float64:
+		return convFloat64(val)
+	case ddl.Int64:
+		return convInt64(val)
+	case ddl.Numeric:
+		return convNumeric(val)
+	case ddl.String:
+		return val, nil
+	case ddl.Timestamp:
+		return convTimestamp(val)
+	case ddl.JSON:
+		return val, nil
+	default:
+		return val, fmt.Errorf("data conversion not implemented for type %v", spannerType)
+	}
+}
+
+func convBool(val string) (bool, error) {
+	b, err := strconv.ParseBool(val)
+	if err != nil {
+		return b, fmt.Errorf("can't convert to bool: %w", err)
+	}
+	return b, err
+}
+
+func convBytes(val string) ([]byte, error) {
+	// convert a string to a byte slice.
+	b := []byte(val)
+	return b, nil
+}
+
+func convDate(val string) (civil.Date, error) {
+	d, err := civil.ParseDate(val)
+	if err != nil {
+		return d, fmt.Errorf("can't convert to date: %w", err)
+	}
+	return d, err
+}
+
+func convFloat64(val string) (float64, error) {
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return f, fmt.Errorf("can't convert to float64: %w", err)
+	}
+	return f, err
+}
+
+func convInt64(val string) (int64, error) {
+	i, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return i, fmt.Errorf("can't convert to int64: %w", err)
+	}
+	return i, err
+}
+
+// convNumeric maps a source database string value (representing a numeric)
+// into a string representing a valid Spanner numeric.
+func convNumeric(val string) (interface{}, error) {
+	r := new(big.Rat)
+	if _, ok := r.SetString(val); !ok {
+		return "", fmt.Errorf("can't convert %q to big.Rat", val)
+	}
+	return r, nil
+}
+
+func convTimestamp(val string) (t time.Time, err error) {
+	t, err = time.Parse("2006-01-02 15:04:05", val)
+	if err != nil {
+		return t, fmt.Errorf("can't convert to timestamp: %s", val)
+	}
+	return t, err
+}

--- a/sources/csv/data.go
+++ b/sources/csv/data.go
@@ -117,7 +117,7 @@ func SetRowStats(conv *internal.Conv, tables []Table, delimiter rune) {
 				continue
 			}
 			if count == 0 {
-				conv.Unexpected(fmt.Sprintf("File %s is empty.", filePath))
+				conv.Unexpected(fmt.Sprintf("error processing table %s: file %s is empty.", table.Table_name, filePath))
 				continue
 			}
 			conv.Stats.Rows[table.Table_name] += count - 1
@@ -156,7 +156,7 @@ func ProcessCSV(conv *internal.Conv, tables []Table, nullStr string, delimiter r
 			// First row is expected to be the column headers.
 			srcCols, err := r.Read()
 			if err == io.EOF {
-				conv.Unexpected(fmt.Sprintf("File %s is empty.", filePath))
+				conv.Unexpected(fmt.Sprintf("error processing table %s: file %s is empty.", table.Table_name, filePath))
 				continue
 			}
 			if err != nil {

--- a/sources/csv/data_test.go
+++ b/sources/csv/data_test.go
@@ -1,0 +1,216 @@
+package csv
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+	"github.com/stretchr/testify/assert"
+)
+
+type spannerData struct {
+	table string
+	cols  []string
+	vals  []interface{}
+}
+
+const (
+	ALL_TYPES_TABLE string = "all_data_types"
+	SINGERS_TABLE   string = "singers"
+
+	ALL_TYPES_CSV string = ALL_TYPES_TABLE + ".csv"
+	SINGERS_1_CSV string = SINGERS_TABLE + "_1.csv"
+	SINGERS_2_CSV string = SINGERS_TABLE + "_2.csv"
+)
+
+func getManifestTables() []Table {
+	return []Table{
+		{
+			Table_name:    ALL_TYPES_TABLE,
+			File_patterns: []string{ALL_TYPES_CSV},
+			Columns: []Column{
+				{Column_name: "bool_col", Type_name: "BOOL"},
+				{Column_name: "byte_col", Type_name: "BYTES"},
+				{Column_name: "date_col", Type_name: "DATE"},
+				{Column_name: "float_col", Type_name: "FLOAT64"},
+				{Column_name: "int_col", Type_name: "INT64"},
+				{Column_name: "numeric_col", Type_name: "NUMERIC"},
+				{Column_name: "string_col", Type_name: "STRING"},
+				{Column_name: "timestamp_col", Type_name: "TIMESTAMP"},
+				{Column_name: "json_col", Type_name: "JSON"},
+			},
+		},
+		{
+			Table_name:    SINGERS_TABLE,
+			File_patterns: []string{SINGERS_1_CSV, SINGERS_2_CSV},
+			Columns: []Column{
+				{Column_name: "SingerId", Type_name: "INT64"},
+				{Column_name: "FirstName", Type_name: "STRING"},
+				{Column_name: "LastName", Type_name: "STRING"},
+			},
+		},
+	}
+}
+
+func writeCSVs(t *testing.T) {
+	csvInput := []struct {
+		fileName string
+		data     []string
+	}{
+		{
+			ALL_TYPES_CSV,
+			[]string{
+				"bool_col,byte_col,date_col,float_col,int_col,numeric_col,string_col,timestamp_col,json_col\n",
+				"true,test,2019-10-29,15.13,100,39.94,Helloworld,2019-10-29 05:30:00,\"{\"\"key1\"\": \"\"value1\"\", \"\"key2\"\": \"\"value2\"\"}\"",
+			},
+		},
+		{
+			SINGERS_1_CSV,
+			[]string{
+				"SingerId,FirstName,LastName\n",
+				"1,\"fn1\",ln1",
+			},
+		},
+		{
+			SINGERS_2_CSV,
+			[]string{
+				"SingerId,FirstName,LastName\n",
+				"2,fn2,\"ln2\"",
+			},
+		},
+	}
+	for _, in := range csvInput {
+		f, err := os.Create(in.fileName)
+		if err != nil {
+			t.Fatalf("Could not create %s: %v", in.fileName, err)
+		}
+		if _, err := f.WriteString(strings.Join(in.data, "")); err != nil {
+			t.Fatalf("Could not write to %s: %v", in.fileName, err)
+		}
+	}
+}
+
+func cleanupCSVs() {
+	for _, fn := range []string{ALL_TYPES_CSV, SINGERS_1_CSV, SINGERS_2_CSV} {
+		os.Remove(fn)
+	}
+}
+
+func TestSetRowStats(t *testing.T) {
+	conv := internal.MakeConv()
+	writeCSVs(t)
+	defer cleanupCSVs()
+	SetRowStats(conv, getManifestTables())
+	assert.Equal(t, map[string]int64{ALL_TYPES_TABLE: 1, SINGERS_TABLE: 2}, conv.Stats.Rows)
+}
+
+func TestProcessDataRow(t *testing.T) {
+	conv := internal.MakeConv()
+	var rows []spannerData
+	conv.SetDataMode()
+	conv.SetDataSink(
+		func(table string, cols []string, vals []interface{}) {
+			rows = append(rows, spannerData{table: table, cols: cols, vals: vals})
+		})
+
+	writeCSVs(t)
+	defer cleanupCSVs()
+
+	err := ProcessCSV(conv, getManifestTables())
+	fmt.Println(err)
+	assert.Nil(t, err)
+	assert.Equal(t, []spannerData{
+		{
+			table: ALL_TYPES_TABLE,
+			cols:  []string{"bool_col", "byte_col", "date_col", "float_col", "int_col", "numeric_col", "string_col", "timestamp_col", "json_col"},
+			vals:  []interface{}{true, []uint8{0x74, 0x65, 0x73, 0x74}, getDate("2019-10-29"), 15.13, int64(100), big.NewRat(3994, 100), "Helloworld", getTime(t, "2019-10-29T05:30:00Z"), "{\"key1\": \"value1\", \"key2\": \"value2\"}"},
+		},
+		{table: SINGERS_TABLE, cols: []string{"SingerId", "FirstName", "LastName"}, vals: []interface{}{int64(1), "fn1", "ln1"}},
+		{table: SINGERS_TABLE, cols: []string{"SingerId", "FirstName", "LastName"}, vals: []interface{}{int64(2), "fn2", "ln2"}},
+	}, rows)
+}
+
+func TestConvertData(t *testing.T) {
+	singleColTests := []struct {
+		name string
+		ty   ddl.Type
+		in   string      // Input value for conversion.
+		ev   interface{} // Expected values.
+	}{
+		{"bool", ddl.Type{Name: ddl.Bool}, "true", true},
+		{"bytes", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, string([]byte{137, 80}), []byte{0x89, 0x50}},
+		{"date", ddl.Type{Name: ddl.Date}, "2019-10-29", getDate("2019-10-29")},
+		{"float64", ddl.Type{Name: ddl.Float64}, "42.6", float64(42.6)},
+		{"int64", ddl.Type{Name: ddl.Int64}, "42", int64(42)},
+		{"numeric", ddl.Type{Name: ddl.Numeric}, "42.6", big.NewRat(426, 10)},
+		{"string", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, "eh", "eh"},
+		{"timestamp", ddl.Type{Name: ddl.Timestamp}, "2019-10-29 05:30:00", getTime(t, "2019-10-29T05:30:00Z")},
+		{"json", ddl.Type{Name: ddl.JSON}, "{\"key1\": \"value1\"}", "{\"key1\": \"value1\"}"},
+	}
+	tableName := "testtable"
+	for _, tc := range singleColTests {
+		col := "a"
+		conv := buildConv(
+			ddl.CreateTable{
+				Name:    tableName,
+				ColDefs: map[string]ddl.ColumnDef{col: ddl.ColumnDef{Name: col, T: tc.ty}}})
+		av, err := convertData(conv, tableName, []string{col}, []string{tc.in})
+		assert.Nil(t, err, tc.name)
+		assert.Equal(t, []interface{}{tc.ev}, av, tc.name+": value mismatch")
+	}
+
+	cols := []string{"a", "b", "c"}
+	spTable := ddl.CreateTable{
+		Name: tableName,
+		ColDefs: map[string]ddl.ColumnDef{
+			"a": ddl.ColumnDef{Name: "a", T: ddl.Type{Name: ddl.Int64}},
+			"b": ddl.ColumnDef{Name: "b", T: ddl.Type{Name: ddl.Float64}},
+			"c": ddl.ColumnDef{Name: "c", T: ddl.Type{Name: ddl.Bool}},
+		}}
+	errorTests := []struct {
+		name string
+		cols []string // Input columns.
+		vals []string // Input values.
+	}{
+		{
+			name: "Error in int64",
+			vals: []string{" 6", "6.6", "true"},
+		},
+		{
+			name: "Error in float64",
+			vals: []string{"6", "6.6e", "true"},
+		},
+		{
+			name: "Error in bool",
+			vals: []string{"6", "6.6", "truee"},
+		},
+	}
+	for _, tc := range errorTests {
+		conv := buildConv(spTable)
+		_, err := convertData(conv, tableName, cols, tc.vals)
+		assert.NotNil(t, err, tc.name)
+	}
+}
+
+func buildConv(spTable ddl.CreateTable) *internal.Conv {
+	conv := internal.MakeConv()
+	conv.SpSchema[spTable.Name] = spTable
+	return conv
+}
+
+func getTime(t *testing.T, s string) time.Time {
+	x, err := time.Parse(time.RFC3339, s)
+	assert.Nil(t, err, fmt.Sprintf("getTime can't parse %s:", s))
+	return x
+}
+
+func getDate(s string) civil.Date {
+	d, _ := civil.ParseDate(s)
+	return d
+}

--- a/sources/csv/toddl.go
+++ b/sources/csv/toddl.go
@@ -1,0 +1,36 @@
+package csv
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+)
+
+func ToSpannerType(columnType string) (ddl.Type, error) {
+	ty := strings.ToUpper(columnType)
+	switch {
+	case ty == "BOOL":
+		return ddl.Type{Name: ddl.Bool}, nil
+	// In case user enters the length as well, ex: BYTES(40).
+	case strings.HasPrefix(ty, "BYTES"):
+		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
+	case ty == "DATE":
+		return ddl.Type{Name: ddl.Date}, nil
+	case ty == "FLOAT64" || ty == "FLOAT":
+		return ddl.Type{Name: ddl.Float64}, nil
+	case ty == "INT64" || ty == "INT":
+		return ddl.Type{Name: ddl.Int64}, nil
+	case ty == "NUMERIC":
+		return ddl.Type{Name: ddl.Numeric}, nil
+	// In case user enters the length as well, ex: STRING(40).
+	case strings.HasPrefix(ty, "STRING"):
+		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
+	case ty == "TIMESTAMP":
+		return ddl.Type{Name: ddl.Timestamp}, nil
+	case ty == "JSON":
+		return ddl.Type{Name: ddl.JSON}, nil
+	default:
+		return ddl.Type{}, fmt.Errorf("%v is not a valid Spanner column type", columnType)
+	}
+}

--- a/sources/csv/toddl.go
+++ b/sources/csv/toddl.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
@@ -12,20 +13,28 @@ func ToSpannerType(columnType string) (ddl.Type, error) {
 	switch {
 	case ty == "BOOL":
 		return ddl.Type{Name: ddl.Bool}, nil
-	// In case user enters the length as well, ex: BYTES(40).
+	// We accept variations including BYTES, BYTES(), BYTES(0) since the length doesn't matter.
 	case strings.HasPrefix(ty, "BYTES"):
-		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
+		match, _ := regexp.MatchString(`^BYTES\([0-9]*\)$`, ty)
+		if match || ty == "BYTES" {
+			return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
+		}
+		return ddl.Type{}, fmt.Errorf("%v is not a valid Spanner column type", columnType)
 	case ty == "DATE":
 		return ddl.Type{Name: ddl.Date}, nil
-	case ty == "FLOAT64" || ty == "FLOAT":
+	case ty == "FLOAT64":
 		return ddl.Type{Name: ddl.Float64}, nil
-	case ty == "INT64" || ty == "INT":
+	case ty == "INT64":
 		return ddl.Type{Name: ddl.Int64}, nil
 	case ty == "NUMERIC":
 		return ddl.Type{Name: ddl.Numeric}, nil
-	// In case user enters the length as well, ex: STRING(40).
+	// We accept variations including STRING, STRING(), STRING(0) since the length doesn't matter.
 	case strings.HasPrefix(ty, "STRING"):
-		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
+		match, _ := regexp.MatchString(`^STRING\([0-9]*\)$`, ty)
+		if match || ty == "STRING" {
+			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
+		}
+		return ddl.Type{}, fmt.Errorf("%v is not a valid Spanner column type", columnType)
 	case ty == "TIMESTAMP":
 		return ddl.Type{Name: ddl.Timestamp}, nil
 	case ty == "JSON":

--- a/sources/csv/toddl_test.go
+++ b/sources/csv/toddl_test.go
@@ -1,0 +1,59 @@
+package csv
+
+import (
+	"testing"
+
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToSpannerType(t *testing.T) {
+	conv := internal.MakeConv()
+	conv.SetSchemaMode()
+	toDDLTests := []struct {
+		name       string
+		columnType string
+		expDDLType ddl.Type
+	}{
+		// Exact inputs.
+		{"bool", "BOOL", ddl.Type{Name: ddl.Bool}},
+		{"bytes", "BYTES", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},
+		{"date", "DATE", ddl.Type{Name: ddl.Date}},
+		{"float", "FLOAT64", ddl.Type{Name: ddl.Float64}},
+		{"int", "INT64", ddl.Type{Name: ddl.Int64}},
+		{"numeric", "NUMERIC", ddl.Type{Name: ddl.Numeric}},
+		{"string", "STRING", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+		{"timestamp", "TIMESTAMP", ddl.Type{Name: ddl.Timestamp}},
+		{"json", "JSON", ddl.Type{Name: ddl.JSON}},
+		// Variations in case and field length.
+		{"bool mixed case", "BoOl", ddl.Type{Name: ddl.Bool}},
+		{"NUMERIC mixed case", "numErIC", ddl.Type{Name: ddl.Numeric}},
+		{"timestamp mixed case", "tImEsTamP", ddl.Type{Name: ddl.Timestamp}},
+		{"string with length", "STRING(100)", ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+		{"mixed case byte with length", "BytES(100)", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},
+		{"mixed case byte with no length", "BytES()", ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},
+	}
+	for _, tc := range toDDLTests {
+		ty, err := ToSpannerType(tc.columnType)
+		assert.Nil(t, err, tc.name)
+		assert.Equal(t, tc.expDDLType, ty, tc.name)
+	}
+
+	errorTests := []struct {
+		columnType string
+	}{
+		// These columns should error out.
+		{"BYTE"},
+		{"STRINGS"},
+		{"INTEGER"},
+		{"INT32"},
+		{"INT"},
+		{"FLOAT"},
+		{"BOOLEAN"},
+	}
+	for _, tc := range errorTests {
+		_, err := ToSpannerType(tc.columnType)
+		assert.NotNil(t, err)
+	}
+}

--- a/test_data/csv_manifest.json
+++ b/test_data/csv_manifest.json
@@ -1,0 +1,19 @@
+[
+    {
+      "table_name": "all_data_types",
+      "file_patterns": [
+        "../../test_data/all_data_types.csv"
+      ],
+      "columns": [
+        {"column_name": "a", "type_name": "BOOL"},
+        {"column_name": "b", "type_name": "BYTES"},
+        {"column_name": "c", "type_name": "DATE"},
+        {"column_name": "d", "type_name": "FLOAT64"},
+        {"column_name": "e", "type_name": "INT64"},
+        {"column_name": "f", "type_name": "NUMERIC"},
+        {"column_name": "g", "type_name": "STRING"},
+        {"column_name": "h", "type_name": "TIMESTAMP"},
+        {"column_name": "i", "type_name": "JSON"}
+      ]
+    }
+]

--- a/testing/csv/integration_test.go
+++ b/testing/csv/integration_test.go
@@ -1,0 +1,275 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csv_test
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudspannerecosystem/harbourbridge/testing/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"google.golang.org/api/iterator"
+
+	databasepb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+)
+
+var (
+	projectID  string
+	instanceID string
+
+	ctx           context.Context
+	databaseAdmin *database.DatabaseAdminClient
+)
+
+const (
+	ALL_TYPES_CSV string = "../../test_data/all_data_types.csv"
+)
+
+type SpannerRecord struct {
+	AttrBool      bool
+	AttrBytes     []byte
+	AttrDate      civil.Date
+	AttrFloat     float64
+	AttrInt       int64
+	AttrNumeric   float64
+	AttrString    string
+	AttrTimestamp time.Time
+	AttrJson      spanner.NullJSON
+}
+
+func TestMain(m *testing.M) {
+	cleanup := initIntegrationTests()
+	res := m.Run()
+	cleanup()
+	os.Exit(res)
+}
+
+func initIntegrationTests() (cleanup func()) {
+	projectID = os.Getenv("HARBOURBRIDGE_TESTS_GCLOUD_PROJECT_ID")
+	instanceID = os.Getenv("HARBOURBRIDGE_TESTS_GCLOUD_INSTANCE_ID")
+
+	ctx = context.Background()
+	flag.Parse() // Needed for testing.Short().
+	noop := func() {}
+
+	if testing.Short() {
+		log.Println("Integration tests skipped in -short mode.")
+		return noop
+	}
+
+	if projectID == "" {
+		log.Println("Integration tests skipped: HARBOURBRIDGE_TESTS_GCLOUD_PROJECT_ID is missing")
+		return noop
+	}
+
+	if instanceID == "" {
+		log.Println("Integration tests skipped: HARBOURBRIDGE_TESTS_GCLOUD_INSTANCE_ID is missing")
+		return noop
+	}
+
+	var err error
+	databaseAdmin, err = database.NewDatabaseAdminClient(ctx)
+	if err != nil {
+		log.Fatalf("cannot create databaseAdmin client: %v", err)
+	}
+
+	return func() {
+		databaseAdmin.Close()
+	}
+}
+
+func dropDatabase(t *testing.T, dbURI string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	// Drop the testing database.
+	if err := databaseAdmin.DropDatabase(ctx, &databasepb.DropDatabaseRequest{Database: dbURI}); err != nil {
+		t.Fatalf("failed to drop testing database %v: %v", dbURI, err)
+	}
+}
+
+func prepareIntegrationTest(t *testing.T) string {
+	tmpdir, err := ioutil.TempDir(".", "int-test-")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return tmpdir
+}
+
+func createSpannerSchema(t *testing.T, project, instance, dbName string) {
+	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, dbName)
+	req := &databasepb.CreateDatabaseRequest{
+		Parent: fmt.Sprintf("projects/%s/instances/%s", project, instance),
+	}
+	req.CreateStatement = "CREATE DATABASE `" + dbName + "`"
+	req.ExtraStatements = []string{"CREATE TABLE all_data_types (" +
+		"a BOOL," +
+		"b BYTES(50)," +
+		"c DATE," +
+		"d FLOAT64," +
+		"e INT64," +
+		"f NUMERIC," +
+		"g STRING(50)," +
+		"h TIMESTAMP," +
+		"i JSON," +
+		") PRIMARY KEY(e)",
+	}
+	op, err := databaseAdmin.CreateDatabase(ctx, req)
+	if err != nil {
+		t.Fatalf("can't build CreateDatabaseRequest for %s", dbURI)
+	}
+	if _, err := op.Wait(ctx); err != nil {
+		t.Fatalf("createDatabase call failed for %s", dbURI)
+	}
+}
+
+func TestIntegration_CSV_Command(t *testing.T) {
+	onlyRunForEmulatorTest(t)
+	t.Parallel()
+
+	tmpdir := prepareIntegrationTest(t)
+	defer os.RemoveAll(tmpdir)
+
+	dbName := "csv-test"
+	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
+	manifest := "../../test_data/csv_manifest.json"
+
+	writeCSVs(t)
+	defer cleanupCSVs()
+	createSpannerSchema(t, projectID, instanceID, dbName)
+	args := fmt.Sprintf("data -source=csv -source-profile='manifest=%s' -target-profile='instance=%s,dbname=%s'", manifest, instanceID, dbName)
+	err := common.RunCommand(args, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drop the database later.
+	defer dropDatabase(t, dbURI)
+
+	checkResults(t, dbURI, false)
+}
+
+func writeCSVs(t *testing.T) {
+	csvInput := []struct {
+		fileName string
+		data     []string
+	}{
+		{
+			ALL_TYPES_CSV,
+			[]string{
+				"a,b,c,d,e,f,g,h,i\n",
+				"true,test,2019-10-29,15.13,100,39.94,Helloworld,2019-10-29 05:30:00,\"{\"\"key1\"\": \"\"value1\"\", \"\"key2\"\": \"\"value2\"\"}\"",
+			},
+		},
+	}
+	for _, in := range csvInput {
+		f, err := os.Create(in.fileName)
+		if err != nil {
+			t.Fatalf("Could not create %s: %v", in.fileName, err)
+		}
+		if _, err := f.WriteString(strings.Join(in.data, "")); err != nil {
+			t.Fatalf("Could not write to %s: %v", in.fileName, err)
+		}
+	}
+}
+
+func cleanupCSVs() {
+	for _, fn := range []string{ALL_TYPES_CSV} {
+		os.Remove(fn)
+	}
+}
+
+func checkResults(t *testing.T, dbURI string, skipJson bool) {
+	// Make a query to check results.
+	client, err := spanner.NewClient(ctx, dbURI)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	checkRow(ctx, t, client)
+}
+
+func checkRow(ctx context.Context, t *testing.T, client *spanner.Client) {
+	wantRecord := SpannerRecord{
+		AttrBool:      true,
+		AttrBytes:     []uint8{0x74, 0x65, 0x73, 0x74},
+		AttrDate:      getDate("2019-10-29"),
+		AttrFloat:     15.13,
+		AttrInt:       int64(100),
+		AttrNumeric:   float64(39.94),
+		AttrString:    "Helloworld",
+		AttrTimestamp: getTime(t, "2019-10-29T05:30:00Z"),
+		AttrJson:      spanner.NullJSON{Valid: true},
+	}
+	json.Unmarshal([]byte("{\"key1\": \"value1\", \"key2\": \"value2\"}"), &wantRecord.AttrJson.Value)
+
+	gotRecord := SpannerRecord{}
+	stmt := spanner.Statement{SQL: `SELECT a, b, c, d, e, f, g, h, i FROM all_data_types`}
+	iter := client.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Println("Error reading row: ", err)
+			t.Fatal(err)
+			break
+		}
+		// We don't create big.Rat fields in the SpannerRecord structs
+		// because cmp.Equal cannot compare big.Rat fields automatically.
+		var AttrNumeric big.Rat
+		if err := row.Columns(&gotRecord.AttrBool, &gotRecord.AttrBytes, &gotRecord.AttrDate, &gotRecord.AttrFloat, &gotRecord.AttrInt, &AttrNumeric, &gotRecord.AttrString, &gotRecord.AttrTimestamp, &gotRecord.AttrJson); err != nil {
+			log.Println("Error reading into variables: ", err)
+			t.Fatal(err)
+			break
+		}
+		gotRecord.AttrNumeric, _ = AttrNumeric.Float64()
+	}
+	if !cmp.Equal(wantRecord, gotRecord) {
+		t.Fatalf("found unequal records, want: %+v, got: %+v", wantRecord, gotRecord)
+	}
+}
+
+func onlyRunForEmulatorTest(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("Skipping tests only running against the emulator.")
+	}
+}
+
+func getTime(t *testing.T, s string) time.Time {
+	x, err := time.Parse(time.RFC3339, s)
+	assert.Nil(t, err, fmt.Sprintf("getTime can't parse %s:", s))
+	return x
+}
+
+func getDate(s string) civil.Date {
+	d, _ := civil.ParseDate(s)
+	return d
+}

--- a/testing/dynamodb/integration_test.go
+++ b/testing/dynamodb/integration_test.go
@@ -267,6 +267,8 @@ func checkRow(ctx context.Context, t *testing.T, client *spanner.Client) {
 			t.Fatal(err)
 			break
 		}
+		// We don't create big.Rat fields in the SpannerRecord structs
+		// because cmp.Equal cannot compare big.Rat fields automatically.
 		var AttrInt, AttrFloat big.Rat
 		var AttrNumberSet []big.Rat
 		if err := row.Columns(&gotRecord.AttrString, &AttrInt, &AttrFloat, &gotRecord.AttrBool, &gotRecord.AttrBytes, &AttrNumberSet, &gotRecord.AttrByteSet, &gotRecord.AttrStringSet, &gotRecord.AttrList, &gotRecord.AttrMap); err != nil {


### PR DESCRIPTION
First cut of changes to support CSV in harbourbridge. The functionality is limited in the first cut to just unblock customers.

Subcommand changes:
Added CSV as a source for data mode. The source profile accepts the path to the manifest file. No changes to target profile.
**Sample command:**
```
data -source=csv -source-profile="manifest=manifest.json" -target-profile="project=my-project,instance=spanner-instance,dbname=spanner-db"
```
The manifest structure is largely similar to dataflow's manifest with slight changes:
```
[
    {
      "table_name": "Albums",
      "file_patterns": [
        "/Users/deepchowdhury/Desktop/harbourbridge/Albums.csv"
      ],
      "columns": [
        {"column_name": "a", "type_name": "BOOL"},
        {"column_name": "b", "type_name": "BYTES(124)"},   // Length is optional
        {"column_name": "c", "type_name": "DATE"},
        {"column_name": "d", "type_name": "FLOAT64"},
        {"column_name": "e", "type_name": "INT64"},
        {"column_name": "f", "type_name": "NUMERIC"},
        {"column_name": "g", "type_name": "STRING"},
        {"column_name": "h", "type_name": "TIMESTAMP"},
        {"column_name": "i", "type_name": "JSON"}
      ]
    },
    {
      "table_name": "Singers",
      "file_patterns": [
        "/Users/deepchowdhury/Desktop/harbourbridge/Singers.csv"
      ],
      "columns": [
        {"column_name": "SingerId", "type_name": "INT64"},
        {"column_name": "FirstName", "type_name": "STRING(100)"},  // Length is optional
        {"column_name": "LastName", "type_name": "STRING"}
      ]
    }
]
```
**Note regarding the manifest:**

- The `table_name` field should be identical to the table name in Spanner schema.
- File patterns do not accept regex expressions. Provide the path inside double quotes.
- The type_name should be identical to the types in spanner schema. Only for `STRING` and `BYTES`, the length can be optionally omitted.

**CSV file format:**
```
bool_col,byte_col,date_col,float_col,int_col,numeric_col,string_col,timestamp_col,json_col // column headers
true,bytevalue,2020-12-09,15.13,100,39.94,Helloworld,2019-10-29 05:30:00,"{""key1"": ""value1"", ""key2"": ""value2""}" // data
```
Note regarding the CSV file:

- Each column in a row should be separated by commas.
- The first row needs to have the column name headers. The column names should be identical to the column names in Spanner schema.
- Remove trailing spaces, tabs in the column name headers.

**CSV Data types:**

- We only support scalar data types right now. Sample data format for each provided in the snippet above.
- The only supported data format right now is RFC3339 full-date format
- The only supported timestamp format right now is ISO 8601
- The format to escape the quotes in json is adding an additional " in front of the double quote. \ does not work. Also enclose the whole data inside "". Some modification might be required since most databases do not export CSVs with escaping quotes like mentioned.

**Pending tasks:**

Interleaved table support
PG Spanner support
Stretch Goal:
Implement as a full fledged feature where manifest file is not required.