### PR TITLE
Csv handling for dialect mismatch

### DIFF
--- a/cmd/data.go
+++ b/cmd/data.go
@@ -95,10 +95,14 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 	}
 
 	now := time.Now()
-	project, instance, dbName, err := profiles.GetResourceIds(ctx, targetProfile, now, sourceProfile.Driver, ioHelper.Out)
+	project, instance, dbName, err := targetProfile.GetResourceIds(ctx, now, sourceProfile.Driver, ioHelper.Out)
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
+	fmt.Println("Using Google Cloud project:", project)
+	fmt.Println("Using Cloud Spanner instance:", instance)
+	utils.PrintPermissionsWarning(sourceProfile.Driver, ioHelper.Out)
+
 	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, dbName)
 
 	// If filePrefix not explicitly set, use dbName as prefix.

--- a/cmd/schema_and_data.go
+++ b/cmd/schema_and_data.go
@@ -112,10 +112,14 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 	conversion.WriteSessionFile(conv, cmd.filePrefix+sessionFile, ioHelper.Out)
 	conversion.Report(sourceProfile.Driver, nil, ioHelper.BytesRead, "", conv, cmd.filePrefix+reportFile, ioHelper.Out)
 
-	project, instance, dbName, err := profiles.GetResourceIds(ctx, targetProfile, now, sourceProfile.Driver, ioHelper.Out)
+	project, instance, dbName, err := targetProfile.GetResourceIds(ctx, now, sourceProfile.Driver, ioHelper.Out)
 	if err != nil {
 		return subcommands.ExitUsageError
 	}
+	fmt.Println("Using Google Cloud project:", project)
+	fmt.Println("Using Cloud Spanner instance:", instance)
+	utils.PrintPermissionsWarning(sourceProfile.Driver, ioHelper.Out)
+
 	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, dbName)
 
 	adminClient, err := utils.NewDatabaseAdminClient(ctx)

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -485,3 +485,10 @@ func ReadSpannerSchema(ctx context.Context, conv *internal.Conv, client *sp.Clie
 	}
 	return nil
 }
+
+func DialectToTarget(dialect string) string {
+	if strings.ToLower(dialect) == constants.DIALECT_POSTGRESQL {
+		return constants.TargetExperimentalPostgres
+	}
+	return constants.TargetSpanner
+}

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,9 @@ require (
 	cloud.google.com/go/storage v1.17.0
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/aws/aws-sdk-go v1.34.5
-	github.com/denisenkom/go-mssqldb v0.11.0 // indirect
+	github.com/denisenkom/go-mssqldb v0.11.0
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/google/subcommands v1.2.0
 	github.com/gorilla/handlers v1.5.0
@@ -22,10 +21,11 @@ require (
 	//github.com/pingcap/parser v3.0.12+incompatible
 	github.com/pingcap/parser v0.0.0-20200422082501-7329d80eaf2c
 	github.com/pingcap/tidb v1.1.0-beta.0.20200423105559-af376db3dc46
-	github.com/sijms/go-ora/v2 v2.2.17 // indirect
+	github.com/sijms/go-ora/v2 v2.2.17
 	github.com/sirupsen/logrus v1.5.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
 	golang.org/x/tools v0.1.7 // indirect
 	google.golang.org/api v0.57.0
 	google.golang.org/genproto v0.0.0-20210921142501-181ce0d877f6

--- a/profiles/common.go
+++ b/profiles/common.go
@@ -1,13 +1,11 @@
 package profiles
 
 import (
-	"context"
 	"encoding/csv"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cloudspannerecosystem/harbourbridge/common/utils"
 	go_ora "github.com/sijms/go-ora/v2"
@@ -47,37 +45,6 @@ func parseProfile(s string) (map[string]string, error) {
 		params[s[0]] = s[1]
 	}
 	return params, nil
-}
-
-func GetResourceIds(ctx context.Context, targetProfile TargetProfile, now time.Time, driverName string, out *os.File) (string, string, string, error) {
-	var err error
-	project := targetProfile.Conn.Sp.Project
-	if project == "" {
-		project, err = utils.GetProject()
-		if err != nil {
-			return "", "", "", fmt.Errorf("can't get project: %v", err)
-		}
-	}
-	fmt.Println("Using Google Cloud project:", project)
-
-	instance := targetProfile.Conn.Sp.Instance
-	if instance == "" {
-		instance, err = utils.GetInstance(ctx, project, out)
-		if err != nil {
-			return "", "", "", fmt.Errorf("can't get instance: %v", err)
-		}
-	}
-	fmt.Println("Using Cloud Spanner instance:", instance)
-	utils.PrintPermissionsWarning(driverName, out)
-
-	dbName := targetProfile.Conn.Sp.Dbname
-	if dbName == "" {
-		dbName, err = utils.GetDatabaseName(driverName, now)
-		if err != nil {
-			return "", "", "", fmt.Errorf("can't get database name: %v", err)
-		}
-	}
-	return project, instance, dbName, err
 }
 
 func GetSQLConnectionStr(sourceProfile SourceProfile) string {


### PR DESCRIPTION
This PR also handles some refactorings to implement this cleanly:

- Move GetResourceIds from common.go to a struct method of target profile. We do this to cache the project, instance and dbname values into target profile and reuse them.
- struct method in target profile called FetchDatabaseDialect() which fetches the dialect which we then compare with the specified dialect to see if there is a mismatch.
-  Passing that admin client from data.go subcommand to the csv is an inefficient way to handle it hencewe create a new admin client inside FetchDatabaseDialect() for now. We should refactor the code such that all clients are stored in target profile, or some new struct that can be passed throughout the code. Marked as todo.