### PR TITLE
verifying spanner endpoint before execution to avoid the client api calls getting stuck

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -40,4 +40,10 @@ const (
 
 	// Temp directory name to write data which we cleanup at the end.
 	HB_TMP_DIR string = "harbourbridge_tmp_data"
+
+	// SPANNER_EMULATOR_HOST is the host address for the emulator when it is running.
+	SPANNER_EMULATOR_HOST string = "localhost:9010"
+
+	// STAGING_SPANNER_API_ENDPOINT is the spanner api endpoint for staging environment.
+	STAGING_SPANNER_API_ENDPOINT string = "staging-wrenchworks.sandbox.googleapis.com:443"
 )

--- a/main.go
+++ b/main.go
@@ -100,6 +100,14 @@ func main() {
 	}
 	defer utils.Close(lf)
 
+	endpoint := os.Getenv("SPANNER_API_ENDPOINT")
+	if endpoint != "" && endpoint != "staging-wrenchworks.sandbox.googleapis.com:443" {
+		fmt.Printf("\nWarning: Endpoint specified may be incorrect: \n" +
+			"For connecting to prod set SPANNER_API_ENDPOINT as blank \n" +
+			"For connecting to emulator set SPANNER_EMULATOR_HOST=localhost:9010 \n" +
+			"For connecting to staging set SPANNER_API_ENDPOINT=staging-wrenchworks.sandbox.googleapis.com:443\n\n")
+	}
+
 	// TODO: Remove this check and always run HB in subcommands mode once
 	// global command line mode is deprecated. We can also enable support for
 	// top-level flags in subcommand then.

--- a/main.go
+++ b/main.go
@@ -101,7 +101,8 @@ func main() {
 	defer utils.Close(lf)
 
 	endpoint := os.Getenv("SPANNER_API_ENDPOINT")
-	if endpoint != "" && endpoint != "staging-wrenchworks.sandbox.googleapis.com:443" {
+	emulator_host := os.Getenv("SPANNER_EMULATOR_HOST")
+	if !((endpoint == "" && (emulator_host == "" || emulator_host == "localhost:9010")) || endpoint == "staging-wrenchworks.sandbox.googleapis.com:443") {
 		fmt.Printf("\nWarning: Endpoint specified may be incorrect: \n" +
 			"For connecting to prod set SPANNER_API_ENDPOINT as blank \n" +
 			"For connecting to emulator set SPANNER_EMULATOR_HOST=localhost:9010 \n" +

--- a/main.go
+++ b/main.go
@@ -101,12 +101,12 @@ func main() {
 	defer utils.Close(lf)
 
 	endpoint := os.Getenv("SPANNER_API_ENDPOINT")
-	emulator_host := os.Getenv("SPANNER_EMULATOR_HOST")
-	if !((endpoint == "" && (emulator_host == "" || emulator_host == "localhost:9010")) || (endpoint == "staging-wrenchworks.sandbox.googleapis.com:443" && emulator_host == "")) {
+	emulatorHost := os.Getenv("SPANNER_EMULATOR_HOST")
+	if !((endpoint == "" && (emulatorHost == "" || emulatorHost == constants.SPANNER_EMULATOR_HOST)) || (endpoint == constants.STAGING_SPANNER_API_ENDPOINT && emulatorHost == "")) {
 		fmt.Printf("\nWarning: Endpoint specified may be incorrect: \n" +
 			"For connecting to prod set SPANNER_API_ENDPOINT as blank \n" +
-			"For connecting to emulator set SPANNER_EMULATOR_HOST=localhost:9010 \n" +
-			"For connecting to staging set SPANNER_API_ENDPOINT=staging-wrenchworks.sandbox.googleapis.com:443\n\n")
+			"For connecting to emulator set SPANNER_EMULATOR_HOST=" + constants.SPANNER_EMULATOR_HOST + "\n" +
+			"For connecting to staging set SPANNER_API_ENDPOINT=" + constants.STAGING_SPANNER_API_ENDPOINT + "\n\n")
 	}
 
 	// TODO: Remove this check and always run HB in subcommands mode once

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 
 	endpoint := os.Getenv("SPANNER_API_ENDPOINT")
 	emulator_host := os.Getenv("SPANNER_EMULATOR_HOST")
-	if !((endpoint == "" && (emulator_host == "" || emulator_host == "localhost:9010")) || endpoint == "staging-wrenchworks.sandbox.googleapis.com:443") {
+	if !((endpoint == "" && (emulator_host == "" || emulator_host == "localhost:9010")) || (endpoint == "staging-wrenchworks.sandbox.googleapis.com:443" && emulator_host == "")) {
 		fmt.Printf("\nWarning: Endpoint specified may be incorrect: \n" +
 			"For connecting to prod set SPANNER_API_ENDPOINT as blank \n" +
 			"For connecting to emulator set SPANNER_EMULATOR_HOST=localhost:9010 \n" +


### PR DESCRIPTION
In case of incorrect spanner api endpoint, the client APIs get stuck as in the background they have a timeout of 60 min. In order to inform the user about the probable incorrect endpoint added a warning to be printed at the start of the process.