### PR TITLE
Add notification GitHub action workflow

### DIFF
--- a/.github/workflows/chat-notification.yaml
+++ b/.github/workflows/chat-notification.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/chat-notification.yaml
+++ b/.github/workflows/chat-notification.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+name: notification
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Google Chat Notification
+      uses: Co-qn/google-chat-notification@releases/v1
+      with:
+        name: ${{ github.event_name }} by ${{ github.actor }}
+        url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+        status: ${{ job.status }}
+


### PR DESCRIPTION
Adds a GitHub action workflow for generating notification on the specified conditions.  The notification destination is a custom web-hook which is stored in the Secrets Manager in the repo (Settings -> Secrets -> Actions).

Current conditions for notifications are:
1. Push to master.
2. Pull request raised to the repo.