### PR TITLE
Update CircleCI resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - image: circleci/golang:1.16
 
     working_directory: /go/src/github.com/cloudspannerecosystem/harbourbridge
-
+    resource_class: large
     steps:
       - checkout
 


### PR DESCRIPTION
Fixes memory issue with CircleCI builds which is causing them to fail for the `master` branch. Currently, there is a configurational inconsistency between CircleCI and Github Actions Workflow (Integration tests) which can lead to different testing results in both the environments. 

Sample CircleCI build with updated configuration:
https://app.circleci.com/pipelines/github/cloudspannerecosystem/harbourbridge/2029/workflows/ce061d8a-f9f1-48d8-81e5-403d364d09cd/jobs/2092
