### PR TITLE
Fixed dbname casing across the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ such as `csv`, `avro` etc.
 HarbourBridge accepts the following options for --target-profile,
 specified as "key1=value1,key2=value,..." pairs:
 
-`dbname` Specifies the name of the Spanner database to create. This must be a
-new database. If dbname is not specified, HarbourBridge creates a new unique
-dbname.
+`dbName` Specifies the name of the Spanner database to create. This must be a
+new database. If dbName is not specified, HarbourBridge creates a new unique
+dbName.
 
 `instance` Specifies the Spanner instance to use. The new database will be
 created in this instance. If not specified, the tool automatically determines an

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -264,7 +264,7 @@ func dataFromDump(driver string, config writer.BatchWriterConfig, ioHelper *util
 
 func dataFromCSV(ctx context.Context, sourceProfile profiles.SourceProfile, targetProfile profiles.TargetProfile, config writer.BatchWriterConfig, conv *internal.Conv, client *sp.Client) (*writer.BatchWriter, error) {
 	if targetProfile.Conn.Sp.Dbname == "" {
-		return nil, fmt.Errorf("dbname is mandatory in target-profile for csv source")
+		return nil, fmt.Errorf("dbName is mandatory in target-profile for csv source")
 	}
 	conv.TargetDb = targetProfile.ToLegacyTargetDb()
 	dialect, err := targetProfile.FetchTargetDialect(ctx)

--- a/performance/README.md
+++ b/performance/README.md
@@ -43,8 +43,8 @@ Run migration for the test database created.
 We can specify the maximum number of writer threads in write-limit flag.
 Enter the password for connecting to MYSQL db and run the below command.
     ```sh
-    go run main.go schema-and-data -source=mysql -source-profile='host=localhost,user=root,db_name=testdb,password='
-     -target-profile='instance=new-test-instance,dbname=testdb' -write-limit 40
+    go run main.go schema-and-data -source=mysql -source-profile='host=localhost,user=root,dbName=testdb,password='
+     -target-profile='instance=new-test-instance,dbName=testdb' -write-limit 40
     ```
 - **Cleanup:**
 Once the migration is complete, the last step is cleanup. It involves deleting the spanner instance and droping the MYSQL database.

--- a/performance/setup.sh
+++ b/performance/setup.sh
@@ -37,7 +37,7 @@ if type mysql >/dev/null 2>&1; then
             do
                 echo "Write limit: $writeLimit"
                 #update source profile password before running the benchmark
-                go run main.go schema-and-data -source=mysql -source-profile='host=localhost,user=root,db_name=testdb,password=' -target-profile='instance=new-test-instance,dbname=testdb' -write-limit $writeLimit
+                go run main.go schema-and-data -source=mysql -source-profile='host=localhost,user=root,dbName=testdb,password=' -target-profile='instance=new-test-instance,dbName=testdb' -write-limit $writeLimit
             done
             yes | gcloud spanner instances delete test-instance
         done
@@ -57,7 +57,7 @@ if type mysql >/dev/null 2>&1; then
             do
                 echo "Write limit: $writeLimit"
                 #update source profile password before running the benchmark
-                go run main.go schema-and-data -source=mysql -source-profile='host=localhost,user=root,db_name=testdb,password=' -target-profile='instance=new-test-instance,dbname=testdb' -write-limit $writeLimit
+                go run main.go schema-and-data -source=mysql -source-profile='host=localhost,user=root,dbName=testdb,password=' -target-profile='instance=new-test-instance,dbName=testdb' -write-limit $writeLimit
             done
             yes | gcloud spanner instances delete test-instance
         done

--- a/profiles/common.go
+++ b/profiles/common.go
@@ -91,8 +91,8 @@ func GeneratePGSQLConnectionStr() (string, error) {
 	server := os.Getenv("PGHOST")
 	port := os.Getenv("PGPORT")
 	user := os.Getenv("PGUSER")
-	dbname := os.Getenv("PGDATABASE")
-	if server == "" || port == "" || user == "" || dbname == "" {
+	dbName := os.Getenv("PGDATABASE")
+	if server == "" || port == "" || user == "" || dbName == "" {
 		fmt.Printf("Please specify host, port, user and database using PGHOST, PGPORT, PGUSER and PGDATABASE environment variables\n")
 		return "", fmt.Errorf("could not connect to source database")
 	}
@@ -100,19 +100,19 @@ func GeneratePGSQLConnectionStr() (string, error) {
 	if password == "" {
 		password = utils.GetPassword()
 	}
-	return getPGSQLConnectionStr(server, port, user, password, dbname), nil
+	return getPGSQLConnectionStr(server, port, user, password, dbName), nil
 }
 
-func getPGSQLConnectionStr(server, port, user, password, dbname string) string {
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", server, port, user, password, dbname)
+func getPGSQLConnectionStr(server, port, user, password, dbName string) string {
+	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", server, port, user, password, dbName)
 }
 
 func GenerateMYSQLConnectionStr() (string, error) {
 	server := os.Getenv("MYSQLHOST")
 	port := os.Getenv("MYSQLPORT")
 	user := os.Getenv("MYSQLUSER")
-	dbname := os.Getenv("MYSQLDATABASE")
-	if server == "" || port == "" || user == "" || dbname == "" {
+	dbName := os.Getenv("MYSQLDATABASE")
+	if server == "" || port == "" || user == "" || dbName == "" {
 		fmt.Printf("Please specify host, port, user and database using MYSQLHOST, MYSQLPORT, MYSQLUSER and MYSQLDATABASE environment variables\n")
 		return "", fmt.Errorf("could not connect to source database")
 	}
@@ -120,15 +120,15 @@ func GenerateMYSQLConnectionStr() (string, error) {
 	if password == "" {
 		password = utils.GetPassword()
 	}
-	return getMYSQLConnectionStr(server, port, user, password, dbname), nil
+	return getMYSQLConnectionStr(server, port, user, password, dbName), nil
 }
 
-func getMYSQLConnectionStr(server, port, user, password, dbname string) string {
-	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, server, port, dbname)
+func getMYSQLConnectionStr(server, port, user, password, dbName string) string {
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, server, port, dbName)
 }
 
-func getSQLSERVERConnectionStr(server, port, user, password, dbname string) string {
-	return fmt.Sprintf(`sqlserver://%s:%s@%s:%s?database=%s`, user, password, server, port, dbname)
+func getSQLSERVERConnectionStr(server, port, user, password, dbName string) string {
+	return fmt.Sprintf(`sqlserver://%s:%s@%s:%s?database=%s`, user, password, server, port, dbName)
 }
 
 func GetSchemaSampleSize(sourceProfile SourceProfile) int64 {
@@ -143,7 +143,7 @@ func GetSchemaSampleSize(sourceProfile SourceProfile) int64 {
 	return schemaSampleSize
 }
 
-func getORACLEConnectionStr(server, port, user, password, dbname string) string {
+func getORACLEConnectionStr(server, port, user, password, dbName string) string {
 	portNumber, _ := strconv.Atoi(port)
-	return go_ora.BuildUrl(server, portNumber, dbname, user, password, nil)
+	return go_ora.BuildUrl(server, portNumber, dbName, user, password, nil)
 }

--- a/profiles/source_profile.go
+++ b/profiles/source_profile.go
@@ -77,7 +77,7 @@ func NewSourceProfileConnectionMySQL(params map[string]string) (SourceProfileCon
 	mysql := SourceProfileConnectionMySQL{}
 	host, hostOk := params["host"]
 	user, userOk := params["user"]
-	db, dbOk := params["db_name"]
+	db, dbOk := params["dbName"]
 	port, portOk := params["port"]
 	pwd, pwdOk := params["password"]
 	// We don't users to mix and match params from source-profile and environment variables.
@@ -96,21 +96,21 @@ func NewSourceProfileConnectionMySQL(params map[string]string) (SourceProfileCon
 			return mysql, fmt.Errorf("found empty string for MYSQLHOST/MYSQLUSER/MYSQLDATABASE. Please specify these environment variables with correct values")
 		}
 	} else if hostOk && userOk && dbOk {
-		// If atleast host, username and dbname are provided through source-profile,
+		// If atleast host, username and dbName are provided through source-profile,
 		// go ahead and use source-profile. Port and password handled later even if they are empty.
 		mysql.Host, mysql.User, mysql.Db, mysql.Port, mysql.Pwd = host, user, db, port, pwd
 		// Throw error if the input entered is empty.
 		if mysql.Host == "" || mysql.User == "" || mysql.Db == "" {
-			return mysql, fmt.Errorf("found empty string for host/user/db_name. Please specify host, port, user and db_name in the source-profile")
+			return mysql, fmt.Errorf("found empty string for host/user/dbName. Please specify host, port, user and dbName in the source-profile")
 		}
 	} else {
 		// Partial params provided through source-profile. Ask user to provide all through the source-profile.
-		return mysql, fmt.Errorf("please specify host, port, user and db_name in the source-profile")
+		return mysql, fmt.Errorf("please specify host, port, user and dbName in the source-profile")
 	}
 
 	// Throw same error if the input entered is empty.
 	if mysql.Host == "" || mysql.User == "" || mysql.Db == "" {
-		return mysql, fmt.Errorf("found empty string for host/user/db. please specify host, port, user and db_name in the source-profile")
+		return mysql, fmt.Errorf("found empty string for host/user/db. please specify host, port, user and dbName in the source-profile")
 	}
 
 	if mysql.Port == "" {
@@ -136,7 +136,7 @@ func NewSourceProfileConnectionPostgreSQL(params map[string]string) (SourceProfi
 	pg := SourceProfileConnectionPostgreSQL{}
 	host, hostOk := params["host"]
 	user, userOk := params["user"]
-	db, dbOk := params["db_name"]
+	db, dbOk := params["dbName"]
 	port, portOk := params["port"]
 	pwd, pwdOk := params["password"]
 	// We don't users to mix and match params from source-profile and environment variables.
@@ -159,11 +159,11 @@ func NewSourceProfileConnectionPostgreSQL(params map[string]string) (SourceProfi
 		pg.Host, pg.User, pg.Db, pg.Port, pg.Pwd = host, user, db, port, pwd
 		// Throw error if the input entered is empty.
 		if pg.Host == "" || pg.User == "" || pg.Db == "" {
-			return pg, fmt.Errorf("found empty string for host/user/db_name. Please specify host, port, user and db_name in the source-profile")
+			return pg, fmt.Errorf("found empty string for host/user/dbName. Please specify host, port, user and dbName in the source-profile")
 		}
 	} else {
 		// Partial params provided through source-profile. Ask user to provide all through the source-profile.
-		return pg, fmt.Errorf("please specify host, port, user and db_name in the source-profile")
+		return pg, fmt.Errorf("please specify host, port, user and dbName in the source-profile")
 	}
 
 	if pg.Port == "" {
@@ -189,7 +189,7 @@ func NewSourceProfileConnectionSqlServer(params map[string]string) (SourceProfil
 	ss := SourceProfileConnectionSqlServer{}
 	host, hostOk := params["host"]
 	user, userOk := params["user"]
-	db, dbOk := params["db_name"]
+	db, dbOk := params["dbName"]
 	port, portOk := params["port"]
 	pwd, pwdOk := params["password"]
 
@@ -218,11 +218,11 @@ func NewSourceProfileConnectionSqlServer(params map[string]string) (SourceProfil
 		ss.Host, ss.User, ss.Db, ss.Port, ss.Pwd = host, user, db, port, pwd
 		// Throw error if the input entered is empty.
 		if ss.Host == "" || ss.User == "" || ss.Db == "" {
-			return ss, fmt.Errorf("found empty string for host/user/db_name. Please specify host, port, user and db_name in the source-profile")
+			return ss, fmt.Errorf("found empty string for host/user/dbName. Please specify host, port, user and dbName in the source-profile")
 		}
 	} else {
 		// Partial params provided through source-profile. Ask user to provide all through the source-profile.
-		return ss, fmt.Errorf("please specify host, port, user and db_name in the source-profile")
+		return ss, fmt.Errorf("please specify host, port, user and dbName in the source-profile")
 	}
 
 	if ss.Port == "" {
@@ -294,7 +294,7 @@ func NewSourceProfileConnectionOracle(params map[string]string) (SourceProfileCo
 	ss := SourceProfileConnectionOracle{}
 	host, hostOk := params["host"]
 	user, userOk := params["user"]
-	db, dbOk := params["db_name"]
+	db, dbOk := params["dbName"]
 	port, _ := params["port"]
 	pwd, _ := params["password"]
 
@@ -303,11 +303,11 @@ func NewSourceProfileConnectionOracle(params map[string]string) (SourceProfileCo
 		ss.Host, ss.User, ss.Db, ss.Port, ss.Pwd = host, user, db, port, pwd
 		// Throw error if the input entered is empty.
 		if ss.Host == "" || ss.User == "" || ss.Db == "" {
-			return ss, fmt.Errorf("found empty string for host/user/db_name. Please specify host, port, user and db_name in the source-profile")
+			return ss, fmt.Errorf("found empty string for host/user/dbName. Please specify host, port, user and dbName in the source-profile")
 		}
 	} else {
 		// Partial params provided through source-profile. Ask user to provide all through the source-profile.
-		return ss, fmt.Errorf("please specify host, port, user and db_name in the source-profile")
+		return ss, fmt.Errorf("please specify host, port, user and dbName in the source-profile")
 	}
 
 	if ss.Port == "" {

--- a/profiles/source_profile_test.go
+++ b/profiles/source_profile_test.go
@@ -77,12 +77,12 @@ func TestNewSourceProfileConnectionSQL(t *testing.T) {
 	}{
 		{
 			name:          "mandatory params provided",
-			params:        map[string]string{"host": "a", "user": "b", "db_name": "c", "password": "e"},
+			params:        map[string]string{"host": "a", "user": "b", "dbName": "c", "password": "e"},
 			errorExpected: false,
 		},
 		{
 			name:          "partial mandatory params provided",
-			params:        map[string]string{"user": "b", "db_name": "c"},
+			params:        map[string]string{"user": "b", "dbName": "c"},
 			errorExpected: true,
 		},
 		{
@@ -97,17 +97,17 @@ func TestNewSourceProfileConnectionSQL(t *testing.T) {
 		},
 		{
 			name:          "all params provided",
-			params:        map[string]string{"host": "a", "user": "b", "db_name": "c", "port": "d", "password": "e"},
+			params:        map[string]string{"host": "a", "user": "b", "dbName": "c", "port": "d", "password": "e"},
 			errorExpected: false,
 		},
 		{
 			name:          "empty mandatory param",
-			params:        map[string]string{"host": "", "user": "b", "db_name": "c"},
+			params:        map[string]string{"host": "", "user": "b", "dbName": "c"},
 			errorExpected: true,
 		},
 		{
 			name:          "empty port",
-			params:        map[string]string{"host": "a", "user": "b", "db_name": "c", "password": "e"},
+			params:        map[string]string{"host": "a", "user": "b", "dbName": "c", "password": "e"},
 			errorExpected: false,
 		},
 	}

--- a/profiles/target_profile.go
+++ b/profiles/target_profile.go
@@ -82,7 +82,7 @@ func (trg TargetProfile) ToLegacyTargetDb() string {
 	}
 }
 
-// This expects that GetResourceIds has already been called once and the project, instance and dbname
+// This expects that GetResourceIds has already been called once and the project, instance and dbName
 // fields in target profile are populated.
 func (trg TargetProfile) FetchTargetDialect(ctx context.Context) (string, error) {
 	// TODO: consider moving all clients to target profile instead of passing them around the codebase.
@@ -141,11 +141,11 @@ func (targetProfile *TargetProfile) GetResourceIds(ctx context.Context, now time
 // correspond to regular Cloud Spanner database and PG Cloud Spanner database
 // respectively.
 //
-// If dbname is not specified, then HarbourBridge will autogenerate the same
+// If dbName is not specified, then HarbourBridge will autogenerate the same
 // and create a database with the same name.
 //
-// Example: -target-profile="instance=my-instance1,dbname=my-new-db1"
-// Example: -target-profile="instance=my-instance1,dbname=my-new-db1,dialect=PostgreSQL"
+// Example: -target-profile="instance=my-instance1,dbName=my-new-db1"
+// Example: -target-profile="instance=my-instance1,dbName=my-new-db1,dialect=PostgreSQL"
 //
 func NewTargetProfile(s string) (TargetProfile, error) {
 	params, err := parseProfile(s)
@@ -163,8 +163,8 @@ func NewTargetProfile(s string) (TargetProfile, error) {
 	if instance, ok := params["instance"]; ok {
 		sp.Instance = instance
 	}
-	if dbname, ok := params["dbname"]; ok {
-		sp.Dbname = dbname
+	if dbName, ok := params["dbName"]; ok {
+		sp.Dbname = dbName
 	}
 	if dialect, ok := params["dialect"]; ok {
 		sp.Dialect = dialect

--- a/sources/csv/README.md
+++ b/sources/csv/README.md
@@ -20,7 +20,7 @@ Harbourbridge will migrate `table_name.csv` to a Spanner table named
 `table_name` in the database specified via the target profile.
 
 ```sh
-harbourbridge data -source=csv -target-profile="instance=my-instance,dbname=my-db,dialect=postgresql" 
+harbourbridge data -source=csv -target-profile="instance=my-instance,dbName=my-db,dialect=postgresql" 
 ```
 
 - **Providing a manifest input:**
@@ -29,7 +29,7 @@ locations (local system as well as Google Cloud Storage). You can also provide
 multiple csv file paths for a single table using the manifest.
 
 ```sh
-harbourbridge data -source=csv -source-profile="manifest=path/to/manifest/file" -target-profile="instance=my-instance,dbname=my-db" 
+harbourbridge data -source=csv -source-profile="manifest=path/to/manifest/file" -target-profile="instance=my-instance,dbName=my-db" 
 ```
 
 ### Manifest File
@@ -81,7 +81,7 @@ profile.
 For example, if you want to use `|` as the delimiter and `NULL` as the null value, 
 you can use 
 ```sh
-harbourbridge data -source=csv -source-profile="delimiter=|,nullStr=NULL" -target-profile="instance=my-instance,dbname=my-db" 
+harbourbridge data -source=csv -source-profile="delimiter=|,nullStr=NULL" -target-profile="instance=my-instance,dbName=my-db" 
 ```
 
 

--- a/sources/mysql/README.md
+++ b/sources/mysql/README.md
@@ -36,7 +36,7 @@ By default, HarbourBridge will generate a new Spanner database name to populate.
 You can override this and specify the database name to use by:
 
 ```sh
-harbourbridge data -session=mydb.session.json -source=mysql -target-profile="instance=my-spanner-instance,dbname=my-spanner-database-name" < my_mysqldump_file
+harbourbridge data -session=mydb.session.json -source=mysql -target-profile="instance=my-spanner-instance,dbName=my-spanner-database-name" < my_mysqldump_file
 ```
 
 You can also run HarbourBridge in a schema-and-data mode, where it will perform both
@@ -69,12 +69,12 @@ that HarbourBridge will not create directories as it writes these files.
 
 In this case, HarbourBridge connects directly to the MySQL database to retrieve
 table schema and data. Set the `-source=mysql` and corresponding source profile
-connection parameters `host`, `port`, `user`, `db_name` and `password`.
+connection parameters `host`, `port`, `user`, `dbName` and `password`.
 
 For example to perform schema conversion, run
 
 ```sh
-harbourbridge schema -source=mysql -source-profile="host=<>,port=<>,user=<>,db_name=<>"
+harbourbridge schema -source=mysql -source-profile="host=<>,port=<>,user=<>,dbName=<>"
 ```
 
 Parameters `port` and `password` are optional. Port (`port`) defaults to `3306`

--- a/sources/oracle/README.md
+++ b/sources/oracle/README.md
@@ -20,18 +20,18 @@ in the [Installing HarbourBridge](https://github.com/cloudspannerecosystem/harbo
 
 In this case, HarbourBridge connects directly to the Oracle database to
 retrieve table schema and data. Set the `-source=oracle` and corresponding
-source profile connection parameters `host`, `port`, `user`, `db_name` and
+source profile connection parameters `host`, `port`, `user`, `dbName` and
 `password`.
 
 For example to perform schema conversion, run
 
 ```sh
-harbourbridge schema -source=oracle -source-profile="host=<>,port=<>,user=<>,db_name=<>,password=<>"
+harbourbridge schema -source=oracle -source-profile="host=<>,port=<>,user=<>,dbName=<>,password=<>"
 ```
 
 In Oracle DB, USER is the account name, SCHEMA is the set of objects owned by that user. Oracle creates the SCHEMA object as part of the CREATE USER statement and the SCHEMA has the same name as the USER. 
 
-db_name will be the SID of the Database used. The Oracle System ID (SID) is used to uniquely identify a particular database on a system.
+dbName will be the SID of the Database used. The Oracle System ID (SID) is used to uniquely identify a particular database on a system.
 
 ## Schema Conversion
 

--- a/sources/postgres/README.md
+++ b/sources/postgres/README.md
@@ -39,7 +39,7 @@ By default, HarbourBridge will generate a new Spanner database name to populate.
 You can override this and specify the database name to use by:
 
 ```sh
-harbourbridge data -session=mydb.session.json -source=pg -target-profile="instance=my-spanner-instance,dbname=my-spanner-database-name" < my_pg_dump_file
+harbourbridge data -session=mydb.session.json -source=pg -target-profile="instance=my-spanner-instance,dbName=my-spanner-database-name" < my_pg_dump_file
 ```
 
 You can also run HarbourBridge in a schema-and-data mode, where it will perform both
@@ -72,13 +72,13 @@ that HarbourBridge will not create directories as it writes these files.
 
 In this case, HarbourBridge connects directly to the PostgreSQL database to
 retrieve table schema and data. Set the `-source=postgres` and corresponding
-source profile connection parameters `host`, `port`, `user`, `db_name` and
+source profile connection parameters `host`, `port`, `user`, `dbName` and
 `password`.
 
 For example to perform schema conversion, run
 
 ```sh
-harbourbridge schema -source=postgres -source-profile="host=<>,port=<>,user=<>,db_name=<>"
+harbourbridge schema -source=postgres -source-profile="host=<>,port=<>,user=<>,dbName=<>"
 ```
 
 Parameters `port` and `password` are optional. Port (`port`) defaults to `5432`

--- a/sources/sqlserver/README.md
+++ b/sources/sqlserver/README.md
@@ -20,13 +20,13 @@ in the [Installing HarbourBridge](https://github.com/cloudspannerecosystem/harbo
 
 In this case, HarbourBridge connects directly to the Sql server database to
 retrieve table schema and data. Set the `-source=sqlserver` and corresponding
-source profile connection parameters `host`, `port`, `user`, `db_name` and
+source profile connection parameters `host`, `port`, `user`, `dbName` and
 `password`.
 
 For example to perform schema conversion, run
 
 ```sh
-harbourbridge schema -source=sqlserver -source-profile="host=<>,port=<>,user=<>,db_name=<>"
+harbourbridge schema -source=sqlserver -source-profile="host=<>,port=<>,user=<>,dbName=<>"
 ```
 
 Parameters `port` and `password` are optional. Port (`port`) defaults to `1433`

--- a/testing/csv/integration_test.go
+++ b/testing/csv/integration_test.go
@@ -165,7 +165,7 @@ func TestIntegration_CSV_Command(t *testing.T) {
 	writeCSVs(t)
 	defer cleanupCSVs()
 	createSpannerSchema(t, projectID, instanceID, dbName)
-	args := fmt.Sprintf("data -source=csv -target-profile='instance=%s,dbname=%s'", instanceID, dbName)
+	args := fmt.Sprintf("data -source=csv -target-profile='instance=%s,dbName=%s'", instanceID, dbName)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)

--- a/testing/mysql/integration_test.go
+++ b/testing/mysql/integration_test.go
@@ -140,9 +140,9 @@ func TestIntegration_MYSQL_SchemaAndDataSubcommand(t *testing.T) {
 	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 
-	host, user, db_name, password := os.Getenv("MYSQLHOST"), os.Getenv("MYSQLUSER"), os.Getenv("MYSQLDATABASE"), os.Getenv("MYSQLPWD")
+	host, user, srcDb, password := os.Getenv("MYSQLHOST"), os.Getenv("MYSQLUSER"), os.Getenv("MYSQLDATABASE"), os.Getenv("MYSQLPWD")
 	envVars := common.ClearEnvVariables([]string{"MYSQLHOST", "MYSQLUSER", "MYSQLDATABASE", "MYSQLPWD"})
-	args := fmt.Sprintf("schema-and-data -source=%s -prefix=%s -source-profile='host=%s,user=%s,db_name=%s,password=%s' -target-profile='instance=%s,dbname=%s'", constants.MYSQL, filePrefix, host, user, db_name, password, instanceID, dbName)
+	args := fmt.Sprintf("schema-and-data -source=%s -prefix=%s -source-profile='host=%s,user=%s,dbName=%s,password=%s' -target-profile='instance=%s,dbName=%s'", constants.MYSQL, filePrefix, host, user, srcDb, password, instanceID, dbName)
 	err := common.RunCommand(args, projectID)
 	common.RestoreEnvVariables(envVars)
 	if err != nil {
@@ -248,7 +248,7 @@ func TestIntegration_MySQLDUMP_DataOnly(t *testing.T) {
 }
 
 func runSchemaSubcommand(t *testing.T, dbName, filePrefix, sessionFile, dumpFilePath string) {
-	args := fmt.Sprintf("schema -prefix %s -source=mysql -target-profile='dbname=%s' < %s", filePrefix, dbName, dumpFilePath)
+	args := fmt.Sprintf("schema -prefix %s -source=mysql -target-profile='dbName=%s' < %s", filePrefix, dbName, dumpFilePath)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -256,7 +256,7 @@ func runSchemaSubcommand(t *testing.T, dbName, filePrefix, sessionFile, dumpFile
 }
 
 func runDataSubcommand(t *testing.T, dbName, dbURI, filePrefix, sessionFile, dumpFilePath string) {
-	args := fmt.Sprintf("data -source=mysql -prefix %s -session %s -target-profile='instance=%s,dbname=%s' < %s", filePrefix, sessionFile, instanceID, dbName, dumpFilePath)
+	args := fmt.Sprintf("data -source=mysql -prefix %s -session %s -target-profile='instance=%s,dbName=%s' < %s", filePrefix, sessionFile, instanceID, dbName, dumpFilePath)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -264,7 +264,7 @@ func runDataSubcommand(t *testing.T, dbName, dbURI, filePrefix, sessionFile, dum
 }
 
 func runSchemaAndDataSubcommand(t *testing.T, dbName, dbURI, filePrefix, dumpFilePath string) {
-	args := fmt.Sprintf("schema-and-data -source=mysql -prefix %s -target-profile='instance=%s,dbname=%s' < %s", filePrefix, instanceID, dbName, dumpFilePath)
+	args := fmt.Sprintf("schema-and-data -source=mysql -prefix %s -target-profile='instance=%s,dbName=%s' < %s", filePrefix, instanceID, dbName, dumpFilePath)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -273,7 +273,7 @@ func runSchemaAndDataSubcommand(t *testing.T, dbName, dbURI, filePrefix, dumpFil
 
 func runDataOnlySubcommandForSessionFile(t *testing.T, dbName, dbURI, sessionFile string) {
 	host, user, password := os.Getenv("MYSQLHOST"), os.Getenv("MYSQLUSER"), os.Getenv("MYSQLPWD")
-	args := fmt.Sprintf("data -source=mysql -session %s -source-profile='host=%s,user=%s,db_name=%s,password=%s' -target-profile='instance=%s,dbname=%s' ", sessionFile, host, user, dbName, password, instanceID, dbName)
+	args := fmt.Sprintf("data -source=mysql -session %s -source-profile='host=%s,user=%s,dbName=%s,password=%s' -target-profile='instance=%s,dbName=%s' ", sessionFile, host, user, dbName, password, instanceID, dbName)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)

--- a/testing/oracle/integration_test.go
+++ b/testing/oracle/integration_test.go
@@ -123,7 +123,7 @@ func TestIntegration_ORACLE_SchemaSubcommand(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 	filePrefix := filepath.Join(tmpdir, "Oracle_IntTest.")
 
-	args := fmt.Sprintf("schema -prefix %s -source=%s -source-profile='host=localhost,user=STI,db_name=xe,password=test1,port=1521'", filePrefix, constants.ORACLE)
+	args := fmt.Sprintf("schema -prefix %s -source=%s -source-profile='host=localhost,user=STI,dbName=xe,password=test1,port=1521'", filePrefix, constants.ORACLE)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -138,7 +138,7 @@ func TestIntegration_ORACLE_SchemaAndDataSubcommand(t *testing.T) {
 	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
 	filePrefix := filepath.Join(tmpdir, "Oracle_IntTest.")
 
-	args := fmt.Sprintf("schema-and-data -prefix %s -source=%s  -source-profile='host=localhost,user=STI,db_name=xe,password=test1,port=1521' -target-profile='instance=%s,dbname=%s'", filePrefix, constants.ORACLE, instanceID, dbName)
+	args := fmt.Sprintf("schema-and-data -prefix %s -source=%s  -source-profile='host=localhost,user=STI,dbName=xe,password=test1,port=1521' -target-profile='instance=%s,dbName=%s'", filePrefix, constants.ORACLE, instanceID, dbName)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)

--- a/testing/postgres/integration_test.go
+++ b/testing/postgres/integration_test.go
@@ -142,7 +142,7 @@ func TestIntegration_PGDUMP_SchemaAndDataSubcommand(t *testing.T) {
 	dataFilepath := "../../test_data/pg_dump.test.out"
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 
-	args := fmt.Sprintf("schema-and-data -prefix %s -source=postgres -target-profile='instance=%s,dbname=%s' < %s", filePrefix, instanceID, dbName, dataFilepath)
+	args := fmt.Sprintf("schema-and-data -prefix %s -source=postgres -target-profile='instance=%s,dbName=%s' < %s", filePrefix, instanceID, dbName, dataFilepath)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -203,7 +203,7 @@ func TestIntegration_POSTGRES_SchemaAndDataSubcommand(t *testing.T) {
 	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
 	filePrefix := filepath.Join(tmpdir, dbName+".")
 
-	args := fmt.Sprintf("schema-and-data -prefix %s -source=postgres -target-profile='instance=%s,dbname=%s'", filePrefix, instanceID, dbName)
+	args := fmt.Sprintf("schema-and-data -prefix %s -source=postgres -target-profile='instance=%s,dbName=%s'", filePrefix, instanceID, dbName)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)

--- a/testing/sqlserver/integration_test.go
+++ b/testing/sqlserver/integration_test.go
@@ -111,7 +111,7 @@ func TestIntegration_SQLserver_SchemaSubcommand(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 	filePrefix := filepath.Join(tmpdir, "SqlServer_IntTest.")
 
-	args := fmt.Sprintf("schema -prefix %s -source=sqlserver -source-profile='host=localhost,user=sa,db_name=SqlServer_IntTest'", filePrefix)
+	args := fmt.Sprintf("schema -prefix %s -source=sqlserver -source-profile='host=localhost,user=sa,dbName=SqlServer_IntTest'", filePrefix)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -126,7 +126,7 @@ func TestIntegration_SQLserver_SchemaAndDataSubcommand(t *testing.T) {
 	dbURI := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, dbName)
 	filePrefix := filepath.Join(tmpdir, "SqlServer_IntTest.")
 
-	args := fmt.Sprintf("schema-and-data -prefix %s -source=%s  -source-profile='host=localhost,user=sa,db_name=SqlServer_IntTest' -target-profile='instance=%s,dbname=%s'", filePrefix, constants.SQLSERVER, instanceID, dbName)
+	args := fmt.Sprintf("schema-and-data -prefix %s -source=%s  -source-profile='host=localhost,user=sa,dbName=SqlServer_IntTest' -target-profile='instance=%s,dbName=%s'", filePrefix, constants.SQLSERVER, instanceID, dbName)
 	err := common.RunCommand(args, projectID)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This fix also makes the parameter casing uniform for dbName. Earlier source profile referred to it as db_name while target referred to it as dbname. It is now referred to as dbName in both places.