### PR TITLE
Oracle number mapping update

### DIFF
--- a/sources/oracle/infoschema.go
+++ b/sources/oracle/infoschema.go
@@ -66,6 +66,8 @@ func getSelectQuery(srcDb string, schemaName string, tableName string, colNames 
 				FROM TABLE ("%s"."%s")) AS "%s"`, tableName, cn, cn)
 		} else {
 			switch colDefs[cn].Type.Name {
+			case "NUMBER":
+				s = fmt.Sprintf(`TO_CHAR("%s") AS "%s"`, cn, cn)
 			case "XMLTYPE":
 				s = fmt.Sprintf(`CAST(XMLTYPE.getStringVal("%s") AS VARCHAR2(4000)) AS "%s"`, cn, cn)
 			case "SDO_GEOMETRY":

--- a/sources/oracle/toddl.go
+++ b/sources/oracle/toddl.go
@@ -89,21 +89,16 @@ func toSpannerTypeInternal(conv *internal.Conv, spType string, srcType string, m
 			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 		default:
 			modsLen := len(mods)
-
 			if modsLen == 0 {
 				return ddl.Type{Name: ddl.Numeric}, nil
-			}
-
-			// If only precision is available.
-			if modsLen == 1 {
+			} else if modsLen == 1 { // Only precision is available.
 				if mods[0] > 29 {
+					// Max precision in Oracle is 38. String representation of the number should not have more than 50 characters
 					return ddl.Type{Name: ddl.String, Len: 50}, nil
 				}
 				return ddl.Type{Name: ddl.Int64}, nil
-			}
-
-			// If both precision and scale are avalible.
-			if mods[0] > 29 || mods[1] > 9 {
+			} else if mods[0] > 29 || mods[1] > 9 { // When both precision and scale are available and within limit
+				// Max precision in Oracle is 38. String representation of the number should not have more than 50 characters
 				return ddl.Type{Name: ddl.String, Len: 50}, nil
 			}
 

--- a/sources/oracle/toddl.go
+++ b/sources/oracle/toddl.go
@@ -94,11 +94,13 @@ func toSpannerTypeInternal(conv *internal.Conv, spType string, srcType string, m
 			} else if modsLen == 1 { // Only precision is available.
 				if mods[0] > 29 {
 					// Max precision in Oracle is 38. String representation of the number should not have more than 50 characters
+					// https://docs.oracle.com/cd/B19306_01/server.102/b14237/limits001.htm#i287903
 					return ddl.Type{Name: ddl.String, Len: 50}, nil
 				}
 				return ddl.Type{Name: ddl.Int64}, nil
 			} else if mods[0] > 29 || mods[1] > 9 { // When both precision and scale are available and within limit
 				// Max precision in Oracle is 38. String representation of the number should not have more than 50 characters
+				// https://docs.oracle.com/cd/B19306_01/server.102/b14237/limits001.htm#i287903
 				return ddl.Type{Name: ddl.String, Len: 50}, nil
 			}
 

--- a/sources/oracle/toddl.go
+++ b/sources/oracle/toddl.go
@@ -97,14 +97,14 @@ func toSpannerTypeInternal(conv *internal.Conv, spType string, srcType string, m
 			// If only precision is available.
 			if modsLen == 1 {
 				if mods[0] > 29 {
-					return ddl.Type{Name: ddl.String, Len: 40}, nil
+					return ddl.Type{Name: ddl.String, Len: 50}, nil
 				}
 				return ddl.Type{Name: ddl.Int64}, nil
 			}
 
 			// If both precision and scale are avalible.
 			if mods[0] > 29 || mods[1] > 9 {
-				return ddl.Type{Name: ddl.String, Len: 40}, nil
+				return ddl.Type{Name: ddl.String, Len: 50}, nil
 			}
 
 			return ddl.Type{Name: ddl.Numeric}, nil


### PR DESCRIPTION
- Maps Oracle's NUMBER type to Spanner's STRING type if the source has precision > 29 or scale > 9
