### PR TITLE
Changes to handle incorrect Spanner API endpoints

### DIFF
--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -28,6 +28,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -413,7 +414,7 @@ func VerifyDb(ctx context.Context, adminClient *database.DatabaseAdminClient, db
 func CheckExistingDb(ctx context.Context, adminClient *database.DatabaseAdminClient, dbURI string) (bool, error) {
 	_, err := adminClient.GetDatabase(ctx, &adminpb.GetDatabaseRequest{Name: dbURI})
 	if err != nil {
-		if err == ctx.Err() {
+		if errors.Is(err, context.DeadlineExceeded) {
 			return false, fmt.Errorf("spanner API endpoint unavailable: make sure that spanner api endpoint is configured properly")
 		}
 		if utils.ContainsAny(strings.ToLower(err.Error()), []string{"database not found"}) {


### PR DESCRIPTION
Fixes #324 

**Issue**: The default timeout limit for client libraries API calls is 60 minutes. Client libraries retries the GetDatabase API call If **Unavailable**/**DeadlineExceeded** error is faced ([More Details](https://github.com/cloudspannerecosystem/harbourbridge/issues/324#issuecomment-1165639181)). When an incorrect Spanner API endpoint is used **Unavailable** error code is returned and this is the reason it is retried for 60 minutes.
>rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp: lookup tcp///staging-wrenchworks.sandbox.googleapis.com/: Servname not supported for ai_socktype" 

**Things changed**: If API call doesn't respond to the request then at an interval of 5 minutes the user is informed through the command line about the problem.

- [x] Tests pass