### PR TITLE
Added support for reading from DynamoDB Streams

### DIFF
--- a/sources/dynamodb/schema.go
+++ b/sources/dynamodb/schema.go
@@ -229,7 +229,7 @@ func (isi InfoSchemaImpl) StartStreamingMigration(ctx context.Context, client *s
 	go catchCtrlC(wg, streamInfo)
 
 	for srcTable, streamArn := range latestStreamArn {
-		streamInfo.Records[srcTable] = make(map[string]int64)
+		streamInfo.makeRecordMaps(srcTable)
 
 		wg.Add(1)
 		go ProcessStream(wg, isi.DynamoStreamsClient, streamInfo, conv, streamArn.(string), srcTable)

--- a/sources/dynamodb/schema.go
+++ b/sources/dynamodb/schema.go
@@ -222,7 +222,7 @@ func (isi InfoSchemaImpl) StartStreamingMigration(ctx context.Context, client *s
 	fmt.Println("Processing of DynamoDB Streams started...")
 	fmt.Println("Use Ctrl+C to stop the process.")
 
-	streamInfo := MakeInfo()
+	streamInfo := MakeStreamingInfo()
 	wg := &sync.WaitGroup{}
 
 	wg.Add(1)

--- a/sources/dynamodb/streaming.go
+++ b/sources/dynamodb/streaming.go
@@ -161,6 +161,10 @@ func ProcessShard(wgShard *sync.WaitGroup, streamInfo *StreamingInfo, conv *inte
 
 		getRecordsOutput, err := getRecords(streamClient, shardIterator)
 		if err != nil {
+			// In case of closed shards, after all data records get expired it still returns a non-nil
+			// shardIterator for GetShardIterator query. Using this shardIterator for GetRecords
+			// API call results in TrimmedDataAccessException. This will result in same steps being
+			// followed again and again. To handle this a retry limit of 5 is set.
 			if checkTrimmedDataError(err) && retryCount < 5 {
 				lastEvaluatedSequenceNumber = nil
 				retryCount++

--- a/sources/dynamodb/streaming.go
+++ b/sources/dynamodb/streaming.go
@@ -15,10 +15,20 @@ package dynamodb
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams/dynamodbstreamsiface"
+
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
 )
 
 // NewDynamoDBStream initializes a new DynamoDB Stream for a table with NEW_AND_OLD_IMAGES
@@ -57,4 +67,187 @@ func NewDynamoDBStream(client dynamodbiface.DynamoDBAPI, srcTable string) (strin
 		}
 		return *res.TableDescription.LatestStreamArn, nil
 	}
+}
+
+// catchCtrlC catches the Ctrl+C signal if customer wants to exit.
+func catchCtrlC(wg *sync.WaitGroup, streamInfo *Info) {
+	defer wg.Done()
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		streamInfo.UserExit = true
+	}()
+}
+
+// ProcessStream processes the latest enabled DynamoDB Stream for a table.
+// It searches for shards within stream and for each shard it creates a
+// seperate working thread to process records within it.
+func ProcessStream(wgStream *sync.WaitGroup, streamClient dynamodbstreamsiface.DynamoDBStreamsAPI, streamInfo *Info, conv *internal.Conv, streamArn, srcTable string) {
+	defer wgStream.Done()
+	wgShard := &sync.WaitGroup{}
+
+	var lastEvaluatedShardId *string = nil
+	passAfterUserExit := false
+	for {
+		result, err := fetchShards(streamClient, lastEvaluatedShardId, streamArn)
+		if err != nil {
+			streamInfo.Unexpected(fmt.Sprintf("Couldn't fetch shards for table %s: %s", srcTable, err))
+			break
+		}
+		for _, shard := range result.Shards {
+			lastEvaluatedShardId = shard.ShardId
+
+			wgShard.Add(1)
+			go ProcessShard(wgShard, streamInfo, conv, streamClient, shard, streamArn, srcTable)
+		}
+
+		if result.LastEvaluatedShardId == nil && passAfterUserExit {
+			break
+		}
+		if streamInfo.UserExit {
+			passAfterUserExit = true
+		} else if len(result.Shards) == 0 {
+			time.Sleep(10 * time.Second)
+		}
+	}
+	wgShard.Wait()
+}
+
+// fetchShards fetches latest unprocessed shards from a given DynamoDB Stream after the lastEvaluatedShardId.
+func fetchShards(streamClient dynamodbstreamsiface.DynamoDBStreamsAPI, lastEvaluatedShardId *string, streamArn string) (*dynamodbstreams.StreamDescription, error) {
+	describeStreamInput := &dynamodbstreams.DescribeStreamInput{
+		ExclusiveStartShardId: lastEvaluatedShardId,
+		StreamArn:             &streamArn,
+	}
+	result, err := streamClient.DescribeStream(describeStreamInput)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected call to DescribeStream: %v", err)
+	}
+	return result.StreamDescription, nil
+}
+
+// CheckTrimmedDataError checks if the error is an TrimmedDataAccessException
+func CheckTrimmedDataError(err error) bool {
+	return strings.Contains(err.Error(), "TrimmedDataAccessException")
+}
+
+// ProcessShard processes records within a shard starting from the first unexpired record. It
+// doesn't start processing unless parent shard is processed. For closed shards this process is
+// completed after processing all records but for open shards it keeps searching for new records
+// until shards gets closed or customer calls for a exit.
+func ProcessShard(wgShard *sync.WaitGroup, streamInfo *Info, conv *internal.Conv, streamClient dynamodbstreamsiface.DynamoDBStreamsAPI, shard *dynamodbstreams.Shard, streamArn, srcTable string) {
+	defer wgShard.Done()
+
+	WaitForParentShard(streamInfo, shard.ParentShardId)
+
+	shardId := *shard.ShardId
+	streamInfo.SetShardStatus(shardId, false)
+
+	var lastEvaluatedSequenceNumber *string = nil
+	passAfterUserExit := false
+	for {
+		shardIterator, err := getShardIterator(streamClient, lastEvaluatedSequenceNumber, shardId, streamArn)
+		if err != nil {
+			if CheckTrimmedDataError(err) {
+				lastEvaluatedSequenceNumber = nil
+				continue
+			} else {
+				streamInfo.Unexpected(fmt.Sprintf("Couldn't get shardIterator for table %s: %s", srcTable, err))
+				break
+			}
+		}
+
+		getRecordsOutput, err := getRecords(streamClient, shardIterator)
+		if err != nil {
+			if CheckTrimmedDataError(err) {
+				lastEvaluatedSequenceNumber = nil
+				continue
+			} else {
+				streamInfo.Unexpected(fmt.Sprintf("Couldn't fetch records for table %s: %s", srcTable, err))
+				break
+			}
+		}
+
+		records := getRecordsOutput.Records
+		for _, record := range records {
+			ProcessRecord(conv, streamInfo, record, srcTable)
+			lastEvaluatedSequenceNumber = record.Dynamodb.SequenceNumber
+		}
+
+		if getRecordsOutput.NextShardIterator == nil || passAfterUserExit {
+			break
+		}
+		if streamInfo.UserExit {
+			passAfterUserExit = true
+		} else if len(records) == 0 {
+			time.Sleep(5 * time.Second)
+		}
+	}
+	streamInfo.SetShardStatus(shardId, true)
+}
+
+// WaitForParentShard checks every 6 seconds if parentShard is processed or
+// not and waits as long as parent shard is not processed.
+func WaitForParentShard(streamInfo *Info, parentShard *string) {
+	if parentShard != nil {
+		for {
+			streamInfo.lock.Lock()
+			done := streamInfo.ShardStatus[*parentShard]
+			streamInfo.lock.Unlock()
+			if done {
+				return
+			} else {
+				time.Sleep(6 * time.Second)
+			}
+		}
+	}
+}
+
+// getShardIterator returns an iterator to find records based on the lastEvaluatedSequence number.
+// If lastEvaluatedSequenceNumber is nil then it uses TrimHorizon as shardIterator type to point to first
+// non-expired record otherwise it finds the first unprocessed record after lastEvaluatedSequence number using
+// AfterSequenceNumber shardIterator type.
+func getShardIterator(streamClient dynamodbstreamsiface.DynamoDBStreamsAPI, lastEvaluatedSequenceNumber *string, shardId, streamArn string) (*string, error) {
+	var getShardIteratorInput *dynamodbstreams.GetShardIteratorInput
+	if lastEvaluatedSequenceNumber == nil {
+		getShardIteratorInput = &dynamodbstreams.GetShardIteratorInput{
+			ShardId:           &shardId,
+			ShardIteratorType: aws.String(dynamodbstreams.ShardIteratorTypeTrimHorizon),
+			StreamArn:         &streamArn,
+		}
+	} else {
+		getShardIteratorInput = &dynamodbstreams.GetShardIteratorInput{
+			SequenceNumber:    lastEvaluatedSequenceNumber,
+			ShardId:           &shardId,
+			ShardIteratorType: aws.String(dynamodbstreams.ShardIteratorTypeAfterSequenceNumber),
+			StreamArn:         &streamArn,
+		}
+	}
+	result, err := streamClient.GetShardIterator(getShardIteratorInput)
+	if err != nil {
+		err = fmt.Errorf("unexpected call to GetShardIterator: %v", err)
+		return nil, err
+	}
+	return result.ShardIterator, nil
+}
+
+// getRecords fetches the records from DynamoDB Streams by using the shardIterator.
+func getRecords(streamClient dynamodbstreamsiface.DynamoDBStreamsAPI, shardIterator *string) (*dynamodbstreams.GetRecordsOutput, error) {
+	getRecordsInput := &dynamodbstreams.GetRecordsInput{
+		ShardIterator: shardIterator,
+	}
+	result, err := streamClient.GetRecords(getRecordsInput)
+	if err != nil {
+		err = fmt.Errorf("unexpected call to GetRecords: %v", err)
+		return result, err
+	}
+	return result, nil
+}
+
+// ProcessRecord processes records retrieved from shards.
+func ProcessRecord(conv *internal.Conv, streamInfo *Info, record *dynamodbstreams.Record, srcTable string) {
+	streamInfo.StatsAddRecord(srcTable, *record.EventName)
+	// TODO(nareshz): work in progress
+	streamInfo.StatsAddRecordProcessed()
 }

--- a/sources/dynamodb/streaming_info.go
+++ b/sources/dynamodb/streaming_info.go
@@ -1,0 +1,95 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dynamodb
+
+import (
+	"sync"
+
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+)
+
+// Info contains information related to processing of DynamoDB Streams.
+type Info struct {
+	Records          map[string]map[string]int64 // Tablewise count of records received from DynamoDB Streams, broken down by record type i.e. INSERT, MODIFY & REMOVE.
+	recordsProcessed int64                       // Count of total records processed to Cloud Spanner(includes records which generated error as well).
+	ShardStatus      map[string]bool             // Processing status of a shard, (default false i.e. unprocessed).
+	UserExit         bool                        // flag confirming if customer wants to exit or not, (false until user presses Ctrl+C).
+	Unexpecteds      map[string]int64            // Count of unexpected conditions, broken down by condition description.
+	lock             sync.Mutex
+}
+
+func MakeInfo() *Info {
+	return &Info{
+		Records:          make(map[string]map[string]int64),
+		recordsProcessed: int64(0),
+		ShardStatus:      make(map[string]bool),
+		Unexpecteds:      make(map[string]int64),
+		UserExit:         false,
+		lock:             sync.Mutex{},
+	}
+}
+
+// SetShardStatus changes the status of a shard.
+//
+// true -> shard processed and vice versa.
+func (info *Info) SetShardStatus(shardId string, status bool) {
+	info.lock.Lock()
+	info.ShardStatus[shardId] = status
+	info.lock.Unlock()
+}
+
+// StatsAddRecord increases the count of records read from DynamoDB Streams
+// based on the table name and record type.
+func (info *Info) StatsAddRecord(srcTable, recordType string) {
+	info.lock.Lock()
+	info.Records[srcTable][recordType]++
+	info.lock.Unlock()
+}
+
+// StatsAddRecordProcessed increases the count of total records processed to Cloud Spanner.
+func (info *Info) StatsAddRecordProcessed() {
+	info.lock.Lock()
+	info.recordsProcessed++
+	info.lock.Unlock()
+}
+
+// Unexpected records stats about corner-cases and conditions
+// that were not expected.
+func (info *Info) Unexpected(u string) {
+	info.lock.Lock()
+	internal.VerbosePrintf("Unexpected condition: %s\n", u)
+	// Limit size of unexpected map. If over limit, then only
+	// update existing entries.
+	if _, ok := info.Unexpecteds[u]; ok || len(info.Unexpecteds) < 1000 {
+		info.Unexpecteds[u]++
+	}
+	info.lock.Unlock()
+}
+
+// TotalUnexpecteds returns the total number of distinct unexpected conditions
+// encountered during processing of DynamoDB Streams.
+func (info *Info) TotalUnexpecteds() int64 {
+	return int64(len(info.Unexpecteds))
+}
+
+// Records returns the total number of records read from DynamoDB Streams.
+func (info *Info) TotalRecords() int64 {
+	n := int64(0)
+	for _, c := range info.Records {
+		for _, x := range c {
+			n += x
+		}
+	}
+	return n
+}

--- a/sources/dynamodb/streaming_info.go
+++ b/sources/dynamodb/streaming_info.go
@@ -19,46 +19,46 @@ import (
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
 )
 
-// Info contains information related to processing of DynamoDB Streams.
-type Info struct {
+// StreamingInfo contains information related to processing of DynamoDB Streams.
+type StreamingInfo struct {
 	Records          map[string]map[string]int64 // Tablewise count of records received from DynamoDB Streams, broken down by record type i.e. INSERT, MODIFY & REMOVE.
 	recordsProcessed int64                       // Count of total records processed to Cloud Spanner(includes records which generated error as well).
-	ShardStatus      map[string]bool             // Processing status of a shard, (default false i.e. unprocessed).
+	ShardProcessed   map[string]bool             // Processing status of a shard, (default false i.e. unprocessed).
 	UserExit         bool                        // flag confirming if customer wants to exit or not, (false until user presses Ctrl+C).
 	Unexpecteds      map[string]int64            // Count of unexpected conditions, broken down by condition description.
 	lock             sync.Mutex
 }
 
-func MakeInfo() *Info {
-	return &Info{
+func MakeStreamingInfo() *StreamingInfo {
+	return &StreamingInfo{
 		Records:          make(map[string]map[string]int64),
 		recordsProcessed: int64(0),
-		ShardStatus:      make(map[string]bool),
+		ShardProcessed:   make(map[string]bool),
 		Unexpecteds:      make(map[string]int64),
 		UserExit:         false,
 		lock:             sync.Mutex{},
 	}
 }
 
-// SetShardStatus changes the status of a shard.
+// SetShardStatus changes the processing status of a shard.
 //
 // true -> shard processed and vice versa.
-func (info *Info) SetShardStatus(shardId string, status bool) {
+func (info *StreamingInfo) SetShardStatus(shardId string, status bool) {
 	info.lock.Lock()
-	info.ShardStatus[shardId] = status
+	info.ShardProcessed[shardId] = status
 	info.lock.Unlock()
 }
 
 // StatsAddRecord increases the count of records read from DynamoDB Streams
 // based on the table name and record type.
-func (info *Info) StatsAddRecord(srcTable, recordType string) {
+func (info *StreamingInfo) StatsAddRecord(srcTable, recordType string) {
 	info.lock.Lock()
 	info.Records[srcTable][recordType]++
 	info.lock.Unlock()
 }
 
 // StatsAddRecordProcessed increases the count of total records processed to Cloud Spanner.
-func (info *Info) StatsAddRecordProcessed() {
+func (info *StreamingInfo) StatsAddRecordProcessed() {
 	info.lock.Lock()
 	info.recordsProcessed++
 	info.lock.Unlock()
@@ -66,7 +66,7 @@ func (info *Info) StatsAddRecordProcessed() {
 
 // Unexpected records stats about corner-cases and conditions
 // that were not expected.
-func (info *Info) Unexpected(u string) {
+func (info *StreamingInfo) Unexpected(u string) {
 	info.lock.Lock()
 	internal.VerbosePrintf("Unexpected condition: %s\n", u)
 	// Limit size of unexpected map. If over limit, then only
@@ -79,17 +79,6 @@ func (info *Info) Unexpected(u string) {
 
 // TotalUnexpecteds returns the total number of distinct unexpected conditions
 // encountered during processing of DynamoDB Streams.
-func (info *Info) TotalUnexpecteds() int64 {
+func (info *StreamingInfo) TotalUnexpecteds() int64 {
 	return int64(len(info.Unexpecteds))
-}
-
-// Records returns the total number of records read from DynamoDB Streams.
-func (info *Info) TotalRecords() int64 {
-	n := int64(0)
-	for _, c := range info.Records {
-		for _, x := range c {
-			n += x
-		}
-	}
-	return n
 }

--- a/sources/dynamodb/streaming_info.go
+++ b/sources/dynamodb/streaming_info.go
@@ -40,6 +40,12 @@ func MakeStreamingInfo() *StreamingInfo {
 	}
 }
 
+// makeRecordMaps initializes maps used to stores record count for
+// a given table.
+func (info *StreamingInfo) makeRecordMaps(srcTable string) {
+	info.Records[srcTable] = make(map[string]int64)
+}
+
 // SetShardStatus changes the processing status of a shard.
 //
 // true -> shard processed and vice versa.

--- a/sources/dynamodb/streaming_info_test.go
+++ b/sources/dynamodb/streaming_info_test.go
@@ -25,3 +25,50 @@ func TestInfo_TotalUnexpecteds(t *testing.T) {
 	streamInfo.Unexpected("testing-unexpecteds-faced-2")
 	assert.Equal(t, int64(2), streamInfo.TotalUnexpecteds())
 }
+
+func TestStreamingInfo_SetShardStatus(t *testing.T) {
+	streamInfo := MakeStreamingInfo()
+	shardId := "testShardId"
+	streamInfo.SetShardStatus(shardId, true)
+	assert.Equal(t, true, streamInfo.ShardProcessed[shardId])
+}
+
+func sumNestedMapValues(mp map[string]map[string]int64) int64 {
+	n := int64(0)
+	for _, x := range mp {
+		for _, y := range x {
+			n += y
+		}
+	}
+	return n
+}
+
+func TestStreamingInfo_StatsAddRecord(t *testing.T) {
+	streamInfo := MakeStreamingInfo()
+
+	streamInfo.makeRecordMaps("testtable1")
+	streamInfo.makeRecordMaps("testtable2")
+	assert.NotNil(t, streamInfo.Records["testtable1"])
+
+	streamInfo.StatsAddRecord("testtable1", "INSERT")
+	streamInfo.StatsAddRecord("testtable2", "REMOVE")
+
+	assert.Equal(t, int64(2), sumNestedMapValues(streamInfo.Records))
+}
+
+func TestStreamingInfo_StatsAddRecordProcessed(t *testing.T) {
+	streamInfo := MakeStreamingInfo()
+	for i := 0; i < 3; i++ {
+		streamInfo.StatsAddRecordProcessed()
+	}
+	assert.Equal(t, int64(3), streamInfo.recordsProcessed)
+}
+
+func TestStreamingInfo_makeRecordMaps(t *testing.T) {
+	streamInfo := MakeStreamingInfo()
+	table := "testtable"
+
+	assert.Nil(t, streamInfo.Records[table])
+	streamInfo.makeRecordMaps(table)
+	assert.NotNil(t, streamInfo.Records[table])
+}

--- a/sources/dynamodb/streaming_info_test.go
+++ b/sources/dynamodb/streaming_info_test.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dynamodb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInfo_Unexpected(t *testing.T) {
+	streamInfo := MakeInfo()
+	streamInfo.Unexpected("testing-unexpecteds-faced-1")
+	streamInfo.Unexpected("testing-unexpecteds-faced-2")
+	assert.Equal(t, int64(2), streamInfo.TotalUnexpecteds())
+}
+
+func TestInfo_TotalRecords(t *testing.T) {
+	streamInfo := MakeInfo()
+	testTables := [2]string{"testTable1", "testTable2"}
+	for i := 0; i < 2; i++ {
+		streamInfo.Records[testTables[i]] = make(map[string]int64)
+	}
+	streamInfo.Records[testTables[0]]["INSERT"] = 37
+	streamInfo.Records[testTables[1]]["MODIFY"] = 3
+	assert.Equal(t, int64(40), streamInfo.TotalRecords())
+}

--- a/sources/dynamodb/streaming_info_test.go
+++ b/sources/dynamodb/streaming_info_test.go
@@ -19,20 +19,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInfo_Unexpected(t *testing.T) {
-	streamInfo := MakeInfo()
+func TestInfo_TotalUnexpecteds(t *testing.T) {
+	streamInfo := MakeStreamingInfo()
 	streamInfo.Unexpected("testing-unexpecteds-faced-1")
 	streamInfo.Unexpected("testing-unexpecteds-faced-2")
 	assert.Equal(t, int64(2), streamInfo.TotalUnexpecteds())
-}
-
-func TestInfo_TotalRecords(t *testing.T) {
-	streamInfo := MakeInfo()
-	testTables := [2]string{"testTable1", "testTable2"}
-	for i := 0; i < 2; i++ {
-		streamInfo.Records[testTables[i]] = make(map[string]int64)
-	}
-	streamInfo.Records[testTables[0]]["INSERT"] = 37
-	streamInfo.Records[testTables[1]]["MODIFY"] = 3
-	assert.Equal(t, int64(40), streamInfo.TotalRecords())
 }

--- a/sources/dynamodb/streaming_test.go
+++ b/sources/dynamodb/streaming_test.go
@@ -80,7 +80,7 @@ func (m *mockDynamoStreamsClient) GetRecords(input *dynamodbstreams.GetRecordsIn
 }
 
 func TestProcessStream(t *testing.T) {
-	streamInfo := MakeInfo()
+	streamInfo := MakeStreamingInfo()
 	streamInfo.UserExit = true
 	wgStream := &sync.WaitGroup{}
 
@@ -258,7 +258,7 @@ func Test_getRecords(t *testing.T) {
 
 func TestProcessShard(t *testing.T) {
 	wgShard := &sync.WaitGroup{}
-	streamInfo := MakeInfo()
+	streamInfo := MakeStreamingInfo()
 	streamInfo.UserExit = true
 	shardIterator_TrimHorizon := "testShardIteratorTrimHorizon"
 
@@ -291,10 +291,10 @@ func TestProcessShard(t *testing.T) {
 
 	wgShard.Add(1)
 	ProcessShard(wgShard, streamInfo, nil, mockStreamClient, shard, streamArn, srcTable)
-	assert.Equal(t, true, streamInfo.ShardStatus[*shard.ShardId])
+	assert.Equal(t, true, streamInfo.ShardProcessed[*shard.ShardId])
 
 	wgShard.Add(1)
 	ProcessShard(wgShard, streamInfo, nil, mockStreamClient, shard, streamArn, srcTable)
 	assert.Equal(t, int64(1), streamInfo.TotalUnexpecteds())
-	assert.Equal(t, true, streamInfo.ShardStatus[*shard.ShardId])
+	assert.Equal(t, true, streamInfo.ShardProcessed[*shard.ShardId])
 }

--- a/sources/dynamodb/streaming_test.go
+++ b/sources/dynamodb/streaming_test.go
@@ -1,0 +1,300 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dynamodb
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams/dynamodbstreamsiface"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDynamoStreamsClient struct {
+	describeStreamOutputs                []dynamodbstreams.DescribeStreamOutput
+	describeStreamCallCount              int
+	listStreamsOutputs                   []dynamodbstreams.ListStreamsOutput
+	listStreamsCallCount                 int
+	getShardIteratorOutputsTrimHorizon   []dynamodbstreams.GetShardIteratorOutput
+	getShardIteratorCallCountTrimHorizon int
+	getShardIteratorOutputsSeqNum        []dynamodbstreams.GetShardIteratorOutput
+	getShardIteratorCallCountSeqNum      int
+	getRecordsOutputs                    []dynamodbstreams.GetRecordsOutput
+	getRecordsCallCount                  int
+	dynamodbstreamsiface.DynamoDBStreamsAPI
+}
+
+func (m *mockDynamoStreamsClient) DescribeStream(input *dynamodbstreams.DescribeStreamInput) (*dynamodbstreams.DescribeStreamOutput, error) {
+	if m.describeStreamCallCount >= len(m.describeStreamOutputs) {
+		return nil, fmt.Errorf("unexpected call to DescribeStream: %v", input)
+	}
+	m.describeStreamCallCount++
+	return &m.describeStreamOutputs[m.describeStreamCallCount-1], nil
+}
+
+func (m *mockDynamoStreamsClient) ListStreams(input *dynamodbstreams.ListStreamsInput) (*dynamodbstreams.ListStreamsOutput, error) {
+	if m.listStreamsCallCount >= len(m.listStreamsOutputs) {
+		return nil, fmt.Errorf("unexpected call to ListStreams: %v", input)
+	}
+	m.listStreamsCallCount++
+	return &m.listStreamsOutputs[m.listStreamsCallCount-1], nil
+}
+
+func (m *mockDynamoStreamsClient) GetShardIterator(input *dynamodbstreams.GetShardIteratorInput) (*dynamodbstreams.GetShardIteratorOutput, error) {
+	if *input.ShardIteratorType == "TRIM_HORIZON" {
+		if m.getShardIteratorCallCountTrimHorizon >= len(m.getShardIteratorOutputsTrimHorizon) {
+			return nil, fmt.Errorf("unexpected call to GetShardIterator: %v", input)
+		}
+		m.getShardIteratorCallCountTrimHorizon++
+		return &m.getShardIteratorOutputsTrimHorizon[m.getShardIteratorCallCountTrimHorizon-1], nil
+	} else {
+		if m.getShardIteratorCallCountSeqNum >= len(m.getShardIteratorOutputsSeqNum) {
+			return nil, fmt.Errorf("unexpected call to GetShardIterator: %v", input)
+		}
+		m.getShardIteratorCallCountSeqNum++
+		return &m.getShardIteratorOutputsSeqNum[m.getShardIteratorCallCountSeqNum-1], nil
+	}
+}
+
+func (m *mockDynamoStreamsClient) GetRecords(input *dynamodbstreams.GetRecordsInput) (*dynamodbstreams.GetRecordsOutput, error) {
+	if m.getRecordsCallCount >= len(m.getRecordsOutputs) {
+		return nil, fmt.Errorf("unexpected call to GetShardIterator: %v", input)
+	}
+	m.getRecordsCallCount++
+	return &m.getRecordsOutputs[m.getRecordsCallCount-1], nil
+}
+
+func TestProcessStream(t *testing.T) {
+	streamInfo := MakeInfo()
+	streamInfo.UserExit = true
+	wgStream := &sync.WaitGroup{}
+
+	streamArn := [2]string{"streamArn1", "streamArn2"}
+	srcTableName := [2]string{"table1", "table2"}
+
+	describeStreamOutputs := []dynamodbstreams.DescribeStreamOutput{
+		{
+			StreamDescription: &dynamodbstreams.StreamDescription{
+				LastEvaluatedShardId: nil,
+				Shards:               []*dynamodbstreams.Shard{},
+				StreamArn:            &streamArn[0],
+			},
+		},
+		{
+			StreamDescription: &dynamodbstreams.StreamDescription{
+				LastEvaluatedShardId: nil,
+				Shards:               []*dynamodbstreams.Shard{},
+				StreamArn:            &streamArn[0],
+			},
+		},
+		{
+			StreamDescription: &dynamodbstreams.StreamDescription{
+				LastEvaluatedShardId: nil,
+				Shards:               []*dynamodbstreams.Shard{},
+				StreamArn:            &streamArn[1],
+			},
+		},
+	}
+	streamsClient := &mockDynamoStreamsClient{
+		describeStreamOutputs: describeStreamOutputs,
+	}
+
+	wgStream.Add(2)
+	for i := 0; i < 2; i++ {
+		ProcessStream(wgStream, streamsClient, streamInfo, nil, streamArn[i], srcTableName[i])
+	}
+	wgStream.Wait()
+	assert.Equal(t, int64(1), streamInfo.TotalUnexpecteds())
+}
+
+func Test_fetchShards(t *testing.T) {
+	streamArn := "testStreamArn"
+	tableName := "testTable"
+	type args struct {
+		streamClient         dynamodbstreamsiface.DynamoDBStreamsAPI
+		lastEvaluatedShardId *string
+		streamArn            string
+	}
+	streamDescription := dynamodbstreams.StreamDescription{
+		LastEvaluatedShardId: aws.String("shard2"),
+		Shards: []*dynamodbstreams.Shard{
+			{
+				ShardId: aws.String("shard1"),
+			},
+			{
+				ShardId: aws.String("shard2"),
+			},
+		},
+		StreamArn: &streamArn,
+		TableName: &tableName,
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *dynamodbstreams.StreamDescription
+		wantErr bool
+	}{
+		{
+			name: "test for correctness of output",
+			args: args{
+				streamClient: &mockDynamoStreamsClient{
+					describeStreamOutputs: []dynamodbstreams.DescribeStreamOutput{
+						{
+							StreamDescription: &streamDescription,
+						},
+					},
+				},
+				streamArn: streamArn,
+			},
+			want:    &streamDescription,
+			wantErr: false,
+		},
+		{
+			name: "test for checking api failures",
+			args: args{
+				streamClient: &mockDynamoStreamsClient{},
+				streamArn:    streamArn,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fetchShards(tt.args.streamClient, tt.args.lastEvaluatedShardId, tt.args.streamArn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fetchShards() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("fetchShards() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getShardIterator(t *testing.T) {
+	shardIteratorTrimHorizon := "testShardIteratorTrimHorizon"
+	shardIteratorSeqNum := "testShardIteratorSeqNum"
+	lastEvaluatedSequenceNumber := "0000000000000001"
+
+	mockStreamsClient := &mockDynamoStreamsClient{
+		getShardIteratorOutputsTrimHorizon: []dynamodbstreams.GetShardIteratorOutput{
+			{
+				ShardIterator: &shardIteratorTrimHorizon,
+			},
+		},
+		getShardIteratorOutputsSeqNum: []dynamodbstreams.GetShardIteratorOutput{
+			{
+				ShardIterator: &shardIteratorSeqNum,
+			},
+		},
+	}
+
+	shardIterator, err := getShardIterator(mockStreamsClient, nil, "", "")
+	assert.Nil(t, err)
+	assert.Equal(t, shardIteratorTrimHorizon, *shardIterator)
+
+	shardIterator, err = getShardIterator(mockStreamsClient, &lastEvaluatedSequenceNumber, "", "")
+	assert.Nil(t, err)
+	assert.Equal(t, shardIteratorSeqNum, *shardIterator)
+
+	_, err = getShardIterator(mockStreamsClient, nil, "", "")
+	assert.NotNil(t, err)
+}
+
+func Test_getRecords(t *testing.T) {
+	mockStreamsClient := &mockDynamoStreamsClient{
+		getRecordsOutputs: []dynamodbstreams.GetRecordsOutput{
+			{
+				NextShardIterator: nil,
+				Records: []*dynamodbstreams.Record{
+					{
+						EventName: aws.String("INSERT"),
+					},
+					{
+						EventName: aws.String("REMOVE"),
+					},
+					{
+						EventName: aws.String("MODIFY"),
+					},
+					{
+						EventName: aws.String("INSERT"),
+					},
+				},
+			},
+		},
+	}
+	shardIterator := "testShardIterator"
+	result, err := getRecords(mockStreamsClient, &shardIterator)
+	assert.Nil(t, err)
+	assert.Equal(t, int(4), len(result.Records))
+	mp := make(map[string]int)
+	for i := 0; i < len(result.Records); i++ {
+		mp[*result.Records[i].EventName]++
+	}
+	assert.Equal(t, int(1), mp["REMOVE"])
+	assert.Equal(t, int(2), mp["INSERT"])
+	assert.Equal(t, int(1), mp["MODIFY"])
+
+	_, err = getRecords(mockStreamsClient, &shardIterator)
+	assert.NotNil(t, err)
+}
+
+func TestProcessShard(t *testing.T) {
+	wgShard := &sync.WaitGroup{}
+	streamInfo := MakeInfo()
+	streamInfo.UserExit = true
+	shardIterator_TrimHorizon := "testShardIteratorTrimHorizon"
+
+	mockStreamClient := &mockDynamoStreamsClient{
+		getShardIteratorOutputsTrimHorizon: []dynamodbstreams.GetShardIteratorOutput{
+			{
+				ShardIterator: &shardIterator_TrimHorizon,
+			},
+			{
+				ShardIterator: &shardIterator_TrimHorizon,
+			},
+		},
+		getRecordsOutputs: []dynamodbstreams.GetRecordsOutput{
+			{
+				NextShardIterator: nil,
+				Records:           []*dynamodbstreams.Record{},
+			},
+		},
+	}
+	shardId := "testShardId"
+	shard := &dynamodbstreams.Shard{
+		SequenceNumberRange: &dynamodbstreams.SequenceNumberRange{
+			EndingSequenceNumber:   aws.String("10"),
+			StartingSequenceNumber: aws.String("10"),
+		},
+		ShardId: &shardId,
+	}
+	streamArn := "testStreamArn"
+	srcTable := "testSrcTable"
+
+	wgShard.Add(1)
+	ProcessShard(wgShard, streamInfo, nil, mockStreamClient, shard, streamArn, srcTable)
+	assert.Equal(t, true, streamInfo.ShardStatus[*shard.ShardId])
+
+	wgShard.Add(1)
+	ProcessShard(wgShard, streamInfo, nil, mockStreamClient, shard, streamArn, srcTable)
+	assert.Equal(t, int64(1), streamInfo.TotalUnexpecteds())
+	assert.Equal(t, true, streamInfo.ShardStatus[*shard.ShardId])
+}


### PR DESCRIPTION
**Things added**
- Support for reading records from DynamoDB Streams
   -  processing of DynamoDB Streams for different tables concurrently using threads
   - retrieval of shards from streams and processing so that order of changes on source database is maintained
   - strategy for processing records within shards handling all the corner cases.
  
- Unit tests for testing individual functions.
  - tests for checking DynamoDB Streams API calls.
  - tests for checking whole reading logic by creating a mock DynamoDB Streams client. 

**Things not handled**
- Writing data read from DynamoDB Streams to Cloud Spanner and changes to reportFile.
- Changes to README will be added after complete streaming migration solution is ready.

- [x] Tests pass