### PR TITLE
Adding Cloud Builds configuration file to setup Git-GCR pipeline

### DIFF
--- a/.docker/cloudbuild.yaml
+++ b/.docker/cloudbuild.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name : 'gcr.io/cloud-builders/docker'
+  args : ['build', '-t', 'gcr.io/${PROJECT_ID}/harbour-bridge:${_VERSION_NUMBER}', '-t', 'gcr.io/${PROJECT_ID}/harbour-bridge:latest', '.']
+  id : 'build-harbourbridge-image'
+  waitFor: ['-']
+substitutions:
+  _VERSION_NUMBER: 0.0.0 # default value
+images:
+- 'gcr.io/$PROJECT_ID/harbour-bridge:latest'
+- 'gcr.io/$PROJECT_ID/harbour-bridge:${_VERSION_NUMBER}'
+options:
+  dynamic_substitutions: true


### PR DESCRIPTION
This PR consists of 
- A `cloudbuild.yaml` file.

The file will be used by Google Cloud Build to establish a pipeline between the HarbourBridge's git repository and the Google Container Registry.
The pipeline will enable Cloud Build to build docker images of HarbourBridge using the latest source code in the git repository and push them to GCR.

Trigger for this operation - build and push, will be to click on the `run` button of the `HarbourBridge-Image-Release` trigger in the `Cloud Build > Triggers` console in Google Cloud followed by the entry of the release version number.

The tags for the released image in GCR will be 
- Version Number. eg - `1.0.1`
- `latest`

The logs of the image build will be stored in the `${PROJECT_ID}_cloudbuild` storage bucket.