### PR TITLE
Support for writing data from DynamoDB Streams to Cloud Spanner

### DIFF
--- a/sources/dynamodb/schema.go
+++ b/sources/dynamodb/schema.go
@@ -223,10 +223,13 @@ func (isi InfoSchemaImpl) StartStreamingMigration(ctx context.Context, client *s
 	fmt.Println("Use Ctrl+C to stop the process.")
 
 	streamInfo := MakeStreamingInfo()
+	setWriter(streamInfo, client, conv)
+
 	wg := &sync.WaitGroup{}
 
-	wg.Add(1)
+	wg.Add(2)
 	go catchCtrlC(wg, streamInfo)
+	go cutoverHelper(wg, streamInfo)
 
 	for srcTable, streamArn := range latestStreamArn {
 		streamInfo.makeRecordMaps(srcTable)

--- a/sources/dynamodb/streaming.go
+++ b/sources/dynamodb/streaming.go
@@ -14,21 +14,31 @@
 package dynamodb
 
 import (
+	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	sp "cloud.google.com/go/spanner"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams/dynamodbstreamsiface"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
+	"github.com/cloudspannerecosystem/harbourbridge/common/metrics"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/schema"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 // NewDynamoDBStream initializes a new DynamoDB Stream for a table with NEW_AND_OLD_IMAGES
@@ -78,6 +88,58 @@ func catchCtrlC(wg *sync.WaitGroup, streamInfo *StreamingInfo) {
 		<-c
 		streamInfo.UserExit = true
 	}()
+}
+
+const ESC = 27
+
+var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
+
+// updateProgress updates the customer every minute with number of records processed
+// and if the current moment is an optimum condition for cutover or not.
+func updateProgress(optimumCondition, firstCall bool, totalRecordsProcessed int64) {
+	if !firstCall {
+		fmt.Print(strings.Repeat(clear, 2))
+	}
+	fmt.Printf("Optimum time for switching to Cloud Spanner: %s\n", strconv.FormatBool(optimumCondition))
+	fmt.Printf("Count of records processed: %s\n", strconv.FormatInt(totalRecordsProcessed, 10))
+}
+
+// cutoverHelper analyzes the records processed and makes a decision if current moment is
+// optimum for switching to Cloud Spanner or not.
+func cutoverHelper(wg *sync.WaitGroup, streamInfo *StreamingInfo) {
+	defer wg.Done()
+
+	updateProgress(false, true, streamInfo.recordsProcessed)
+
+	timer := int64(0)
+	firstFiveMin := int64(0)
+	lastFiveMin := int64(0)
+	tillLastMin := int64(0)
+	arr := [5]int64{0, 0, 0, 0, 0}
+
+	for {
+		time.Sleep(60 * time.Second)
+		if streamInfo.UserExit {
+			break
+		}
+		counter := timer % 5
+
+		lastFiveMin -= arr[counter]
+
+		arr[counter] = streamInfo.recordsProcessed - tillLastMin
+		tillLastMin += arr[counter]
+
+		lastFiveMin += arr[counter]
+
+		if timer < 5 {
+			firstFiveMin += arr[counter]
+		}
+
+		lastMin := arr[counter]
+		optimumCondition := ((lastFiveMin*100 <= 5*firstFiveMin) || (lastMin == 0))
+		updateProgress(optimumCondition, false, tillLastMin)
+		timer++
+	}
 }
 
 // ProcessStream processes the latest enabled DynamoDB Stream for a table. It searches
@@ -253,9 +315,133 @@ func getRecords(streamClient dynamodbstreamsiface.DynamoDBStreamsAPI, shardItera
 	return result, nil
 }
 
-// ProcessRecord processes records retrieved from shards.
+// getColsAndSchemas provides information about columns and schema for a table.
+func getColsAndSchemas(conv *internal.Conv, srcTable string) (schema.Table, string, []string, ddl.CreateTable, error) {
+	srcSchema := conv.SrcSchema[srcTable]
+	spTable, err1 := internal.GetSpannerTable(conv, srcTable)
+	spCols, err2 := internal.GetSpannerCols(conv, srcTable, srcSchema.ColNames)
+	spSchema, ok := conv.SpSchema[spTable]
+	var err error
+	if err1 != nil || err2 != nil || !ok {
+		err = fmt.Errorf(fmt.Sprintf("err1=%s, err2=%s, ok=%t", err1, err2, ok))
+	}
+	return srcSchema, spTable, spCols, spSchema, err
+}
+
+// ProcessRecord processes records retrieved from shards. It first converts the data
+// to Spanner data (based on the source and Spanner schemas), and then writes that data
+// to Cloud Spanner.
 func ProcessRecord(conv *internal.Conv, streamInfo *StreamingInfo, record *dynamodbstreams.Record, srcTable string) {
-	streamInfo.StatsAddRecord(srcTable, *record.EventName)
-	// TODO(nareshz): work in progress
+	eventName := *record.EventName
+	streamInfo.StatsAddRecord(srcTable, eventName)
+
+	srcSchema, spTable, spCols, spSchema, err := getColsAndSchemas(conv, srcTable)
+	if err != nil {
+		streamInfo.Unexpected(fmt.Sprintf("Can't get cols and schemas for table %s: %v", srcTable, err))
+		return
+	}
+
+	var srcImage map[string]*dynamodb.AttributeValue
+	if eventName == "REMOVE" {
+		srcImage = record.Dynamodb.Keys
+	} else {
+		srcImage = record.Dynamodb.NewImage
+	}
+
+	spVals, badCols, srcStrVals := cvtRow(srcImage, srcSchema, spSchema, spCols)
+	if len(badCols) == 0 {
+		writeRecord(streamInfo, srcTable, spTable, eventName, spCols, spVals, srcSchema)
+	} else {
+		streamInfo.StatsAddBadRecord(srcTable, eventName)
+		streamInfo.CollectBadRecord(eventName, srcTable, srcSchema.ColNames, srcStrVals)
+	}
 	streamInfo.StatsAddRecordProcessed()
+}
+
+// writeRecord checks if the writer to write data to Cloud Spanner is configured or not.
+//
+// It handles creation and processing of mutations to Cloud Spanner.
+func writeRecord(streamInfo *StreamingInfo, srcTable, spTable, eventName string, spCols []string, spVals []interface{}, srcSchema schema.Table) {
+	if streamInfo.write == nil {
+		msg := "Internal error: writeRecord called but writer not configured"
+		streamInfo.StatsAddBadRecord(srcTable, eventName)
+		streamInfo.Unexpected(msg)
+	} else {
+		m := getMutation(eventName, srcTable, spTable, spCols, spVals, srcSchema)
+		err := writeMutation(m, streamInfo)
+		if err != nil {
+			streamInfo.StatsAddDroppedRecord(srcTable, eventName)
+			streamInfo.CollectDroppedRecord(eventName, spTable, spCols, spVals, err)
+		}
+	}
+}
+
+// getMutation creates a mutation for writing to Cloud Spanner from the converted data.
+func getMutation(eventName, srcTable, spTable string, spCols []string, spVals []interface{}, srcSchema schema.Table) (m *sp.Mutation) {
+	if eventName == "INSERT" {
+		m = sp.Insert(spTable, spCols, spVals)
+	} else if eventName == "MODIFY" {
+		m = sp.InsertOrUpdate(spTable, spCols, spVals)
+	} else {
+		m = removeMutation(srcSchema, spTable, srcTable, spVals)
+	}
+	return m
+}
+
+// removeMutation create a mutation from converted data for records of type 'REMOVE'.
+// It ensures that when keyset is created the order for primary keys passed is same
+// as the original database i.e. HASH Key, Partition Key.
+func removeMutation(srcSchema schema.Table, spTable, srcTable string, spVals []interface{}) (m *sp.Mutation) {
+	var srcKeys []string
+	var reqSpVals []interface{}
+	for i := 0; i < len(spVals); i++ {
+		if spVals[i] == nil {
+			continue
+		}
+		srcKeys = append(srcKeys, srcSchema.ColNames[i])
+		reqSpVals = append(reqSpVals, spVals[i])
+	}
+	primaryKeys := srcSchema.PrimaryKeys
+	if primaryKeys[0].Column != srcKeys[0] {
+		reqSpVals[0], reqSpVals[1] = reqSpVals[1], reqSpVals[0]
+	}
+	if len(reqSpVals) == 1 {
+		m = sp.Delete(spTable, sp.Key{reqSpVals[0]})
+	} else {
+		m = sp.Delete(spTable, sp.Key{reqSpVals[0], reqSpVals[1]})
+	}
+	return m
+}
+
+// parentDataMissingError checks if the error is a parent data missing error.
+func parentDataMissingError(err error) bool {
+	return strings.Contains(err.Error(), "NotFound") && strings.Contains(err.Error(), "Parent row") && strings.Contains(err.Error(), "is missing")
+}
+
+// writeMutation handles writing of a mutation to Cloud Spanner. If insertion fails
+// because of parent data missing error then it retries for a limit of 1000.
+func writeMutation(m *sp.Mutation, streamInfo *StreamingInfo) error {
+	retryLimit := 1000
+	var err error
+	for retryLimit > 0 {
+		err = streamInfo.write(m)
+		if err == nil || !parentDataMissingError(err) {
+			break
+		}
+		time.Sleep(4 * time.Second)
+		retryLimit--
+	}
+	return err
+}
+
+// setWriter initializes the write function used to write mutations to Cloud Spanner.
+func setWriter(streamInfo *StreamingInfo, client *sp.Client, conv *internal.Conv) {
+	streamInfo.write = func(m *sp.Mutation) error {
+		const migrationMetadataKey = "cloud-spanner-migration-metadata"
+		migrationData := metrics.GetMigrationData(conv, "", "", constants.DataConv)
+		serializedMigrationData, _ := proto.Marshal(migrationData)
+		migrationMetadataValue := base64.StdEncoding.EncodeToString(serializedMigrationData)
+		_, err := client.Apply(metadata.AppendToOutgoingContext(context.Background(), migrationMetadataKey, migrationMetadataValue), []*sp.Mutation{m})
+		return err
+	}
 }

--- a/sources/dynamodb/streaming_test.go
+++ b/sources/dynamodb/streaming_test.go
@@ -14,15 +14,24 @@
 package dynamodb
 
 import (
+	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
+	sp "cloud.google.com/go/spanner"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams/dynamodbstreamsiface"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/schema"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
 type mockDynamoStreamsClient struct {
@@ -297,4 +306,323 @@ func TestProcessShard(t *testing.T) {
 	ProcessShard(wgShard, streamInfo, nil, mockStreamClient, shard, streamArn, srcTable)
 	assert.Equal(t, int64(1), streamInfo.TotalUnexpecteds())
 	assert.Equal(t, true, streamInfo.ShardProcessed[*shard.ShardId])
+}
+
+func Test_getColsAndSchemas(t *testing.T) {
+	tableName := "testtable"
+	cols := []string{"a", "b", "c", "d"}
+	spSchema := ddl.CreateTable{
+		Name:     tableName,
+		ColNames: cols,
+		ColDefs: map[string]ddl.ColumnDef{
+			"a": {Name: "a", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+			"b": {Name: "b", T: ddl.Type{Name: ddl.Numeric}},
+			"c": {Name: "c", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+			"d": {Name: "d", T: ddl.Type{Name: ddl.Bool}},
+		},
+		Pks: []ddl.IndexKey{{Col: "a"}},
+	}
+	srcSchema := schema.Table{
+		Name:     tableName,
+		ColNames: cols,
+		ColDefs: map[string]schema.Column{
+			"a": {Name: "a", Type: schema.Type{Name: typeString}},
+			"b": {Name: "b", Type: schema.Type{Name: typeNumber}},
+			"c": {Name: "c", Type: schema.Type{Name: typeNumberString}},
+			"d": {Name: "d", Type: schema.Type{Name: typeBool}},
+		},
+		PrimaryKeys: []schema.Key{{Column: "a"}},
+	}
+	conv := buildConv(spSchema, srcSchema)
+
+	type args struct {
+		conv     *internal.Conv
+		srcTable string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    schema.Table
+		want1   string
+		want2   []string
+		want3   ddl.CreateTable
+		wantErr bool
+	}{
+		{
+			name: "test for checking correctness of output",
+			args: args{
+				conv:     conv,
+				srcTable: tableName,
+			},
+			want:    srcSchema,
+			want1:   tableName,
+			want2:   cols,
+			want3:   spSchema,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, got2, got3, err := getColsAndSchemas(tt.args.conv, tt.args.srcTable)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getColsAndSchemas() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getColsAndSchemas() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("getColsAndSchemas() got1 = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("getColsAndSchemas() got2 = %v, want %v", got2, tt.want2)
+			}
+			if !reflect.DeepEqual(got3, tt.want3) {
+				t.Errorf("getColsAndSchemas() got3 = %v, want %v", got3, tt.want3)
+			}
+		})
+	}
+}
+
+func TestProcessRecord(t *testing.T) {
+	valA := "strA"
+	numStr := "10.1"
+	numVal := big.NewRat(101, 10)
+
+	tableName := "testtable"
+	cols := []string{"a", "b"}
+	spSchema := ddl.CreateTable{
+		Name:     tableName,
+		ColNames: cols,
+		ColDefs: map[string]ddl.ColumnDef{
+			"a": {Name: "a", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
+			"b": {Name: "b", T: ddl.Type{Name: ddl.Numeric}},
+		},
+		Pks: []ddl.IndexKey{{Col: "a"}},
+	}
+	conv := buildConv(
+		spSchema,
+		schema.Table{
+			Name:     tableName,
+			ColNames: cols,
+			ColDefs: map[string]schema.Column{
+				"a": {Name: "a", Type: schema.Type{Name: typeString}},
+				"b": {Name: "b", Type: schema.Type{Name: typeNumber}},
+			},
+			PrimaryKeys: []schema.Key{{Column: "a"}},
+		},
+	)
+
+	record := &dynamodbstreams.Record{
+		Dynamodb: &dynamodbstreams.StreamRecord{
+			NewImage: map[string]*dynamodb.AttributeValue{
+				"a": {S: &valA},
+				"b": {N: &numStr},
+			},
+		},
+		EventName: aws.String("INSERT"),
+	}
+
+	streamInfo := MakeStreamingInfo()
+	streamInfo.Records[tableName] = make(map[string]int64)
+	writes := 0
+	streamInfo.write = func(m *sp.Mutation) error {
+		writes++
+		assert.Equal(t, m, sp.Insert(tableName, []string{"a", "b"}, []interface{}{valA, *numVal}))
+		return nil
+	}
+	ProcessRecord(conv, streamInfo, record, tableName)
+
+	// Check if call was successful.
+	assert.Equal(t, 1, writes)
+}
+
+func Test_getMutation(t *testing.T) {
+	srcTable := "testtable_src"
+	spTable := "testtable_sp"
+	spCols := []string{"a", "b", "c", "d"}
+	srcSchema := schema.Table{
+		Name:     srcTable,
+		ColNames: spCols,
+		ColDefs: map[string]schema.Column{
+			"a": {Name: "a", Type: schema.Type{Name: typeNumber}},
+			"b": {Name: "b", Type: schema.Type{Name: typeString}},
+			"c": {Name: "c", Type: schema.Type{Name: typeBool}},
+			"d": {Name: "d", Type: schema.Type{Name: typeString}},
+		},
+		PrimaryKeys: []schema.Key{schema.Key{Column: "d"}, schema.Key{Column: "b"}},
+	}
+
+	type args struct {
+		eventName string
+		srcTable  string
+		spTable   string
+		spCols    []string
+		spVals    []interface{}
+		srcSchema schema.Table
+	}
+	tests := []struct {
+		name  string
+		args  args
+		wantM *sp.Mutation
+	}{
+		{
+			name: "test for checking insert/update mutations",
+			args: args{
+				eventName: "INSERT",
+				srcTable:  srcTable,
+				spTable:   spTable,
+				spCols:    spCols,
+				spVals:    []interface{}{25, "key1", true, "key2", 3},
+				srcSchema: srcSchema,
+			},
+			wantM: sp.Insert(spTable, spCols, []interface{}{25, "key1", true, "key2", 3}),
+		},
+		{
+			name: "test for checking delete mutations",
+			args: args{
+				eventName: "REMOVE",
+				srcTable:  srcTable,
+				spTable:   spTable,
+				spCols:    spCols,
+				spVals:    []interface{}{nil, "key1", nil, "key2", nil},
+				srcSchema: srcSchema,
+			},
+			wantM: sp.Delete(spTable, sp.Key{"key2", "key1"}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotM := getMutation(tt.args.eventName, tt.args.srcTable, tt.args.spTable, tt.args.spCols, tt.args.spVals, tt.args.srcSchema); !reflect.DeepEqual(gotM, tt.wantM) {
+				t.Errorf("CreateMutation() = %v, want %v", gotM, tt.wantM)
+			}
+		})
+	}
+}
+
+func Test_writeRecord(t *testing.T) {
+	streamInfo := MakeStreamingInfo()
+
+	table := "testTable"
+	streamInfo.Records[table] = make(map[string]int64)
+	streamInfo.BadRecords[table] = make(map[string]int64)
+	streamInfo.DroppedRecords[table] = make(map[string]int64)
+
+	srcSchema := schema.Table{
+		Name:     table,
+		ColNames: []string{"e", "f"},
+		ColDefs: map[string]schema.Column{
+			"e": {Name: "e", Type: schema.Type{Name: typeString}},
+			"f": {Name: "f", Type: schema.Type{Name: typeNumber}},
+		},
+		PrimaryKeys: []schema.Key{schema.Key{Column: "f"}, schema.Key{Column: "e"}},
+	}
+	tests := []struct {
+		srcTable  string
+		spTable   string
+		eventName string
+		spCols    []string
+		spVals    []interface{}
+		srcSchema schema.Table
+	}{
+		{
+			srcTable:  table,
+			spTable:   table,
+			eventName: "INSERT",
+			spCols:    []string{"a", "b"},
+			spVals:    []interface{}{23, true},
+		},
+		{
+			srcTable:  table,
+			spTable:   table,
+			eventName: "MODIFY",
+			spCols:    []string{"c", "d"},
+			spVals:    []interface{}{"goodTesting", 45},
+		},
+		{
+			srcTable:  table,
+			spTable:   table,
+			eventName: "INSERT",
+			spCols:    []string{"a", "b"},
+			spVals:    []interface{}{27, false},
+		},
+		{
+			srcTable:  table,
+			spTable:   table,
+			eventName: "MODIFY",
+			spCols:    []string{"c", "d"},
+			spVals:    []interface{}{"badTesting", 49},
+		},
+		{
+			srcTable:  table,
+			spTable:   table,
+			eventName: "REMOVE",
+			spCols:    []string{"e", "f"},
+			spVals:    []interface{}{"goodTesting", 45},
+			srcSchema: srcSchema,
+		},
+		{
+			srcTable:  table,
+			spTable:   table,
+			eventName: "REMOVE",
+			spCols:    []string{"e", "f"},
+			spVals:    []interface{}{"badTesting", 55},
+			srcSchema: srcSchema,
+		},
+	}
+	goodMutations := []*sp.Mutation{
+		sp.Insert(table, []string{"a", "b"}, []interface{}{23, true}),
+		sp.InsertOrUpdate(table, []string{"c", "d"}, []interface{}{"goodTesting", 45}),
+		sp.Delete(table, sp.Key{45, "goodTesting"}),
+	}
+	badMutations := []*sp.Mutation{
+		sp.Insert(table, []string{"a", "b"}, []interface{}{27, false}),
+		sp.InsertOrUpdate(table, []string{"c", "d"}, []interface{}{"badTesting", 49}),
+		sp.Delete(table, sp.Key{55, "badTesting"}),
+	}
+
+	writeCount := int64(0)
+	var mutationsWritten []*sp.Mutation
+	var mutationsFailed []*sp.Mutation
+
+	streamInfo.write = func(m *sp.Mutation) error {
+		var err error
+		writeCount++
+		if intersect(m, badMutations) {
+			err = errors.New("record not processed")
+			mutationsFailed = append(mutationsFailed, m)
+		} else {
+			mutationsWritten = append(mutationsWritten, m)
+		}
+		time.Sleep(20 * time.Millisecond)
+		return err
+	}
+
+	for _, data := range tests {
+		writeRecord(streamInfo, data.srcTable, data.spTable, data.eventName, data.spCols, data.spVals, data.srcSchema)
+	}
+
+	// Check data written.
+	assert.Equal(t, true, reflect.DeepEqual(mutationsWritten, goodMutations))
+
+	// Check data rejected.
+	assert.Equal(t, true, reflect.DeepEqual(mutationsFailed, badMutations))
+
+	// Check total write calls.
+	assert.Equal(t, int64(6), writeCount)
+
+	// Check total dropped records.
+	assert.Equal(t, int64(3), sumNestedMapValues(streamInfo.DroppedRecords))
+
+	// Check dropped insert record.
+	assert.Equal(t, "type=INSERT table=testTable cols=[a b] data=[27 false] error=record not processed", streamInfo.SampleBadWrites[0])
+}
+
+func intersect(m *sp.Mutation, mutationSet []*sp.Mutation) bool {
+	for _, mutation := range mutationSet {
+		if reflect.DeepEqual(m, mutation) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Things added
- Converting data read from DynamoDB Streams to Cloud Spanner data based on source and spanner schemas.
- Creating mutations from converted data and processing them to Cloud Spanner.
- Collecting of bad and dropped records if errors are faced.
- Retry logic if insertion fails because of missing parent data.
- Updating customers about the progress of processing every minute. 
- Unit tests.

Things not handled
- Changes to report, badData files and Integration tests.
- Appropriate changes to README for using streaming migration.
- These will be added in subsequent PRs.