### PR TITLE
Changes to shard processing in DynamoDB Streams

### DIFF
--- a/sources/dynamodb/streaming_test.go
+++ b/sources/dynamodb/streaming_test.go
@@ -134,8 +134,8 @@ func Test_scanShards(t *testing.T) {
 	streamArn := "testStreamArn"
 	tableName := "testTable"
 	type args struct {
-		streamClient         dynamodbstreamsiface.DynamoDBStreamsAPI
-		streamArn            string
+		streamClient dynamodbstreamsiface.DynamoDBStreamsAPI
+		streamArn    string
 	}
 	tests := []struct {
 		name    string
@@ -182,7 +182,7 @@ func Test_scanShards(t *testing.T) {
 				},
 				streamArn: streamArn,
 			},
-			want:    []*dynamodbstreams.Shard{
+			want: []*dynamodbstreams.Shard{
 				{
 					ShardId: aws.String("shard1"),
 				},


### PR DESCRIPTION
**Issue**: 
- Child shards ended up waiting for parent shards infinitely in case parent shards get deleted within DynamoDB Streams. 

**Things changed**
- Changed the scanning strategy of shards to handle issue.