### PR TITLE
Fixing report file names for consistency with db name

### DIFF
--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -124,7 +124,7 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	)
 
 	if !cmd.dryRun {
-		adminClient, _, dbURI, err = CreateDatabaseClient(ctx, targetProfile, sourceProfile.Driver, ioHelper)
+		adminClient, _, dbURI, err = CreateDatabaseClient(ctx, targetProfile, sourceProfile.Driver, dbName, ioHelper)
 		if err != nil {
 			err = fmt.Errorf("can't create database client: %v", err)
 			return subcommands.ExitFailure

--- a/cmd/schema_and_data.go
+++ b/cmd/schema_and_data.go
@@ -135,7 +135,7 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 
 	if !cmd.dryRun {
 		conversion.Report(sourceProfile.Driver, nil, ioHelper.BytesRead, "", conv, cmd.filePrefix+reportFile, ioHelper.Out)
-		adminClient, client, dbURI, err = CreateDatabaseClient(ctx, targetProfile, sourceProfile.Driver, ioHelper)
+		adminClient, client, dbURI, err = CreateDatabaseClient(ctx, targetProfile, sourceProfile.Driver, dbName, ioHelper)
 		if err != nil {
 			err = fmt.Errorf("can't create database client: %v", err)
 			return subcommands.ExitFailure

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -26,7 +26,10 @@ import (
 )
 
 // CreateDatabaseClient creates new database client and admin client.
-func CreateDatabaseClient(ctx context.Context, targetProfile profiles.TargetProfile, driver string, ioHelper utils.IOStreams) (*database.DatabaseAdminClient, *sp.Client, string, error) {
+func CreateDatabaseClient(ctx context.Context, targetProfile profiles.TargetProfile, driver, dbName string, ioHelper utils.IOStreams) (*database.DatabaseAdminClient, *sp.Client, string, error) {
+	if targetProfile.Conn.Sp.Dbname == "" {
+		targetProfile.Conn.Sp.Dbname = dbName
+	}
 	project, instance, dbName, err := targetProfile.GetResourceIds(ctx, time.Now(), driver, ioHelper.Out)
 	if err != nil {
 		return nil, nil, "", err


### PR DESCRIPTION
Currently, the generated database name and file names mismatch in case of target db name provided. This PR fixes the issue by generating the name only once.