### PR TITLE
Add nightly builds in Github actions

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 on:
+  schedule:
+    - cron:  '0 0 * * *'
   push:
     branches:
       - master


### PR DESCRIPTION
Adds nightly builds via Github actions. This is the out AI of Harbourbridge testing strategy discussion.