### PR TITLE
Add new build targets for vendoring dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,33 @@
+# Set GOPATH env variable if not set
+ifndef $(GOPATH)
+    GOPATH=$(shell go env GOPATH)
+    export GOPATH
+endif
 # Build the default binary
 build:
 	go build
 # Build a static binary
 build-static:
+	go build -a -tags osusergo,netgo -ldflags '-w -extldflags "-static"' -o harbourbridge main.go
+# Build the default binary with vendored dependencies
+build-vendor:
+	go mod tidy
+# 	vendor the dependencies
+	go mod vendor
+# 	vendor non-go files
+	go install github.com/goware/modvendor@latest
+	$(GOPATH)/bin/modvendor -copy="**/*.c **/*.h **/*.proto" -v
+# 	build the binary
+	go build
+# Build the static binary with vendored dependencies
+build-static-vendor:
+	go mod tidy
+# 	vendor the dependencies
+	go mod vendor
+# 	vendor non-go files
+	go install github.com/goware/modvendor@latest
+	$(GOPATH)/bin/modvendor -copy="**/*.c **/*.h **/*.proto" -v
+# build the binary
 	go build -a -tags osusergo,netgo -ldflags '-w -extldflags "-static"' -o harbourbridge main.go
 # Run unit tests
 test:


### PR DESCRIPTION
Adds new targets to the `Makefile` to build harbourbridge from vendored dependencies. This also includes using a tool to vendor non-go files since `go mod vendor` does not vendor them properly.