### PR TITLE
Fix case sensitivity issue with Spangres target

### DIFF
--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -72,8 +72,9 @@ const (
 )
 
 // Type represents the type of a column.
-//     type:
-//        { BOOL | INT64 | FLOAT64 | STRING( length ) | BYTES( length ) | DATE | TIMESTAMP | NUMERIC }
+//
+//	type:
+//	   { BOOL | INT64 | FLOAT64 | STRING( length ) | BYTES( length ) | DATE | TIMESTAMP | NUMERIC }
 type Type struct {
 	Name string
 	// Len encodes the following Spanner DDL definition:
@@ -140,8 +141,9 @@ func (ty Type) PGPrintColumnDefType() string {
 }
 
 // ColumnDef encodes the following DDL definition:
-//     column_def:
-//       column_name type [NOT NULL] [options_def]
+//
+//	column_def:
+//	  column_name type [NOT NULL] [options_def]
 type ColumnDef struct {
 	Name    string
 	T       Type
@@ -162,7 +164,7 @@ type Config struct {
 func (c Config) quote(s string) string {
 	if c.ProtectIds {
 		if c.TargetDb == constants.TargetExperimentalPostgres {
-			return "\"" + s + "\""
+			return s
 		} else {
 			return "`" + s + "`"
 		}
@@ -187,10 +189,11 @@ func (cd ColumnDef) PrintColumnDef(c Config) (string, string) {
 }
 
 // IndexKey encodes the following DDL definition:
-//     primary_key:
-//       PRIMARY KEY ( [key_part, ...] )
-//     key_part:
-//        column_name [{ ASC | DESC }]
+//
+//	primary_key:
+//	  PRIMARY KEY ( [key_part, ...] )
+//	key_part:
+//	   column_name [{ ASC | DESC }]
 type IndexKey struct {
 	Col   string
 	Desc  bool // Default order is ascending i.e. Desc = false.
@@ -208,8 +211,9 @@ func (pk IndexKey) PrintIndexKey(c Config) string {
 }
 
 // Foreignkey encodes the following DDL definition:
-//    [ CONSTRAINT constraint_name ]
-// 	  FOREIGN KEY ( column_name [, ... ] ) REFERENCES ref_table ( ref_column [, ... ] ) }
+//
+//	   [ CONSTRAINT constraint_name ]
+//		  FOREIGN KEY ( column_name [, ... ] ) REFERENCES ref_table ( ref_column [, ... ] ) }
 type Foreignkey struct {
 	Name         string
 	Columns      []string
@@ -233,7 +237,8 @@ func (k Foreignkey) PrintForeignKey(c Config) string {
 }
 
 // CreateTable encodes the following DDL definition:
-//     create_table: CREATE TABLE table_name ([column_def, ...] ) primary_key [, cluster]
+//
+//	create_table: CREATE TABLE table_name ([column_def, ...] ) primary_key [, cluster]
 type CreateTable struct {
 	Name     string
 	ColNames []string             // Provides names and order of columns
@@ -294,7 +299,8 @@ func (ct CreateTable) PrintCreateTable(config Config) string {
 }
 
 // CreateIndex encodes the following DDL definition:
-//     create index: CREATE [UNIQUE] [NULL_FILTERED] INDEX index_name ON table_name ( key_part [, ...] ) [ storing_clause ] [ , interleave_clause ]
+//
+//	create index: CREATE [UNIQUE] [NULL_FILTERED] INDEX index_name ON table_name ( key_part [, ...] ) [ storing_clause ] [ , interleave_clause ]
 type CreateIndex struct {
 	Name          string
 	Table         string

--- a/spanner/ddl/ast_test.go
+++ b/spanner/ddl/ast_test.go
@@ -88,7 +88,7 @@ func TestPrintColumnDefPG(t *testing.T) {
 		{in: ColumnDef{Name: "col1", T: Type{Name: Int64, IsArray: true}}, expected: "col1 VARCHAR(2621440)"},
 		{in: ColumnDef{Name: "col1", T: Type{Name: Int64}, NotNull: true}, expected: "col1 INT8 NOT NULL"},
 		{in: ColumnDef{Name: "col1", T: Type{Name: Int64, IsArray: true}, NotNull: true}, expected: "col1 VARCHAR(2621440) NOT NULL"},
-		{in: ColumnDef{Name: "col1", T: Type{Name: Int64}}, protectIds: true, expected: "\"col1\" INT8"},
+		{in: ColumnDef{Name: "col1", T: Type{Name: Int64}}, protectIds: true, expected: "col1 INT8"},
 	}
 	for _, tc := range tests {
 		s, _ := tc.in.PrintColumnDef(Config{ProtectIds: tc.protectIds, TargetDb: constants.TargetExperimentalPostgres})
@@ -106,7 +106,7 @@ func TestPrintIndexKey(t *testing.T) {
 		{in: IndexKey{Col: "col1"}, expected: "col1"},
 		{in: IndexKey{Col: "col1", Desc: true}, expected: "col1 DESC"},
 		{in: IndexKey{Col: "col1"}, protectIds: true, expected: "`col1`"},
-		{in: IndexKey{Col: "col1"}, protectIds: true, targetDb: constants.TargetExperimentalPostgres, expected: "\"col1\""},
+		{in: IndexKey{Col: "col1"}, protectIds: true, targetDb: constants.TargetExperimentalPostgres, expected: "col1"},
 	}
 	for _, tc := range tests {
 		assert.Equal(t, tc.expected, tc.in.PrintIndexKey(Config{ProtectIds: tc.protectIds, TargetDb: tc.targetDb}))
@@ -231,11 +231,11 @@ func TestPrintCreateTablePG(t *testing.T) {
 			"quote",
 			true,
 			t1,
-			"CREATE TABLE \"mytable\" (\n" +
-				"	\"col1\" INT8 NOT NULL,\n" +
-				"	\"col2\" VARCHAR(2621440),\n" +
-				"	\"col3\" BYTEA,\n" +
-				"	PRIMARY KEY (\"col1\" DESC)\n" +
+			"CREATE TABLE mytable (\n" +
+				"	col1 INT8 NOT NULL,\n" +
+				"	col2 VARCHAR(2621440),\n" +
+				"	col3 BYTEA,\n" +
+				"	PRIMARY KEY (col1 DESC)\n" +
 				")",
 		},
 		{
@@ -283,8 +283,8 @@ func TestPrintCreateIndex(t *testing.T) {
 		{"no quote non unique", false, "", ci[0], "CREATE INDEX myindex ON mytable (col1 DESC, col2)"},
 		{"quote non unique", true, "", ci[0], "CREATE INDEX `myindex` ON `mytable` (`col1` DESC, `col2`)"},
 		{"unique key", true, "", ci[1], "CREATE UNIQUE INDEX `myindex2` ON `mytable` (`col1` DESC, `col2`)"},
-		{"quote non unique PG", true, constants.TargetExperimentalPostgres, ci[0], "CREATE INDEX \"myindex\" ON \"mytable\" (\"col1\" DESC, \"col2\")"},
-		{"unique key PG", true, constants.TargetExperimentalPostgres, ci[1], "CREATE UNIQUE INDEX \"myindex2\" ON \"mytable\" (\"col1\" DESC, \"col2\")"},
+		{"quote non unique PG", true, constants.TargetExperimentalPostgres, ci[0], "CREATE INDEX myindex ON mytable (col1 DESC, col2)"},
+		{"unique key PG", true, constants.TargetExperimentalPostgres, ci[1], "CREATE UNIQUE INDEX myindex2 ON mytable (col1 DESC, col2)"},
 	}
 	for _, tc := range tests {
 		assert.Equal(t, tc.expected, tc.index.PrintCreateIndex(Config{ProtectIds: tc.protectIds, TargetDb: tc.targetDb}))
@@ -318,7 +318,7 @@ func TestPrintForeignKey(t *testing.T) {
 		{"no quote", false, "", "CONSTRAINT fk_test FOREIGN KEY (c1, c2) REFERENCES ref_table (ref_c1, ref_c2)", fk[0]},
 		{"quote", true, "", "CONSTRAINT `fk_test` FOREIGN KEY (`c1`, `c2`) REFERENCES `ref_table` (`ref_c1`, `ref_c2`)", fk[0]},
 		{"no constraint name", false, "", "FOREIGN KEY (c1) REFERENCES ref_table (ref_c1)", fk[1]},
-		{"quote PG", true, constants.TargetExperimentalPostgres, "CONSTRAINT \"fk_test\" FOREIGN KEY (\"c1\", \"c2\") REFERENCES \"ref_table\" (\"ref_c1\", \"ref_c2\")", fk[0]},
+		{"quote PG", true, constants.TargetExperimentalPostgres, "CONSTRAINT fk_test FOREIGN KEY (c1, c2) REFERENCES ref_table (ref_c1, ref_c2)", fk[0]},
 	}
 	for _, tc := range tests {
 		assert.Equal(t, tc.expected, tc.fk.PrintForeignKey(Config{ProtectIds: tc.protectIds, TargetDb: tc.targetDb}))
@@ -353,7 +353,7 @@ func TestPrintForeignKeyAlterTable(t *testing.T) {
 		{"no quote", "table1", false, "", "ALTER TABLE table1 ADD CONSTRAINT fk_test FOREIGN KEY (c1, c2) REFERENCES ref_table (ref_c1, ref_c2)", fk[0]},
 		{"quote", "table1", true, "", "ALTER TABLE `table1` ADD CONSTRAINT `fk_test` FOREIGN KEY (`c1`, `c2`) REFERENCES `ref_table` (`ref_c1`, `ref_c2`)", fk[0]},
 		{"no constraint name", "table1", false, "", "ALTER TABLE table1 ADD FOREIGN KEY (c1) REFERENCES ref_table (ref_c1)", fk[1]},
-		{"quote PG", "table1", true, constants.TargetExperimentalPostgres, "ALTER TABLE \"table1\" ADD CONSTRAINT \"fk_test\" FOREIGN KEY (\"c1\", \"c2\") REFERENCES \"ref_table\" (\"ref_c1\", \"ref_c2\")", fk[0]},
+		{"quote PG", "table1", true, constants.TargetExperimentalPostgres, "ALTER TABLE table1 ADD CONSTRAINT fk_test FOREIGN KEY (c1, c2) REFERENCES ref_table (ref_c1, ref_c2)", fk[0]},
 	}
 	for _, tc := range tests {
 		assert.Equal(t, tc.expected, tc.fk.PrintForeignKeyAlterTable(Config{ProtectIds: tc.protectIds, TargetDb: tc.targetDb}, tc.table))


### PR DESCRIPTION
Fixes case sensitivity issue with Spangres migration. PostgreSQL is case sensitive if double quotes are added around identifiers. This was the default behaviour.

Read up about case sensitivity in Postgres:

1. https://stackoverflow.com/questions/7651417/escaping-keyword-like-column-names-in-postgres
2. https://dev.to/lefebvre/dont-get-bit-by-postgresql-case-sensitivity--457i


In order to protect Ids for transformation, we add backticks for Spanner target, and quotes for Spangres target. Adding quotes results in the schema in the comment above, and makes the CREATE TABLE and other related DDL statements case-sensitive.

As per the PostgreSQL docs, I did not find a direct equivalent for backticks. It looks like PostgreSQL allows creation of table names, columns with reserved keywords and it is during querying where it requires special handling of these keywords.

### Testing details:
1. Verified that a MySQL Db with created with `camelCase` fields does not preserve case sensitivity while migrating to Spangres.
2. Verified foreign key constraints are added properly. 