### PR TITLE
Fix: Initialise logger for harbourbridge web command

### DIFF
--- a/webv2/webCmd.go
+++ b/webv2/webCmd.go
@@ -31,7 +31,8 @@ import (
 var FrontendDir embed.FS
 
 type WebCmd struct {
-	DistDir embed.FS
+	DistDir 	embed.FS
+	logLevel 	string
 }
 
 // Name returns the name of operation.
@@ -49,6 +50,7 @@ func (cmd *WebCmd) Usage() string {
 }
 
 func (cmd *WebCmd) SetFlags(f *flag.FlagSet) {
+	f.StringVar(&cmd.logLevel, "log-level", "INFO", "Configure the logging level for the command (INFO, DEBUG), defaults to INFO")
 }
 
 func (cmd *WebCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
@@ -60,9 +62,9 @@ func (cmd *WebCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{
 			logger.Log.Fatal("FATAL error", zap.Error(err))
 		}
 	}()
-	err = logger.InitializeLogger("INFO")
+	err = logger.InitializeLogger(cmd.logLevel)
 	if err != nil {
-		fmt.Println("Error initialising logger: ", err)
+		fmt.Println("Error initialising logger, did you specify a valid log-level? [DEBUG, INFO, WARN, ERROR, FATAL]", err)
 		return subcommands.ExitFailure
 	}
 	defer logger.Log.Sync()

--- a/webv2/webCmd.go
+++ b/webv2/webCmd.go
@@ -23,7 +23,9 @@ import (
 	"path"
 
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
+	"github.com/cloudspannerecosystem/harbourbridge/logger"
 	"github.com/google/subcommands"
+	"go.uber.org/zap"
 )
 
 var FrontendDir embed.FS
@@ -52,6 +54,18 @@ func (cmd *WebCmd) SetFlags(f *flag.FlagSet) {
 func (cmd *WebCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
 	FrontendDir = cmd.DistDir
+	var err error
+	defer func() {
+		if err != nil {
+			logger.Log.Fatal("FATAL error", zap.Error(err))
+		}
+	}()
+	err = logger.InitializeLogger("INFO")
+	if err != nil {
+		fmt.Println("Error initialising logger: ", err)
+		return subcommands.ExitFailure
+	}
+	defer logger.Log.Sync()
 	App()
 	return subcommands.ExitSuccess
 }


### PR DESCRIPTION
Initialise logger for `./harbourbridge web` command. This was earlier causing failures when running the UI via the CLI sub-structure `web` command.
