### PR TITLE
Use filepath.Join to concatinate files and paths

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -48,7 +49,7 @@ const DefaultWritersLimit = 40
 // 4. Generate report
 func CommandLine(ctx context.Context, driver, targetDb, dbURI string, dataOnly, schemaOnly, skipForeignKeys bool, schemaSampleSize int64, sessionJSON string, ioHelper *utils.IOStreams, outputFilePrefix string, now time.Time) error {
 	// Cleanup hb tmp data directory in case residuals remain from prev runs.
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	// Legacy mode is only supported for MySQL, PostgreSQL and DynamoDB
 	if driver != "" && utils.IsValidDriver(driver) && !utils.IsLegacyModeSupportedDriver(driver) {
 		return fmt.Errorf("legacy mode is not supported for drivers other than %s", strings.Join(utils.GetLegacyModeSupportedDrivers(), ", "))
@@ -131,6 +132,6 @@ func CommandLine(ctx context.Context, driver, targetDb, dbURI string, dataOnly, 
 	conversion.Report(driver, bw.DroppedRowsByTable(), ioHelper.BytesRead, banner, conv, outputFilePrefix+reportFile, ioHelper.Out)
 	conversion.WriteBadData(bw, conv, banner, outputFilePrefix+badDataFile, ioHelper.Out)
 	// Cleanup hb tmp data directory.
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	return nil
 }

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	sp "cloud.google.com/go/spanner"
@@ -87,7 +88,7 @@ func (cmd *DataCmd) SetFlags(f *flag.FlagSet) {
 
 func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	// Cleanup hb tmp data directory in case residuals remain from prev runs.
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	var err error
 	defer func() {
 		if err != nil {
@@ -158,7 +159,7 @@ func (cmd *DataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface
 	conversion.Report(sourceProfile.Driver, bw.DroppedRowsByTable(), ioHelper.BytesRead, banner, conv, cmd.filePrefix+reportFile, ioHelper.Out)
 	conversion.WriteBadData(bw, conv, banner, cmd.filePrefix+badDataFile, ioHelper.Out)
 	// Cleanup hb tmp data directory.
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	return subcommands.ExitSuccess
 }
 

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
@@ -78,7 +79,7 @@ func (cmd *SchemaCmd) SetFlags(f *flag.FlagSet) {
 
 func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	// Cleanup hb tmp data directory in case residuals remain from prev runs.
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	var err error
 	defer func() {
 		if err != nil {
@@ -130,6 +131,6 @@ func (cmd *SchemaCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfa
 	banner := utils.GetBanner(schemaConversionStartTime, dbName)
 	conversion.Report(sourceProfile.Driver, nil, ioHelper.BytesRead, banner, conv, cmd.filePrefix+reportFile, ioHelper.Out)
 	// Cleanup hb tmp data directory.
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	return subcommands.ExitSuccess
 }

--- a/cmd/schema_and_data.go
+++ b/cmd/schema_and_data.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
@@ -83,7 +84,7 @@ func (cmd *SchemaAndDataCmd) SetFlags(f *flag.FlagSet) {
 
 func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	// Cleanup hb tmp data directory in case residuals remain from prev runs.
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	var err error
 	defer func() {
 		if err != nil {
@@ -157,6 +158,6 @@ func (cmd *SchemaAndDataCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...
 	conversion.WriteBadData(bw, conv, banner, cmd.filePrefix+badDataFile, ioHelper.Out)
 
 	// Cleanup hb tmp data directory.
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	return subcommands.ExitSuccess
 }

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -111,7 +112,7 @@ func DownloadFromGCS(bucketName, filePath, tmpFile string) (*os.File, error) {
 	defer rc.Close()
 	r := bufio.NewReader(rc)
 
-	tmpDir := os.TempDir() + constants.HB_TMP_DIR
+	tmpDir := filepath.Join(os.TempDir(), constants.HB_TMP_DIR)
 	os.MkdirAll(tmpDir, os.ModePerm)
 	tmpfile, err := os.Create(tmpDir + "/" + tmpFile)
 	if err != nil {
@@ -158,7 +159,7 @@ func PreloadGCSFiles(tables []ManifestTable) ([]ManifestTable, error) {
 				filePath := u.Path[1:] // removes "/" from beginning of path
 				tmpFile := strings.ReplaceAll(filePath, "/", ".")
 				// Files get downloaded to tmp dir.
-				fileLoc := os.TempDir() + constants.HB_TMP_DIR + "/" + tmpFile
+				fileLoc := filepath.Join(os.TempDir(), constants.HB_TMP_DIR, tmpFile)
 				_, err = DownloadFromGCS(bucketName, filePath, tmpFile)
 				if err != nil {
 					return nil, fmt.Errorf("cannot download gcs file: %s for table %s", filePath, table.Table_name)

--- a/webv2/webCmd.go
+++ b/webv2/webCmd.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/google/subcommands"
@@ -50,7 +51,7 @@ func (cmd *WebCmd) SetFlags(f *flag.FlagSet) {
 }
 
 func (cmd *WebCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	os.RemoveAll(os.TempDir() + constants.HB_TMP_DIR)
+	os.RemoveAll(filepath.Join(os.TempDir(), constants.HB_TMP_DIR))
 	FrontendDir = cmd.DistDir
 	App()
 	return subcommands.ExitSuccess


### PR DESCRIPTION
* files and paths concatenation with filepath.Join is more portable rather than with '+'

* os.TempDir() returns '/tmp' if TMPDIR is not defilned(https://github.com/golang/go/blob/master/src/os/file_unix.go#L339-L346). But, the current implementation expected the path to end with a '/'

- [x] Tests pass