### PR TITLE
Fix: WebApp logging when called from outside the CLI.

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func main() {
 
 	// Note: the web interface does not use any commandline flags.
 	if webapiv2 {
-		webv2.App()
+		webv2.App("INFO")
 		return
 	}
 

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -2038,7 +2038,7 @@ func init() {
 func App(logLevel string) {
 	err := logger.InitializeLogger(logLevel)
 	if err != nil {
-		log.Fatal("Cannot boot up the webApp!")
+		log.Fatal("Error initialising webapp, did you specify a valid log-level? [DEBUG, INFO, WARN, ERROR, FATAL]")
 	}
 	addr := ":8080"
 	router := getRoutes()

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cloudspannerecosystem/harbourbridge/common/utils"
 	"github.com/cloudspannerecosystem/harbourbridge/conversion"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/logger"
 	"github.com/cloudspannerecosystem/harbourbridge/profiles"
 	"github.com/cloudspannerecosystem/harbourbridge/proto/migration"
 	"github.com/cloudspannerecosystem/harbourbridge/schema"
@@ -2034,7 +2035,11 @@ func init() {
 }
 
 // App connects to the web app v2.
-func App() {
+func App(logLevel string) {
+	err := logger.InitializeLogger(logLevel)
+	if err != nil {
+		log.Fatal("Cannot boot up the webApp!")
+	}
 	addr := ":8080"
 	router := getRoutes()
 	fmt.Println("Harbourbridge UI started at:", fmt.Sprintf("http://localhost%s", addr))

--- a/webv2/webCmd.go
+++ b/webv2/webCmd.go
@@ -63,12 +63,7 @@ func (cmd *WebCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{
 			logger.Log.Fatal("FATAL error", zap.Error(err))
 		}
 	}()
-	err = logger.InitializeLogger(cmd.logLevel)
-	if err != nil {
-		fmt.Println("Error initialising logger, did you specify a valid log-level? [DEBUG, INFO, WARN, ERROR, FATAL]", err)
-		return subcommands.ExitFailure
-	}
 	defer logger.Log.Sync()
-	App()
+	App(cmd.logLevel)
 	return subcommands.ExitSuccess
 }


### PR DESCRIPTION
Fixes an issue where indirect calls to the webapp from outside the CLI would cause segmentation faults due to the logging library not being initialised.
This change initialises the logging library at the time of bootup of the webapp ensuring all the call paths have the logging library available.