### PR TITLE
Add support for JSONB data type for PG Spanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,8 +623,3 @@ the data. This is not verified during updation of the keys
 - Conversion to Spanner ARRAY type is currently not supported
 - MySQL types BIT and TIME are not converted correctly
 - PostgreSQL types bit, bit varying, bytea and time not converted correctly.
-### Data Types
-
-**PG Spanner JSONB type** 
- - Harbourbridge does not support the PG Spanner's JSONB type. HB will convert any source Postgres database columns of type JSON or JSONB into strings representing the JSON value.
-- As a workaround, after schema conversion, users can drop the `string` column created for the JSONB type, and manually add a new column of `jsonb` type. This can be on the Cloud Spanner console.

--- a/sources/common/toddl.go
+++ b/sources/common/toddl.go
@@ -30,7 +30,6 @@ While adding new methods or code here
 package common
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"unicode"
@@ -111,8 +110,6 @@ func SchemaToSpannerDDLHelper(conv *internal.Conv, toddl ToDdl, srcTable schema.
 		Fks:      cvtForeignKeys(conv, spTableName, srcTable.Name, srcTable.ForeignKeys, isRestore),
 		Indexes:  cvtIndexes(conv, spTableName, srcTable.Name, srcTable.Indexes),
 		Comment:  comment}
-	schema_json, _ := json.Marshal(conv.SpSchema[spTableName])
-	fmt.Println(string(schema_json))
 	return nil
 }
 

--- a/sources/common/toddl.go
+++ b/sources/common/toddl.go
@@ -30,6 +30,7 @@ While adding new methods or code here
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"unicode"
@@ -110,6 +111,8 @@ func SchemaToSpannerDDLHelper(conv *internal.Conv, toddl ToDdl, srcTable schema.
 		Fks:      cvtForeignKeys(conv, spTableName, srcTable.Name, srcTable.ForeignKeys, isRestore),
 		Indexes:  cvtIndexes(conv, spTableName, srcTable.Name, srcTable.Indexes),
 		Comment:  comment}
+	schema_json, _ := json.Marshal(conv.SpSchema[spTableName])
+	fmt.Println(string(schema_json))
 	return nil
 }
 

--- a/sources/postgres/infoschema.go
+++ b/sources/postgres/infoschema.go
@@ -17,7 +17,6 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"math/bits"
 	"reflect"
@@ -134,10 +133,6 @@ func (isi InfoSchemaImpl) ProcessData(conv *internal.Conv, srcTable string, srcS
 			continue
 		}
 		cvtCols, cvtVals, err := convertSQLRow(conv, srcTable, srcCols, srcSchema, spTable, spCols, spSchema, v)
-		cvtCols_json, _ := json.Marshal(cvtCols)
-		fmt.Println(string(cvtCols_json))
-		cvtVals_json, _ := json.Marshal(cvtVals)
-		fmt.Println(string(cvtVals_json))
 		if err != nil {
 			conv.Unexpected(fmt.Sprintf("Couldn't process sql data row: %s", err))
 			conv.StatsAddBadRow(srcTable, conv.DataMode())

--- a/sources/postgres/infoschema.go
+++ b/sources/postgres/infoschema.go
@@ -17,6 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"math/bits"
 	"reflect"
@@ -133,6 +134,10 @@ func (isi InfoSchemaImpl) ProcessData(conv *internal.Conv, srcTable string, srcS
 			continue
 		}
 		cvtCols, cvtVals, err := convertSQLRow(conv, srcTable, srcCols, srcSchema, spTable, spCols, spSchema, v)
+		cvtCols_json, _ := json.Marshal(cvtCols)
+		fmt.Println(string(cvtCols_json))
+		cvtVals_json, _ := json.Marshal(cvtVals)
+		fmt.Println(string(cvtVals_json))
 		if err != nil {
 			conv.Unexpected(fmt.Sprintf("Couldn't process sql data row: %s", err))
 			conv.StatsAddBadRow(srcTable, conv.DataMode())
@@ -560,6 +565,13 @@ func cvtSQLScalar(conv *internal.Conv, srcCd schema.Column, spCd ddl.ColumnDef, 
 			return v, nil
 		}
 	case ddl.JSON:
+		switch v := val.(type) {
+		case string:
+			return string(v), nil
+		case []uint8:
+			return string(v), nil
+		}
+	case ddl.JSONB:
 		switch v := val.(type) {
 		case string:
 			return string(v), nil

--- a/sources/postgres/toddl.go
+++ b/sources/postgres/toddl.go
@@ -267,8 +267,10 @@ func toSpannerTypeIntern(conv *internal.Conv, id string, mods []int64) (ddl.Type
 func overrideExperimentalType(columnType schema.Type, originalType ddl.Type) ddl.Type {
 	if len(columnType.ArrayBounds) > 0 {
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
-	} else if columnType.Name == "json" || columnType.Name == "jsonb" {
+	} else if columnType.Name == "json" {
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
+	} else if columnType.Name == "jsonb" {
+		return ddl.Type{Name: ddl.JSONB}
 	}
 	return originalType
 }

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -50,6 +50,8 @@ const (
 	Numeric string = "NUMERIC"
 	// Json represent JSON type.
 	JSON string = "JSON"
+	// Jsonb reprents the JSONB type
+	JSONB string = "JSONB"
 	// MaxLength is a sentinel for Type's Len field, representing the MAX value.
 	MaxLength = math.MaxInt64
 	// StringMaxLength represents maximum allowed STRING length.

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -50,7 +50,7 @@ const (
 	Numeric string = "NUMERIC"
 	// Json represent JSON type.
 	JSON string = "JSON"
-	// Jsonb reprents the JSONB type
+	// Jsonb represents the PG.JSONB type
 	JSONB string = "JSONB"
 	// MaxLength is a sentinel for Type's Len field, representing the MAX value.
 	MaxLength = math.MaxInt64


### PR DESCRIPTION
Adds support for PG.JSONB data type for PG Spanner.
All Postgres JSONB data type columns are now mapped to PG.JSONB data type instead of `character varying`.

Please note that the Postgres JSON data type, and JSON/JSONB arrays still map to `character varying`. This change only handles the `JSONB` data type.

Testing:
Command Run - 

```
./harbourbridge schema-and-data -source=postgresql --target-profile="instance=manit-testing,dialect=postgresql" --source-profile="host=localhost,port=5432,user=postgres,password=postgres@123,dbName=harbourbridge"
```

Spanner DDL:
```
CREATE TABLE test (
  id bigint NOT NULL,
  data jsonb,
  data_json character varying,
  PRIMARY KEY(id)
);
```


Source DDL:
|table_name|column_name|data_type|
|----------|-----------|---------|
|test|id|integer|
|test|data|jsonb|
|test|data_json|json|

The table contains 2 rows which get written to Spanner. 