### PR TITLE
Adds --open flag to the web command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20220517085838-12e2f5a9d167 // indirect
 	github.com/pingcap/log v1.1.1-0.20221116035753-734d527bc87c // indirect
 	github.com/pingcap/tipb v0.0.0-20220314125451-bfb5c2c55188 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.sum
+++ b/go.sum
@@ -369,7 +369,8 @@ github.com/pingcap/tidb/parser v0.0.0-20221126021158-6b02a5d8ba7d h1:1DyyRrgYeNj
 github.com/pingcap/tidb/parser v0.0.0-20221126021158-6b02a5d8ba7d/go.mod h1:ElJiub4lRy6UZDb+0JHDkGEdr6aOli+ykhyej7VCLoI=
 github.com/pingcap/tipb v0.0.0-20220314125451-bfb5c2c55188 h1:+46isFI9fR9R+nJVDMI55tCC/TCwp+bvVA4HLGEv1rY=
 github.com/pingcap/tipb v0.0.0-20220314125451-bfb5c2c55188/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -650,6 +651,7 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func main() {
 
 	// Note: the web interface does not use any commandline flags.
 	if webapiv2 {
-		webv2.App("INFO")
+		webv2.App("INFO", false)
 		return
 	}
 

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cloudspannerecosystem/harbourbridge/webv2/profile"
 	utilities "github.com/cloudspannerecosystem/harbourbridge/webv2/utilities"
 	"github.com/google/uuid"
+	"github.com/pkg/browser"
 	instancepb "google.golang.org/genproto/googleapis/spanner/admin/instance/v1"
 
 	"github.com/cloudspannerecosystem/harbourbridge/webv2/session"
@@ -2259,7 +2260,7 @@ func init() {
 }
 
 // App connects to the web app v2.
-func App(logLevel string) {
+func App(logLevel string, open bool) {
 	err := logger.InitializeLogger(logLevel)
 	if err != nil {
 		log.Fatal("Error initialising webapp, did you specify a valid log-level? [DEBUG, INFO, WARN, ERROR, FATAL]")
@@ -2267,5 +2268,8 @@ func App(logLevel string) {
 	addr := ":8080"
 	router := getRoutes()
 	fmt.Println("Harbourbridge UI started at:", fmt.Sprintf("http://localhost%s", addr))
+	if open {
+		browser.OpenURL(fmt.Sprintf("http://localhost%s", addr))
+	}
 	log.Fatal(http.ListenAndServe(addr, handlers.CORS(handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}), handlers.AllowedMethods([]string{"GET", "POST", "PUT", "HEAD", "OPTIONS"}), handlers.AllowedOrigins([]string{"*"}))(router)))
 }

--- a/webv2/webCmd.go
+++ b/webv2/webCmd.go
@@ -34,6 +34,7 @@ var FrontendDir embed.FS
 type WebCmd struct {
 	DistDir 	embed.FS
 	logLevel 	string
+	open		bool
 }
 
 // Name returns the name of operation.
@@ -52,6 +53,7 @@ func (cmd *WebCmd) Usage() string {
 
 func (cmd *WebCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.logLevel, "log-level", "INFO", "Configure the logging level for the command (INFO, DEBUG), defaults to INFO")
+	f.BoolVar(&cmd.open, "open", true, "Opens the Harbourbridge web interface in the default browser")
 }
 
 func (cmd *WebCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
@@ -64,6 +66,6 @@ func (cmd *WebCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{
 		}
 	}()
 	defer logger.Log.Sync()
-	App(cmd.logLevel)
+	App(cmd.logLevel, cmd.open)
 	return subcommands.ExitSuccess
 }

--- a/webv2/webCmd.go
+++ b/webv2/webCmd.go
@@ -32,9 +32,9 @@ import (
 var FrontendDir embed.FS
 
 type WebCmd struct {
-	DistDir 	embed.FS
-	logLevel 	string
-	open		bool
+	DistDir  embed.FS
+	logLevel string
+	open     bool
 }
 
 // Name returns the name of operation.
@@ -53,7 +53,7 @@ func (cmd *WebCmd) Usage() string {
 
 func (cmd *WebCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.logLevel, "log-level", "INFO", "Configure the logging level for the command (INFO, DEBUG), defaults to INFO")
-	f.BoolVar(&cmd.open, "open", true, "Opens the Harbourbridge web interface in the default browser")
+	f.BoolVar(&cmd.open, "open", true, "Opens the Harbourbridge web interface in the default browser, defaults to true")
 }
 
 func (cmd *WebCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {


### PR DESCRIPTION
Adds a `--open` flag to the web command which opens HB UI on the default browser. It defaults to true, and can be overridden to false by specifying `--open=false`.

Example command: `./harbourbridge web` and `./harbourbridge web --open=false`