### PR TITLE
Extend conversion from source JSON to PG Spanner JSONB

### DIFF
--- a/sources/mysql/data.go
+++ b/sources/mysql/data.go
@@ -118,7 +118,7 @@ func convScalar(conv *internal.Conv, spannerType ddl.Type, srcTypeName string, T
 		return val, nil
 	case ddl.Timestamp:
 		return convTimestamp(srcTypeName, TimezoneOffset, val)
-	case ddl.JSON:
+	case ddl.JSON, ddl.JSONB:
 		return val, nil
 	default:
 		return val, fmt.Errorf("data conversion not implemented for type %v", spannerType.Name)

--- a/sources/mysql/toddl.go
+++ b/sources/mysql/toddl.go
@@ -197,7 +197,7 @@ func overrideExperimentalType(columnType schema.Type, originalType ddl.Type) ddl
 	if len(columnType.ArrayBounds) > 0 {
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
 	} else if columnType.Name == "json" {
-		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
+		return ddl.Type{Name: ddl.JSONB}
 	}
 	return originalType
 }

--- a/sources/oracle/data.go
+++ b/sources/oracle/data.go
@@ -113,7 +113,7 @@ func convScalar(conv *internal.Conv, spannerType ddl.Type, srcTypeName string, T
 		return val, nil
 	case ddl.Timestamp:
 		return convTimestamp(srcTypeName, val)
-	case ddl.JSON:
+	case ddl.JSON, ddl.JSONB:
 		if srcTypeName == "OBJECT" {
 			return convertXmlToJson(val)
 		}

--- a/sources/oracle/toddl.go
+++ b/sources/oracle/toddl.go
@@ -170,7 +170,7 @@ func toSpannerTypeInternal(conv *internal.Conv, spType string, srcType string, m
 // Override the types to map to experimental postgres types.
 func overrideExperimentalType(columnType schema.Type, originalType ddl.Type) ddl.Type {
 	if columnType.Name == "JSON" {
-		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
+		return ddl.Type{Name: ddl.JSONB}
 	}
 	return originalType
 }

--- a/sources/postgres/infoschema.go
+++ b/sources/postgres/infoschema.go
@@ -559,14 +559,7 @@ func cvtSQLScalar(conv *internal.Conv, srcCd schema.Column, spCd ddl.ColumnDef, 
 		case time.Time:
 			return v, nil
 		}
-	case ddl.JSON:
-		switch v := val.(type) {
-		case string:
-			return string(v), nil
-		case []uint8:
-			return string(v), nil
-		}
-	case ddl.JSONB:
+	case ddl.JSON, ddl.JSONB:
 		switch v := val.(type) {
 		case string:
 			return string(v), nil

--- a/sources/postgres/toddl.go
+++ b/sources/postgres/toddl.go
@@ -267,9 +267,7 @@ func toSpannerTypeIntern(conv *internal.Conv, id string, mods []int64) (ddl.Type
 func overrideExperimentalType(columnType schema.Type, originalType ddl.Type) ddl.Type {
 	if len(columnType.ArrayBounds) > 0 {
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
-	} else if columnType.Name == "json" {
-		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
-	} else if columnType.Name == "jsonb" {
+	} else if columnType.Name == "jsonb" || columnType.Name == "json" {
 		return ddl.Type{Name: ddl.JSONB}
 	}
 	return originalType


### PR DESCRIPTION
We will map `JSON` from postgres, mysql and oracle to the JSONB data type in PGSpanner, in addition to `JSONB` which was done previously.

### Testing:

#### MySQL 

```
create table json_test (
id int,
col json,
primary key(id));

INSERT INTO json_test(id, col) VALUES (1, '{"pid": 101, "name": "name1"}');
```

HB command - 
```
./harbourbridge schema-and-data -source=mysql --target-profile="instance=manit-testing,dialect=postgresql" --source-profile="host=localhost,port=3306,user=root,password=mysql@123,dbName=SHARD3"
```

Result - Schema and Data migrated to Spanner. 

Dest Schema
```
CREATE TABLE json_test (
  id bigint NOT NULL,
  col jsonb,
  PRIMARY KEY(id)
);
```

#### PostgreSQL
Already captured here in #439.
