### PR TITLE
code refactoring to modify ToSpannerType

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -138,3 +138,11 @@ func (ty Type) Print() string {
 	}
 	return s
 }
+
+func MakeType() Type {
+	return Type{
+		Name:        "",
+		Mods:        []int64{},
+		ArrayBounds: []int64{},
+	}
+}

--- a/sources/common/toddl.go
+++ b/sources/common/toddl.go
@@ -44,7 +44,7 @@ import (
 // type expected. In case a particular source to target transoformation is not
 // supported, an error is to be returned by the corresponding method.
 type ToDdl interface {
-	ToSpannerType(conv *internal.Conv, spType string, srcType string, mods, arrayBounds []int64) (ddl.Type, []internal.SchemaIssue)
+	ToSpannerType(conv *internal.Conv, spType string, srcType schema.Type) (ddl.Type, []internal.SchemaIssue)
 }
 
 // SchemaToSpannerDDL performs schema conversion from the source DB schema to
@@ -76,7 +76,7 @@ func SchemaToSpannerDDLHelper(conv *internal.Conv, toddl ToDdl, srcTable schema.
 			continue
 		}
 		spColNames = append(spColNames, colName)
-		ty, issues := toddl.ToSpannerType(conv, "", srcCol.Type.Name, srcCol.Type.Mods, srcCol.Type.ArrayBounds)
+		ty, issues := toddl.ToSpannerType(conv, "", srcCol.Type)
 		// TODO(hengfeng): add issues for all elements of srcCol.Ignored.
 		if srcCol.Ignored.ForeignKey {
 			issues = append(issues, internal.ForeignKey)

--- a/sources/common/toddl.go
+++ b/sources/common/toddl.go
@@ -44,7 +44,7 @@ import (
 // type expected. In case a particular source to target transoformation is not
 // supported, an error is to be returned by the corresponding method.
 type ToDdl interface {
-	ToSpannerType(conv *internal.Conv, columnType schema.Type) (ddl.Type, []internal.SchemaIssue)
+	ToSpannerType(conv *internal.Conv, spType string, srcType string, mods, arrayBounds []int64) (ddl.Type, []internal.SchemaIssue)
 }
 
 // SchemaToSpannerDDL performs schema conversion from the source DB schema to
@@ -76,7 +76,7 @@ func SchemaToSpannerDDLHelper(conv *internal.Conv, toddl ToDdl, srcTable schema.
 			continue
 		}
 		spColNames = append(spColNames, colName)
-		ty, issues := toddl.ToSpannerType(conv, srcCol.Type)
+		ty, issues := toddl.ToSpannerType(conv, "", srcCol.Type.Name, srcCol.Type.Mods, srcCol.Type.ArrayBounds)
 		// TODO(hengfeng): add issues for all elements of srcCol.Ignored.
 		if srcCol.Ignored.ForeignKey {
 			issues = append(issues, internal.ForeignKey)

--- a/sources/dynamodb/toddl.go
+++ b/sources/dynamodb/toddl.go
@@ -18,6 +18,7 @@ package dynamodb
 import (
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/schema"
 	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
@@ -30,7 +31,7 @@ type ToDdlImpl struct {
 // mods) into a Spanner type. This is the core source-to-Spanner type
 // mapping.  toSpannerType returns the Spanner type and a list of type
 // conversion issues encountered.
-func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType string, mods, arrayBounds []int64) (ddl.Type, []internal.SchemaIssue) {
+func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType schema.Type) (ddl.Type, []internal.SchemaIssue) {
 	ty, issues := toSpannerTypeInternal(conv, srcType)
 	if conv.TargetDb == constants.TargetExperimentalPostgres {
 		ty = overrideExperimentalType(ty)
@@ -38,8 +39,8 @@ func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType s
 	return ty, issues
 }
 
-func toSpannerTypeInternal(conv *internal.Conv, id string) (ddl.Type, []internal.SchemaIssue) {
-	switch id {
+func toSpannerTypeInternal(conv *internal.Conv, srcType schema.Type) (ddl.Type, []internal.SchemaIssue) {
+	switch srcType.Name {
 	case typeNumber:
 		return ddl.Type{Name: ddl.Numeric}, nil
 	case typeNumberString, typeString, typeList, typeMap:

--- a/sources/dynamodb/toddl.go
+++ b/sources/dynamodb/toddl.go
@@ -18,7 +18,6 @@ package dynamodb
 import (
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
-	"github.com/cloudspannerecosystem/harbourbridge/schema"
 	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
@@ -31,8 +30,8 @@ type ToDdlImpl struct {
 // mods) into a Spanner type. This is the core source-to-Spanner type
 // mapping.  toSpannerType returns the Spanner type and a list of type
 // conversion issues encountered.
-func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, columnType schema.Type) (ddl.Type, []internal.SchemaIssue) {
-	ty, issues := toSpannerTypeInternal(conv, columnType.Name)
+func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType string, mods, arrayBounds []int64) (ddl.Type, []internal.SchemaIssue) {
+	ty, issues := toSpannerTypeInternal(conv, srcType)
 	if conv.TargetDb == constants.TargetExperimentalPostgres {
 		ty = overrideExperimentalType(ty)
 	}

--- a/sources/mysql/data.go
+++ b/sources/mysql/data.go
@@ -118,7 +118,7 @@ func convScalar(conv *internal.Conv, spannerType ddl.Type, srcTypeName string, T
 		return val, nil
 	case ddl.Timestamp:
 		return convTimestamp(srcTypeName, TimezoneOffset, val)
-	case ddl.JSON, ddl.JSONB:
+	case ddl.JSON:
 		return val, nil
 	default:
 		return val, fmt.Errorf("data conversion not implemented for type %v", spannerType.Name)

--- a/sources/mysql/toddl.go
+++ b/sources/mysql/toddl.go
@@ -18,6 +18,7 @@ package mysql
 import (
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/schema"
 	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
@@ -30,22 +31,22 @@ type ToDdlImpl struct {
 // mapping.  toSpannerType returns the Spanner type and a list of type
 // conversion issues encountered.
 // Functions below implement the common.ToDdl interface
-func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType string, mods, arrayBounds []int64) (ddl.Type, []internal.SchemaIssue) {
-	ty, issues := toSpannerTypeInternal(srcType, spType, mods)
+func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType schema.Type) (ddl.Type, []internal.SchemaIssue) {
+	ty, issues := toSpannerTypeInternal(srcType, spType)
 	if conv.TargetDb == constants.TargetExperimentalPostgres {
-		ty = overrideExperimentalType(arrayBounds, ty)
+		ty = overrideExperimentalType(srcType, ty)
 	} else {
-		if len(arrayBounds) > 1 {
+		if len(srcType.ArrayBounds) > 1 {
 			ty = ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
 			issues = append(issues, internal.MultiDimensionalArray)
 		}
-		ty.IsArray = len(arrayBounds) == 1
+		ty.IsArray = len(srcType.ArrayBounds) == 1
 	}
 	return ty, issues
 }
 
-func toSpannerTypeInternal(srcType string, spType string, mods []int64) (ddl.Type, []internal.SchemaIssue) {
-	switch srcType {
+func toSpannerTypeInternal(srcType schema.Type, spType string) (ddl.Type, []internal.SchemaIssue) {
+	switch srcType.Name {
 	case "bool", "boolean":
 		switch spType {
 		case ddl.String:
@@ -63,7 +64,7 @@ func toSpannerTypeInternal(srcType string, spType string, mods []int64) (ddl.Typ
 			return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Widened}
 		default:
 			// tinyint(1) is a bool in MySQL
-			if len(mods) > 0 && mods[0] == 1 {
+			if len(srcType.Mods) > 0 && srcType.Mods[0] == 1 {
 				return ddl.Type{Name: ddl.Bool}, nil
 			}
 			return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Widened}
@@ -120,13 +121,13 @@ func toSpannerTypeInternal(srcType string, spType string, mods []int64) (ddl.Typ
 	case "varchar", "char":
 		switch spType {
 		case ddl.Bytes:
-			if len(mods) > 0 {
-				return ddl.Type{Name: ddl.Bytes, Len: mods[0]}, nil
+			if len(srcType.Mods) > 0 {
+				return ddl.Type{Name: ddl.Bytes, Len: srcType.Mods[0]}, nil
 			}
 			return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
 		default:
-			if len(mods) > 0 {
-				return ddl.Type{Name: ddl.String, Len: mods[0]}, nil
+			if len(srcType.Mods) > 0 {
+				return ddl.Type{Name: ddl.String, Len: srcType.Mods[0]}, nil
 			}
 			return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
 		}
@@ -189,8 +190,8 @@ func toSpannerTypeInternal(srcType string, spType string, mods []int64) (ddl.Typ
 }
 
 // Override the types to map to experimental postgres types.
-func overrideExperimentalType(arrayBounds []int64, originalType ddl.Type) ddl.Type {
-	if len(arrayBounds) > 0 {
+func overrideExperimentalType(srcType schema.Type, originalType ddl.Type) ddl.Type {
+	if len(srcType.ArrayBounds) > 0 {
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
 	}
 	return originalType

--- a/sources/mysql/toddl_test.go
+++ b/sources/mysql/toddl_test.go
@@ -162,7 +162,7 @@ func TestToExperimentalSpannerType(t *testing.T) {
 			"d": ddl.ColumnDef{Name: "d", T: ddl.Type{Name: ddl.String, Len: int64(6)}},
 			"e": ddl.ColumnDef{Name: "e", T: ddl.Type{Name: ddl.Numeric}},
 			"f": ddl.ColumnDef{Name: "f", T: ddl.Type{Name: ddl.Timestamp}},
-			"g": ddl.ColumnDef{Name: "g", T: ddl.Type{Name: ddl.JSONB}},
+			"g": ddl.ColumnDef{Name: "g", T: ddl.Type{Name: ddl.JSON}},
 			"h": ddl.ColumnDef{Name: "h", T: ddl.Type{Name: ddl.Date}},
 			"i": ddl.ColumnDef{Name: "i", T: ddl.Type{Name: ddl.Timestamp}},
 			"j": ddl.ColumnDef{Name: "j", T: ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}},

--- a/sources/oracle/data.go
+++ b/sources/oracle/data.go
@@ -113,7 +113,7 @@ func convScalar(conv *internal.Conv, spannerType ddl.Type, srcTypeName string, T
 		return val, nil
 	case ddl.Timestamp:
 		return convTimestamp(srcTypeName, val)
-	case ddl.JSON, ddl.JSONB:
+	case ddl.JSON:
 		if srcTypeName == "OBJECT" {
 			return convertXmlToJson(val)
 		}

--- a/sources/oracle/toddl_test.go
+++ b/sources/oracle/toddl_test.go
@@ -172,7 +172,7 @@ func TestToExperimentalSpannerType(t *testing.T) {
 			"f": {Name: "f", T: ddl.Type{Name: ddl.Timestamp}},
 			"g": {Name: "g", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
 			"h": {Name: "h", T: ddl.Type{Name: ddl.Int64}},
-			"i": {Name: "i", T: ddl.Type{Name: ddl.JSONB}},
+			"i": {Name: "i", T: ddl.Type{Name: ddl.JSON}},
 			"j": {Name: "j", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
 			"k": {Name: "k", T: ddl.Type{Name: ddl.String, Len: ddl.MaxLength}},
 		},

--- a/sources/postgres/infoschema.go
+++ b/sources/postgres/infoschema.go
@@ -559,7 +559,7 @@ func cvtSQLScalar(conv *internal.Conv, srcCd schema.Column, spCd ddl.ColumnDef, 
 		case time.Time:
 			return v, nil
 		}
-	case ddl.JSON, ddl.JSONB:
+	case ddl.JSON:
 		switch v := val.(type) {
 		case string:
 			return string(v), nil

--- a/sources/postgres/toddl.go
+++ b/sources/postgres/toddl.go
@@ -18,7 +18,6 @@ package postgres
 import (
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
-	"github.com/cloudspannerecosystem/harbourbridge/schema"
 	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
@@ -30,22 +29,18 @@ type ToDdlImpl struct {
 // mods) into a Spanner type. This is the core source-to-Spanner type
 // mapping.  toSpannerType returns the Spanner type and a list of type
 // conversion issues encountered.
-func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, columnType schema.Type) (ddl.Type, []internal.SchemaIssue) {
-	ty, issues := toSpannerTypeInternal(columnType.Name, "", columnType.Mods)
+func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType string, mods, arrayBounds []int64) (ddl.Type, []internal.SchemaIssue) {
+	ty, issues := toSpannerTypeInternal(srcType, spType, mods)
 	if conv.TargetDb == constants.TargetExperimentalPostgres {
-		ty = overrideExperimentalType(columnType, ty)
+		ty = overrideExperimentalType(arrayBounds, ty)
 	} else {
-		if len(columnType.ArrayBounds) > 1 {
+		if len(arrayBounds) > 1 {
 			ty = ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
 			issues = append(issues, internal.MultiDimensionalArray)
 		}
-		ty.IsArray = len(columnType.ArrayBounds) == 1
+		ty.IsArray = len(arrayBounds) == 1
 	}
 	return ty, issues
-}
-
-func ToSpannerTypeWeb(srcType string, spType string, mods []int64) (ddl.Type, []internal.SchemaIssue) {
-	return toSpannerTypeInternal(srcType, spType, mods)
 }
 
 // toSpannerTypeInternal defines the mapping of source types into Spanner
@@ -199,76 +194,9 @@ func toSpannerTypeInternal(srcType string, spType string, mods []int64) (ddl.Typ
 	return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.NoGoodType}
 }
 
-// toSpannerType maps a scalar source schema type (defined by id and
-// mods) into a Spanner type. This is the core source-to-Spanner type
-// mapping.  toSpannerType returns the Spanner type and a list of type
-// conversion issues encountered.
-func toSpannerTypeIntern(conv *internal.Conv, id string, mods []int64) (ddl.Type, []internal.SchemaIssue) {
-	switch id {
-	case "bool", "boolean":
-		return ddl.Type{Name: ddl.Bool}, nil
-	case "bigserial":
-		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Serial}
-	case "bpchar", "character": // Note: Postgres internal name for char is bpchar (aka blank padded char).
-		if len(mods) > 0 {
-			return ddl.Type{Name: ddl.String, Len: mods[0]}, nil
-		}
-		// Note: bpchar without length specifier is equivalent to bpchar(1)
-		return ddl.Type{Name: ddl.String, Len: 1}, nil
-	case "bytea":
-		return ddl.Type{Name: ddl.Bytes, Len: ddl.MaxLength}, nil
-	case "date":
-		return ddl.Type{Name: ddl.Date}, nil
-	case "float8", "double precision":
-		return ddl.Type{Name: ddl.Float64}, nil
-	case "float4", "real":
-		return ddl.Type{Name: ddl.Float64}, []internal.SchemaIssue{internal.Widened}
-	case "int8", "bigint":
-		return ddl.Type{Name: ddl.Int64}, nil
-	case "int4", "integer":
-		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Widened}
-	case "int2", "smallint":
-		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Widened}
-	case "numeric":
-		// PostgreSQL's NUMERIC type can have a specified precision of up to 1000
-		// digits (and scale can be anything from 0 up to the value of 'precision').
-		// If precision and scale are not specified, then values of any precision
-		// or scale can be stored, up to the implementation's limits (can be up to
-		// 131072 digits before the decimal point and up to 16383 digits after
-		// the decimal point).
-		// Spanner's NUMERIC type can store up to 29 digits before the
-		// decimal point and up to 9 after the decimal point -- it is
-		// equivalent to PostgreSQL's NUMERIC(38,9) type.
-		//
-		// TODO: Generate appropriate SchemaIssue to warn of different precision
-		// capabilities between PostgreSQL and Spanner NUMERIC.
-		return ddl.Type{Name: ddl.Numeric}, nil
-	case "serial":
-		return ddl.Type{Name: ddl.Int64}, []internal.SchemaIssue{internal.Serial}
-	case "text":
-		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
-	case "timestamptz", "timestamp with time zone":
-		return ddl.Type{Name: ddl.Timestamp}, nil
-	case "timestamp", "timestamp without time zone":
-		// Map timestamp without timezone to Spanner timestamp.
-		return ddl.Type{Name: ddl.Timestamp}, []internal.SchemaIssue{internal.Timestamp}
-	case "varchar", "character varying":
-		if len(mods) > 0 {
-			return ddl.Type{Name: ddl.String, Len: mods[0]}, nil
-		}
-		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, nil
-	case "json", "jsonb":
-		return ddl.Type{Name: ddl.JSON}, nil
-	}
-	return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}, []internal.SchemaIssue{internal.NoGoodType}
-}
-
-// Override the types to map to experimental postgres types.
-func overrideExperimentalType(columnType schema.Type, originalType ddl.Type) ddl.Type {
-	if len(columnType.ArrayBounds) > 0 {
+func overrideExperimentalType(arrayBounds []int64, originalType ddl.Type) ddl.Type {
+	if len(arrayBounds) > 0 {
 		return ddl.Type{Name: ddl.String, Len: ddl.MaxLength}
-	} else if columnType.Name == "jsonb" || columnType.Name == "json" {
-		return ddl.Type{Name: ddl.JSONB}
 	}
 	return originalType
 }

--- a/sources/postgres/toddl_test.go
+++ b/sources/postgres/toddl_test.go
@@ -157,7 +157,7 @@ func TestToExperimentalSpannerType(t *testing.T) {
 			"d": ddl.ColumnDef{Name: "d", T: ddl.Type{Name: ddl.String, Len: int64(6)}},
 			"e": ddl.ColumnDef{Name: "e", T: ddl.Type{Name: ddl.Numeric}},
 			"f": ddl.ColumnDef{Name: "f", T: ddl.Type{Name: ddl.Date}},
-			"g": ddl.ColumnDef{Name: "g", T: ddl.Type{Name: ddl.JSONB}},
+			"g": ddl.ColumnDef{Name: "g", T: ddl.Type{Name: ddl.JSON}},
 		},
 		Pks: []ddl.IndexKey{ddl.IndexKey{Col: "a"}},
 		Fks: []ddl.Foreignkey{ddl.Foreignkey{Name: "fk_test", Columns: []string{"d"}, ReferTable: "ref_table", ReferColumns: []string{"dref"}},

--- a/sources/spanner/toddl_test.go
+++ b/sources/spanner/toddl_test.go
@@ -52,7 +52,7 @@ func TestToSpannerType(t *testing.T) {
 		if tc.pgTarget {
 			conv.TargetDb = constants.TargetExperimentalPostgres
 		}
-		ty, err := toDDLImpl.ToSpannerType(conv, "", tc.columnType.Name, tc.columnType.Mods, tc.columnType.ArrayBounds)
+		ty, err := toDDLImpl.ToSpannerType(conv, "", tc.columnType)
 		assert.Nil(t, err, tc.name)
 		assert.Equal(t, tc.expDDLType, ty, tc.name)
 	}

--- a/sources/spanner/toddl_test.go
+++ b/sources/spanner/toddl_test.go
@@ -52,7 +52,7 @@ func TestToSpannerType(t *testing.T) {
 		if tc.pgTarget {
 			conv.TargetDb = constants.TargetExperimentalPostgres
 		}
-		ty, err := toDDLImpl.ToSpannerType(conv, tc.columnType)
+		ty, err := toDDLImpl.ToSpannerType(conv, "", tc.columnType.Name, tc.columnType.Mods, tc.columnType.ArrayBounds)
 		assert.Nil(t, err, tc.name)
 		assert.Equal(t, tc.expDDLType, ty, tc.name)
 	}

--- a/sources/sqlserver/toddl.go
+++ b/sources/sqlserver/toddl.go
@@ -17,7 +17,6 @@ package sqlserver
 
 import (
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
-	"github.com/cloudspannerecosystem/harbourbridge/schema"
 	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
 )
 
@@ -29,13 +28,9 @@ type ToDdlImpl struct {
 // mods) into a Spanner type. This is the core source-to-Spanner type
 // mapping.  toSpannerType returns the Spanner type and a list of type
 // conversion issues encountered.
-func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, columnType schema.Type) (ddl.Type, []internal.SchemaIssue) {
-	ty, issues := toSpannerTypeInternal(columnType.Name, "", columnType.Mods)
+func (tdi ToDdlImpl) ToSpannerType(conv *internal.Conv, spType string, srcType string, mods, arrayBounds []int64) (ddl.Type, []internal.SchemaIssue) {
+	ty, issues := toSpannerTypeInternal(srcType, spType, mods)
 	return ty, issues
-}
-
-func ToSpannerTypeWeb(srcType string, spType string, mods []int64) (ddl.Type, []internal.SchemaIssue) {
-	return toSpannerTypeInternal(srcType, spType, mods)
 }
 
 // toSpannerTypeInternal defines the mapping of source types into Spanner

--- a/spanner/ddl/ast.go
+++ b/spanner/ddl/ast.go
@@ -50,8 +50,6 @@ const (
 	Numeric string = "NUMERIC"
 	// Json represent JSON type.
 	JSON string = "JSON"
-	// Jsonb represents the PG.JSONB type
-	JSONB string = "JSONB"
 	// MaxLength is a sentinel for Type's Len field, representing the MAX value.
 	MaxLength = math.MaxInt64
 	// StringMaxLength represents maximum allowed STRING length.
@@ -69,6 +67,8 @@ const (
 	PGVarchar string = "VARCHAR"
 	// PGTimestamptz represent TIMESTAMPTZ, which is TIMESTAMP type in PG.
 	PGTimestamptz string = "TIMESTAMPTZ"
+	// Jsonb represents the PG.JSONB type
+	PGJSONB string = "JSONB"
 	// PGMaxLength represents sentinel for Type's Len field in PG.
 	PGMaxLength = 2621440
 )
@@ -119,6 +119,8 @@ func (ty Type) PGPrintColumnDefType() string {
 		str = PGVarchar
 	case Timestamp:
 		str = PGTimestamptz
+	case JSON:
+		str = PGJSONB
 	default:
 		str = ty.Name
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -1077,7 +1077,8 @@ func getType(newType, table, colName string, srcTableName string) (ddl.CreateTab
 	case constants.SQLSERVER:
 		ty, issues = toSpannerTypeSQLserver(srcCol.Type.Name, newType, srcCol.Type.Mods)
 	case constants.ORACLE:
-		ty, issues = oracle.ToSpannerTypeWeb(sessionState.conv, newType, srcCol.Type.Name, srcCol.Type.Mods)
+		toddl := oracle.InfoSchemaImpl{}.GetToDdl()
+		ty, issues = toddl.ToSpannerType(sessionState.conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
 	default:
 		return sp, ty, fmt.Errorf("driver : '%s' is not supported", sessionState.driver)
 	}
@@ -1217,10 +1218,11 @@ func init() {
 	}
 
 	// Initialize oracleTypeMap.
+	toddl := oracle.InfoSchemaImpl{}.GetToDdl()
 	for _, srcType := range []string{"NUMBER", "BFILE", "BLOB", "CHAR", "CLOB", "DATE", "BINARY_DOUBLE", "BINARY_FLOAT", "FLOAT", "LONG", "RAW", "LONG RAW", "NCHAR", "NVARCHAR2", "VARCHAR", "VARCHAR2", "NCLOB", "ROWID", "UROWID", "XMLTYPE", "TIMESTAMP", "INTERVAL", "SDO_GEOMETRY"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric} {
-			ty, issues := oracle.ToSpannerTypeWeb(sessionState.conv, spType, srcType, []int64{})
+			ty, issues := toddl.ToSpannerType(sessionState.conv, spType, srcType, []int64{}, []int64{})
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
 		oracleTypeMap[srcType] = l

--- a/webv2/utilities/get_type.go
+++ b/webv2/utilities/get_type.go
@@ -40,16 +40,16 @@ func GetType(conv *internal.Conv, newType, table, colName string, srcTableName s
 	switch sessionState.Driver {
 	case constants.MYSQL, constants.MYSQLDUMP:
 		toddl = mysql.InfoSchemaImpl{}.GetToDdl()
-		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
+		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type)
 	case constants.PGDUMP, constants.POSTGRES:
 		toddl = postgres.InfoSchemaImpl{}.GetToDdl()
-		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
+		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type)
 	case constants.SQLSERVER:
 		toddl = sqlserver.InfoSchemaImpl{}.GetToDdl()
-		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
+		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type)
 	case constants.ORACLE:
 		toddl = oracle.InfoSchemaImpl{}.GetToDdl()
-		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
+		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type)
 	default:
 		return sp, ty, fmt.Errorf("driver : '%s' is not supported", sessionState.Driver)
 	}

--- a/webv2/utilities/get_type.go
+++ b/webv2/utilities/get_type.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cloudspannerecosystem/harbourbridge/common/constants"
 	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/sources/common"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/mysql"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/oracle"
 	"github.com/cloudspannerecosystem/harbourbridge/sources/postgres"
@@ -35,15 +36,20 @@ func GetType(conv *internal.Conv, newType, table, colName string, srcTableName s
 	srcCol := conv.SrcSchema[srcTableName].ColDefs[srcColName]
 	var ty ddl.Type
 	var issues []internal.SchemaIssue
+	var toddl common.ToDdl
 	switch sessionState.Driver {
 	case constants.MYSQL, constants.MYSQLDUMP:
-		ty, issues = mysql.ToSpannerTypeWeb(srcCol.Type.Name, newType, srcCol.Type.Mods)
+		toddl = mysql.InfoSchemaImpl{}.GetToDdl()
+		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
 	case constants.PGDUMP, constants.POSTGRES:
-		ty, issues = postgres.ToSpannerTypeWeb(srcCol.Type.Name, newType, srcCol.Type.Mods)
+		toddl = postgres.InfoSchemaImpl{}.GetToDdl()
+		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
 	case constants.SQLSERVER:
-		ty, issues = sqlserver.ToSpannerTypeWeb(srcCol.Type.Name, newType, srcCol.Type.Mods)
+		toddl = sqlserver.InfoSchemaImpl{}.GetToDdl()
+		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
 	case constants.ORACLE:
-		ty, issues = oracle.ToSpannerTypeWeb(conv, newType, srcCol.Type.Name, srcCol.Type.Mods)
+		toddl = oracle.InfoSchemaImpl{}.GetToDdl()
+		ty, issues = toddl.ToSpannerType(conv, newType, srcCol.Type.Name, srcCol.Type.Mods, []int64{})
 	default:
 		return sp, ty, fmt.Errorf("driver : '%s' is not supported", sessionState.Driver)
 	}

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -2215,48 +2215,56 @@ func init() {
 	var toddl common.ToDdl
 	// Initialize mysqlTypeMap.
 	toddl = mysql.InfoSchemaImpl{}.GetToDdl()
-	for _, srcType := range []string{"bool", "boolean", "varchar", "char", "text", "tinytext", "mediumtext", "longtext", "set", "enum", "json", "bit", "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "tinyint", "smallint", "mediumint", "int", "integer", "bigint", "double", "float", "numeric", "decimal", "date", "datetime", "timestamp", "time", "year", "geometrycollection", "multipoint", "multilinestring", "multipolygon", "point", "linestring", "polygon", "geometry"} {
+	for _, srcTypeName := range []string{"bool", "boolean", "varchar", "char", "text", "tinytext", "mediumtext", "longtext", "set", "enum", "json", "bit", "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "tinyint", "smallint", "mediumint", "int", "integer", "bigint", "double", "float", "numeric", "decimal", "date", "datetime", "timestamp", "time", "year", "geometrycollection", "multipoint", "multilinestring", "multipolygon", "point", "linestring", "polygon", "geometry"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric, ddl.JSON} {
-			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType, []int64{}, []int64{})
+			srcType := schema.MakeType()
+			srcType.Name = srcTypeName
+			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType)
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
-		if srcType == "tinyint" {
+		if srcTypeName == "tinyint" {
 			l = append(l, typeIssue{T: ddl.Bool, Brief: "Only tinyint(1) can be converted to BOOL, for any other mods it will be converted to INT64"})
 		}
-		mysqlTypeMap[srcType] = l
+		mysqlTypeMap[srcTypeName] = l
 	}
 	// Initialize postgresTypeMap.
 	toddl = postgres.InfoSchemaImpl{}.GetToDdl()
-	for _, srcType := range []string{"bool", "boolean", "bigserial", "bpchar", "character", "bytea", "date", "float8", "double precision", "float4", "real", "int8", "bigint", "int4", "integer", "int2", "smallint", "numeric", "serial", "text", "timestamptz", "timestamp with time zone", "timestamp", "timestamp without time zone", "varchar", "character varying"} {
+	for _, srcTypeName := range []string{"bool", "boolean", "bigserial", "bpchar", "character", "bytea", "date", "float8", "double precision", "float4", "real", "int8", "bigint", "int4", "integer", "int2", "smallint", "numeric", "serial", "text", "timestamptz", "timestamp with time zone", "timestamp", "timestamp without time zone", "varchar", "character varying"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric, ddl.JSON} {
-			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType, []int64{}, []int64{})
+			srcType := schema.MakeType()
+			srcType.Name = srcTypeName
+			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType)
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
-		postgresTypeMap[srcType] = l
+		postgresTypeMap[srcTypeName] = l
 	}
 
 	// Initialize sqlserverTypeMap.
 	toddl = sqlserver.InfoSchemaImpl{}.GetToDdl()
-	for _, srcType := range []string{"int", "tinyint", "smallint", "bigint", "bit", "float", "real", "numeric", "decimal", "money", "smallmoney", "char", "nchar", "varchar", "nvarchar", "text", "ntext", "date", "datetime", "datetime2", "smalldatetime", "datetimeoffset", "time", "timestamp", "rowversion", "binary", "varbinary", "image", "xml", "geography", "geometry", "uniqueidentifier", "sql_variant", "hierarchyid"} {
+	for _, srcTypeName := range []string{"int", "tinyint", "smallint", "bigint", "bit", "float", "real", "numeric", "decimal", "money", "smallmoney", "char", "nchar", "varchar", "nvarchar", "text", "ntext", "date", "datetime", "datetime2", "smalldatetime", "datetimeoffset", "time", "timestamp", "rowversion", "binary", "varbinary", "image", "xml", "geography", "geometry", "uniqueidentifier", "sql_variant", "hierarchyid"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric, ddl.JSON} {
-			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType, []int64{}, []int64{})
+			srcType := schema.MakeType()
+			srcType.Name = srcTypeName
+			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType)
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
-		sqlserverTypeMap[srcType] = l
+		sqlserverTypeMap[srcTypeName] = l
 	}
 
 	// Initialize oracleTypeMap.
 	toddl = oracle.InfoSchemaImpl{}.GetToDdl()
-	for _, srcType := range []string{"NUMBER", "BFILE", "BLOB", "CHAR", "CLOB", "DATE", "BINARY_DOUBLE", "BINARY_FLOAT", "FLOAT", "LONG", "RAW", "LONG RAW", "NCHAR", "NVARCHAR2", "VARCHAR", "VARCHAR2", "NCLOB", "ROWID", "UROWID", "XMLTYPE", "TIMESTAMP", "INTERVAL", "SDO_GEOMETRY"} {
+	for _, srcTypeName := range []string{"NUMBER", "BFILE", "BLOB", "CHAR", "CLOB", "DATE", "BINARY_DOUBLE", "BINARY_FLOAT", "FLOAT", "LONG", "RAW", "LONG RAW", "NCHAR", "NVARCHAR2", "VARCHAR", "VARCHAR2", "NCLOB", "ROWID", "UROWID", "XMLTYPE", "TIMESTAMP", "INTERVAL", "SDO_GEOMETRY"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric, ddl.JSON} {
-			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType, []int64{}, []int64{})
+			srcType := schema.MakeType()
+			srcType.Name = srcTypeName
+			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType)
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
-		oracleTypeMap[srcType] = l
+		oracleTypeMap[srcTypeName] = l
 	}
 	config := config.TryInitializeSpannerConfig()
 	session.SetSessionStorageConnectionState(config.GCPProjectID, config.SpannerInstanceID)

--- a/webv2/web.go
+++ b/webv2/web.go
@@ -2211,12 +2211,14 @@ func init() {
 	sessionState := session.GetSessionState()
 
 	uniqueid.InitObjectId()
-
+	sessionState.Conv = internal.MakeConv()
+	var toddl common.ToDdl
 	// Initialize mysqlTypeMap.
+	toddl = mysql.InfoSchemaImpl{}.GetToDdl()
 	for _, srcType := range []string{"bool", "boolean", "varchar", "char", "text", "tinytext", "mediumtext", "longtext", "set", "enum", "json", "bit", "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "tinyint", "smallint", "mediumint", "int", "integer", "bigint", "double", "float", "numeric", "decimal", "date", "datetime", "timestamp", "time", "year", "geometrycollection", "multipoint", "multilinestring", "multipolygon", "point", "linestring", "polygon", "geometry"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric, ddl.JSON} {
-			ty, issues := mysql.ToSpannerTypeWeb(srcType, spType, []int64{})
+			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType, []int64{}, []int64{})
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
 		if srcType == "tinyint" {
@@ -2225,36 +2227,37 @@ func init() {
 		mysqlTypeMap[srcType] = l
 	}
 	// Initialize postgresTypeMap.
+	toddl = postgres.InfoSchemaImpl{}.GetToDdl()
 	for _, srcType := range []string{"bool", "boolean", "bigserial", "bpchar", "character", "bytea", "date", "float8", "double precision", "float4", "real", "int8", "bigint", "int4", "integer", "int2", "smallint", "numeric", "serial", "text", "timestamptz", "timestamp with time zone", "timestamp", "timestamp without time zone", "varchar", "character varying"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric, ddl.JSON} {
-			ty, issues := postgres.ToSpannerTypeWeb(srcType, spType, []int64{})
+			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType, []int64{}, []int64{})
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
 		postgresTypeMap[srcType] = l
 	}
 
 	// Initialize sqlserverTypeMap.
+	toddl = sqlserver.InfoSchemaImpl{}.GetToDdl()
 	for _, srcType := range []string{"int", "tinyint", "smallint", "bigint", "bit", "float", "real", "numeric", "decimal", "money", "smallmoney", "char", "nchar", "varchar", "nvarchar", "text", "ntext", "date", "datetime", "datetime2", "smalldatetime", "datetimeoffset", "time", "timestamp", "rowversion", "binary", "varbinary", "image", "xml", "geography", "geometry", "uniqueidentifier", "sql_variant", "hierarchyid"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric, ddl.JSON} {
-			ty, issues := sqlserver.ToSpannerTypeWeb(srcType, spType, []int64{})
+			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType, []int64{}, []int64{})
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
 		sqlserverTypeMap[srcType] = l
 	}
 
 	// Initialize oracleTypeMap.
+	toddl = oracle.InfoSchemaImpl{}.GetToDdl()
 	for _, srcType := range []string{"NUMBER", "BFILE", "BLOB", "CHAR", "CLOB", "DATE", "BINARY_DOUBLE", "BINARY_FLOAT", "FLOAT", "LONG", "RAW", "LONG RAW", "NCHAR", "NVARCHAR2", "VARCHAR", "VARCHAR2", "NCLOB", "ROWID", "UROWID", "XMLTYPE", "TIMESTAMP", "INTERVAL", "SDO_GEOMETRY"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric, ddl.JSON} {
-			ty, issues := oracle.ToSpannerTypeWeb(sessionState.Conv, spType, srcType, []int64{})
+			ty, issues := toddl.ToSpannerType(sessionState.Conv, spType, srcType, []int64{}, []int64{})
 			l = addTypeToList(ty.Name, spType, issues, l)
 		}
 		oracleTypeMap[srcType] = l
 	}
-
-	sessionState.Conv = internal.MakeConv()
 	config := config.TryInitializeSpannerConfig()
 	session.SetSessionStorageConnectionState(config.GCPProjectID, config.SpannerInstanceID)
 }


### PR DESCRIPTION
Changes:
1. Currently, other PostgreSQL data types that have GSQL equivalent are treated differently from JSONB. Add similar handling for JSONB and map it to JSON column of GSQL dialect.
2. Refactored the toddl interface to have singe ToSpannerType method for both UI and CLI.

Bug link: https://b.corp.google.com/issues/265607004

Tests Run:

1. End to end bulk migration from UI for PostgreSQL database with columns of all supported data type
4. End to end minimal downtime migration from UI for MySQL database with columns of all supported data type
5. CLI schema and data migration to postgres dialect from MySQL database with columns of all supported data type. Cmd used: `go run main.go schema-and-data -source=mysql -source-profile='host=35.222.246.87,user=root,dbName=postgres_test,password=xxx' -target-profile='project=span-cloud-testing, instance=shreya-test-1, dbName=h4, dialect=postgresql'`