### PR TITLE
fixing integration test

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -104,7 +104,7 @@ jobs:
           sudo bash -c "echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main >> /etc/apt/sources.list.d/pgdg.list"
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yq install libpq-dev postgresql-client-12
+          sudo apt-get -yq install postgresql-client-12
       - run: psql --version
       - run: psql -f test_data/pg_dump.test.out
 


### PR DESCRIPTION
Removing the libpq-dev library as its not required and is causing the below issue:

`The following packages have unmet dependencies:
 libpq5 : Depends: libldap-2.4-2 (>= 2.4.7) but it is not installable`