### PR TITLE
chore: Disable digest updates by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:base"
   ],
+  "digest": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
For packages with broken semantic versioning in Go that are used in Harbourbridge, Renovate is creating a new PR update per commit. This is causing a lot of noise. Disabling such kind of updates.